### PR TITLE
feat: Step 7 — Spec language with step driver and multi-interface topology

### DIFF
--- a/docs/poc/step-7-spec-language.md
+++ b/docs/poc/step-7-spec-language.md
@@ -1,0 +1,249 @@
+# Step 7: Spec Language Design
+
+## Goal
+
+Formalize the Faultbox spec language with:
+- Multi-interface service topology with auto-injected service discovery
+- Active scenario driver (`steps`) using `service.interface.operation` addressing
+- Structured fault DSL (object form alongside existing string form)
+- Compose-compatible field naming
+
+## Design Decisions
+
+### 1. Services expose named interfaces
+
+A service can have multiple communication interfaces (public HTTP, internal gRPC,
+async Kafka topics). Each interface has a protocol, port, and optional metadata.
+
+```yaml
+# faultbox.yaml
+version: "1"
+
+services:
+  db:
+    binary: /tmp/mock-db
+    interfaces:
+      main:
+        protocol: tcp
+        port: 5432
+    depends_on: []
+    healthcheck:
+      test: tcp://localhost:5432
+      interval: 1s
+      timeout: 10s
+
+  api:
+    binary: /tmp/mock-api
+    interfaces:
+      public:
+        protocol: http
+        port: 8080
+    depends_on: [db]
+    healthcheck:
+      test: http://localhost:8080/health
+      interval: 1s
+      timeout: 10s
+```
+
+Real-world example (not implemented in PoC, shows the model):
+```yaml
+  courier:
+    binary: ./courier
+    interfaces:
+      public:
+        protocol: http
+        port: 8080
+      internal:
+        protocol: grpc
+        port: 9090
+      events:
+        protocol: kafka
+        port: 9092
+        topics: [courier.updated, courier.assigned]
+```
+
+Services with a single interface allow shorthand in steps:
+`api.post` resolves to `api.public.post` when `public` is the only interface.
+
+### 2. Auto-injected service discovery
+
+Faultbox auto-injects env vars so services can find each other without hardcoded
+addresses. For each dependency, the following env vars are set:
+
+```
+FAULTBOX_<SERVICE>_<INTERFACE>_ADDR=host:port
+FAULTBOX_<SERVICE>_<INTERFACE>_HOST=host
+FAULTBOX_<SERVICE>_<INTERFACE>_PORT=port
+```
+
+Example: `api` depends on `db` →
+```
+FAULTBOX_DB_MAIN_ADDR=localhost:5432
+FAULTBOX_DB_MAIN_HOST=localhost
+FAULTBOX_DB_MAIN_PORT=5432
+```
+
+Additionally, topology env vars support template syntax:
+```yaml
+services:
+  api:
+    environment:
+      DB_ADDR: "{{db.main.addr}}"    # resolved to localhost:5432
+```
+
+### 3. Steps — the active scenario driver
+
+Specs now include `steps` that actively exercise the system. Steps run
+sequentially after all services are ready, before final assertions.
+
+```yaml
+traces:
+  db-timeout-on-write:
+    description: "DB write timeout — API returns 500"
+    faults:
+      db:
+        - { syscall: write, action: delay, delay: 5s, probability: 100% }
+    steps:
+      - api.post:
+          path: /data/key1
+          body: "value1"
+          expect:
+            status: 500
+            body_contains: "timeout"
+      - api.get:
+          path: /health
+          expect:
+            status: 200
+      - db.main.send:
+          data: "PING\n"
+          expect:
+            contains: "PONG"
+      - sleep: 1s
+    assert:
+      - exit_code: { service: api, equals: 0 }
+```
+
+Step addressing: `service[.interface].operation`
+
+### 4. Built-in step types (PoC)
+
+**HTTP protocol** (resolved when interface protocol = http):
+- `service.get`:  `{ path, headers?, expect? }`
+- `service.post`: `{ path, body?, headers?, expect? }`
+- `service.put`:  `{ path, body?, headers?, expect? }`
+- `service.delete`: `{ path, expect? }`
+
+HTTP expect fields:
+- `status`: expected HTTP status code
+- `body_contains`: substring match on response body
+- `body_equals`: exact match on response body
+
+**TCP protocol** (resolved when interface protocol = tcp):
+- `service.send`: `{ data, expect? }`
+
+TCP expect fields:
+- `contains`: substring match on response line
+- `equals`: exact match on response line
+
+**Utility:**
+- `sleep`: duration string (e.g., `1s`, `500ms`)
+
+### 5. Structured fault syntax
+
+Object form (new, alongside existing string form):
+```yaml
+faults:
+  db:
+    - syscall: write
+      action: delay
+      delay: 500ms
+      probability: 100%
+    - syscall: connect
+      action: deny
+      errno: ECONNREFUSED
+      probability: 10%
+      trigger: { type: after, n: 2 }
+```
+
+String form (existing, still supported):
+```yaml
+faults:
+  db:
+    - "write=delay:500ms:100%"
+    - "connect=ECONNREFUSED:10%:after=2"
+```
+
+Both parse to the same `FaultRule`. The YAML parser detects which form is used
+(string vs map node).
+
+### 6. Faults scoped per interface (future)
+
+Not implemented in PoC, but the model supports it:
+```yaml
+faults:
+  courier:
+    internal:
+      - { syscall: write, action: delay, delay: 2s, probability: 100% }
+```
+
+For PoC, faults apply to all interfaces of a service.
+
+### 7. Compose-compatible naming
+
+| Compose field | Faultbox field | Status |
+|---------------|----------------|--------|
+| `environment` | `environment`  | ✓ (alias for `env`) |
+| `depends_on`  | `depends_on`   | ✓ (already used) |
+| `healthcheck` | `healthcheck`  | ✓ (alias for `ready`) |
+| `ports`       | via interfaces | Different model |
+| `image`       | future         | Not in PoC |
+
+## Protocol Layering (Architecture)
+
+```
+L4 Core (built-in):       tcp, udp
+L7 Stdlib (built-in):     http, grpc
+L7 Extensions (Starlark): postgres, kafka, redis, ...
+```
+
+For PoC: `tcp` and `http` are Go built-ins behind a `StepHandler` interface.
+Same interface will be implemented by Starlark modules in future steps.
+
+## Backward Compatibility
+
+Old topology format (`port`, `env`, `ready`) is still accepted and auto-migrated:
+- `port: N` → `interfaces: { default: { protocol: tcp, port: N } }`
+- `env:` → `environment:`
+- `ready:` → `healthcheck: { test: [...] }`
+
+## PoC Scope
+
+**In scope:**
+- Multi-interface topology types + parsing
+- Auto-injected env vars for service discovery
+- Template resolution in env vars (`{{service.interface.addr}}`)
+- `steps` in spec with http and tcp handlers
+- Object-form fault parsing
+- Backward compat with old format
+- Config + step executor tests
+- Updated example files
+
+**Out of scope (future steps):**
+- Starlark runtime / custom protocol modules
+- Event log / trace-log
+- Hooks (INIT/PRE/POST)
+- Per-interface fault scoping
+- gRPC, Kafka protocol support
+- JSON Schema generation
+- Container/image support
+
+## Implementation Plan
+
+1. Extend `internal/config/config.go` — new types, parsing, backward compat
+2. Add `internal/config/config_test.go` — validation + parsing tests
+3. Add `internal/config/resolve.go` — env var injection + template resolution
+4. Add `internal/engine/step.go` — step executor with http/tcp handlers
+5. Add `internal/engine/step_test.go` — step executor tests
+6. Modify `internal/engine/simulation.go` — wire steps into runTrace()
+7. Update `poc/example/` files
+8. Test in Lima VM

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,10 +4,15 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ---------------------------------------------------------------------------
+// Topology (faultbox.yaml)
+// ---------------------------------------------------------------------------
 
 // TopologyConfig is parsed from faultbox.yaml — describes the system topology.
 type TopologyConfig struct {
@@ -17,13 +22,42 @@ type TopologyConfig struct {
 
 // ServiceConfig describes one service in the topology.
 type ServiceConfig struct {
-	Binary    string            `yaml:"binary"`
-	Args      []string          `yaml:"args"`
-	Port      int               `yaml:"port"`
-	Env       map[string]string `yaml:"env"`
-	DependsOn []string          `yaml:"depends_on"`
-	Ready     string            `yaml:"ready"`
+	Binary    string                     `yaml:"binary"`
+	Args      []string                   `yaml:"args"`
+	DependsOn []string                   `yaml:"depends_on"`
+
+	// New: named interfaces (protocol + port).
+	Interfaces map[string]InterfaceConfig `yaml:"interfaces"`
+
+	// Healthcheck (Compose-compatible naming).
+	Healthcheck *HealthcheckConfig `yaml:"healthcheck"`
+
+	// Environment variables. Supports {{service.interface.addr}} templates.
+	Environment map[string]string `yaml:"environment"`
+
+	// --- Legacy fields (backward compat, migrated on load) ---
+	Port  int               `yaml:"port"`
+	Env   map[string]string `yaml:"env"`
+	Ready string            `yaml:"ready"`
 }
+
+// InterfaceConfig describes one communication interface of a service.
+type InterfaceConfig struct {
+	Protocol string   `yaml:"protocol"` // "http", "tcp", "grpc", etc.
+	Port     int      `yaml:"port"`
+	Topics   []string `yaml:"topics,omitempty"` // for async protocols (kafka, etc.)
+}
+
+// HealthcheckConfig describes a service readiness check.
+type HealthcheckConfig struct {
+	Test     string   `yaml:"test"`     // "tcp://host:port" or "http://host/path"
+	Interval Duration `yaml:"interval"` // poll interval (default 1s)
+	Timeout  Duration `yaml:"timeout"`  // overall timeout (default 10s)
+}
+
+// ---------------------------------------------------------------------------
+// Spec (spec.yaml)
+// ---------------------------------------------------------------------------
 
 // SpecConfig is parsed from spec.yaml — describes test traces.
 type SpecConfig struct {
@@ -34,18 +68,155 @@ type SpecConfig struct {
 
 // TraceConfig describes one test trace.
 type TraceConfig struct {
-	Description string                       `yaml:"description"`
-	Faults      map[string][]string          `yaml:"faults"`
-	Assert      []AssertConfig               `yaml:"assert"`
-	Timeout     Duration                     `yaml:"timeout"`
+	Description string              `yaml:"description"`
+	Faults      map[string]FaultSet `yaml:"faults"`
+	Steps       []StepConfig        `yaml:"steps"`
+	Assert      []AssertConfig      `yaml:"assert"`
+	Timeout     Duration            `yaml:"timeout"`
+}
+
+// FaultSet holds fault rules for one service. Supports both string and object forms.
+// YAML can be a list of strings, a list of maps, or a mix.
+type FaultSet []FaultSpec
+
+// FaultSpec holds one fault rule in either string or object form.
+type FaultSpec struct {
+	// Raw is the string form: "write=delay:500ms:100%"
+	Raw string
+	// Object form fields:
+	Syscall     string  `yaml:"syscall"`
+	Action      string  `yaml:"action"`      // "delay" or "deny"
+	Errno       string  `yaml:"errno"`       // for deny
+	Delay       string  `yaml:"delay"`       // for delay (duration string)
+	Probability string  `yaml:"probability"` // "100%" or "0.5"
+	PathGlob    string  `yaml:"path"`
+	Trigger     *TriggerSpec `yaml:"trigger"`
+}
+
+// TriggerSpec is the object form of a stateful trigger.
+type TriggerSpec struct {
+	Type string `yaml:"type"` // "nth" or "after"
+	N    int    `yaml:"n"`
+}
+
+// UnmarshalYAML handles both string and object forms for FaultSpec.
+func (f *FaultSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		f.Raw = value.Value
+		return nil
+	}
+	// Object form — decode into the struct fields.
+	type plain FaultSpec
+	return value.Decode((*plain)(f))
+}
+
+// ToRuleString converts a FaultSpec to the string form used by ParseFaultRule.
+func (f *FaultSpec) ToRuleString() string {
+	if f.Raw != "" {
+		return f.Raw
+	}
+	// Build from object fields.
+	var b strings.Builder
+	b.WriteString(f.Syscall)
+	b.WriteByte('=')
+
+	if f.Action == "delay" {
+		b.WriteString("delay:")
+		b.WriteString(f.Delay)
+		b.WriteByte(':')
+		b.WriteString(f.Probability)
+	} else {
+		// deny
+		errno := f.Errno
+		if errno == "" {
+			errno = "EIO"
+		}
+		b.WriteString(errno)
+		b.WriteByte(':')
+		b.WriteString(f.Probability)
+		if f.PathGlob != "" {
+			b.WriteByte(':')
+			b.WriteString(f.PathGlob)
+		}
+	}
+
+	if f.Trigger != nil {
+		b.WriteByte(':')
+		b.WriteString(f.Trigger.Type)
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%d", f.Trigger.N))
+	}
+	return b.String()
+}
+
+// UnmarshalYAML for FaultSet handles a YAML sequence of mixed string/object items.
+func (fs *FaultSet) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.SequenceNode {
+		return fmt.Errorf("faults must be a list, got %v", value.Kind)
+	}
+	specs := make([]FaultSpec, len(value.Content))
+	for i, item := range value.Content {
+		if err := item.Decode(&specs[i]); err != nil {
+			return fmt.Errorf("fault[%d]: %w", i, err)
+		}
+	}
+	*fs = specs
+	return nil
+}
+
+// ToRuleStrings converts all FaultSpecs to string form.
+func (fs FaultSet) ToRuleStrings() []string {
+	result := make([]string, len(fs))
+	for i := range fs {
+		result[i] = fs[i].ToRuleString()
+	}
+	return result
+}
+
+// StepConfig represents one step in a trace scenario.
+// Exactly one field should be set. The key format is "service[.interface].operation".
+type StepConfig struct {
+	// Sleep pauses execution for a duration.
+	Sleep *Duration `yaml:"sleep,omitempty"`
+	// Action is a service.operation or service.interface.operation step.
+	// Populated during parsing from the dynamic YAML key.
+	Action   string            `yaml:"-"`
+	Args     map[string]any    `yaml:"-"`
+}
+
+// UnmarshalYAML handles the dynamic step format:
+//   - sleep: 1s
+//   - api.post: { path: /health, expect: { status: 200 } }
+func (s *StepConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode || len(value.Content) < 2 {
+		return fmt.Errorf("step must be a mapping with one key")
+	}
+	key := value.Content[0].Value
+	val := value.Content[1]
+
+	// Handle sleep specially.
+	if key == "sleep" {
+		var d Duration
+		if err := val.Decode(&d); err != nil {
+			return fmt.Errorf("step sleep: %w", err)
+		}
+		s.Sleep = &d
+		return nil
+	}
+
+	// Dynamic step: key is "service.operation" or "service.interface.operation".
+	s.Action = key
+	args := make(map[string]any)
+	if err := val.Decode(&args); err != nil {
+		return fmt.Errorf("step %s args: %w", key, err)
+	}
+	s.Args = args
+	return nil
 }
 
 // AssertConfig describes one assertion in a trace.
-// For PoC: supports exit_code checks and eventually(http.get).
 type AssertConfig struct {
-	// ExitCode checks: "api.exit_code == 0"
-	ExitCode *ExitCodeAssert `yaml:"exit_code"`
-	// Eventually checks: poll until condition is met
+	ExitCode   *ExitCodeAssert   `yaml:"exit_code"`
 	Eventually *EventuallyAssert `yaml:"eventually"`
 }
 
@@ -57,7 +228,7 @@ type ExitCodeAssert struct {
 
 // EventuallyAssert polls an HTTP endpoint until expected status.
 type EventuallyAssert struct {
-	Timeout Duration `yaml:"timeout"`
+	Timeout Duration   `yaml:"timeout"`
 	HTTP    *HTTPCheck `yaml:"http"`
 }
 
@@ -66,6 +237,10 @@ type HTTPCheck struct {
 	URL    string `yaml:"url"`
 	Status int    `yaml:"status"`
 }
+
+// ---------------------------------------------------------------------------
+// Duration
+// ---------------------------------------------------------------------------
 
 // Duration wraps time.Duration for YAML unmarshalling.
 type Duration struct {
@@ -89,6 +264,10 @@ func (d Duration) MarshalYAML() (interface{}, error) {
 	return d.Duration.String(), nil
 }
 
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
 // LoadTopology parses a faultbox.yaml file.
 func LoadTopology(path string) (*TopologyConfig, error) {
 	data, err := os.ReadFile(path)
@@ -99,6 +278,7 @@ func LoadTopology(path string) (*TopologyConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse topology %s: %w", path, err)
 	}
+	migrateTopology(&cfg)
 	if err := validateTopology(&cfg); err != nil {
 		return nil, fmt.Errorf("validate topology %s: %w", path, err)
 	}
@@ -121,6 +301,45 @@ func LoadSpec(path string) (*SpecConfig, error) {
 	return &cfg, nil
 }
 
+// ---------------------------------------------------------------------------
+// Migration (legacy → new format)
+// ---------------------------------------------------------------------------
+
+// migrateTopology converts legacy fields to the new format.
+func migrateTopology(cfg *TopologyConfig) {
+	for name, svc := range cfg.Services {
+		// Migrate port → interfaces.default
+		if svc.Port > 0 && len(svc.Interfaces) == 0 {
+			svc.Interfaces = map[string]InterfaceConfig{
+				"default": {Protocol: "tcp", Port: svc.Port},
+			}
+			svc.Port = 0
+		}
+
+		// Migrate env → environment
+		if len(svc.Env) > 0 && len(svc.Environment) == 0 {
+			svc.Environment = svc.Env
+			svc.Env = nil
+		}
+
+		// Migrate ready → healthcheck
+		if svc.Ready != "" && svc.Healthcheck == nil {
+			svc.Healthcheck = &HealthcheckConfig{
+				Test:     svc.Ready,
+				Interval: Duration{time.Second},
+				Timeout:  Duration{10 * time.Second},
+			}
+			svc.Ready = ""
+		}
+
+		cfg.Services[name] = svc
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
 func validateTopology(cfg *TopologyConfig) error {
 	if len(cfg.Services) == 0 {
 		return fmt.Errorf("no services defined")
@@ -129,7 +348,17 @@ func validateTopology(cfg *TopologyConfig) error {
 		if svc.Binary == "" {
 			return fmt.Errorf("service %q: binary is required", name)
 		}
-		// Validate depends_on references exist.
+		if len(svc.Interfaces) == 0 {
+			return fmt.Errorf("service %q: at least one interface is required (or set port for legacy mode)", name)
+		}
+		for ifName, iface := range svc.Interfaces {
+			if iface.Port <= 0 {
+				return fmt.Errorf("service %q interface %q: port is required", name, ifName)
+			}
+			if iface.Protocol == "" {
+				return fmt.Errorf("service %q interface %q: protocol is required", name, ifName)
+			}
+		}
 		for _, dep := range svc.DependsOn {
 			if _, ok := cfg.Services[dep]; !ok {
 				return fmt.Errorf("service %q: depends_on %q not found", name, dep)
@@ -143,11 +372,77 @@ func validateSpec(cfg *SpecConfig) error {
 	if len(cfg.Traces) == 0 {
 		return fmt.Errorf("no traces defined")
 	}
+	for name, trace := range cfg.Traces {
+		for i, step := range trace.Steps {
+			if step.Sleep == nil && step.Action == "" {
+				return fmt.Errorf("trace %q step[%d]: invalid step (no action)", name, i)
+			}
+		}
+	}
 	return nil
 }
 
+// ---------------------------------------------------------------------------
+// Service Discovery Helpers
+// ---------------------------------------------------------------------------
+
+// ResolveServiceAddr returns "host:port" for a service's interface.
+// For PoC, host is always "localhost".
+func ResolveServiceAddr(cfg *TopologyConfig, service, iface string) (string, error) {
+	svc, ok := cfg.Services[service]
+	if !ok {
+		return "", fmt.Errorf("service %q not found", service)
+	}
+
+	// If interface not specified, use the only one (or "default").
+	if iface == "" {
+		if len(svc.Interfaces) == 1 {
+			for _, ic := range svc.Interfaces {
+				return fmt.Sprintf("localhost:%d", ic.Port), nil
+			}
+		}
+		if ic, ok := svc.Interfaces["default"]; ok {
+			return fmt.Sprintf("localhost:%d", ic.Port), nil
+		}
+		return "", fmt.Errorf("service %q has multiple interfaces, specify which one", service)
+	}
+
+	ic, ok := svc.Interfaces[iface]
+	if !ok {
+		return "", fmt.Errorf("service %q interface %q not found", service, iface)
+	}
+	return fmt.Sprintf("localhost:%d", ic.Port), nil
+}
+
+// ResolveInterfaceProtocol returns the protocol for a service's interface.
+func ResolveInterfaceProtocol(cfg *TopologyConfig, service, iface string) (string, error) {
+	svc, ok := cfg.Services[service]
+	if !ok {
+		return "", fmt.Errorf("service %q not found", service)
+	}
+	if iface == "" {
+		if len(svc.Interfaces) == 1 {
+			for _, ic := range svc.Interfaces {
+				return ic.Protocol, nil
+			}
+		}
+		if ic, ok := svc.Interfaces["default"]; ok {
+			return ic.Protocol, nil
+		}
+		return "", fmt.Errorf("service %q has multiple interfaces, specify which one", service)
+	}
+	ic, ok := svc.Interfaces[iface]
+	if !ok {
+		return "", fmt.Errorf("service %q interface %q not found", service, iface)
+	}
+	return ic.Protocol, nil
+}
+
+// ---------------------------------------------------------------------------
+// Dependency ordering
+// ---------------------------------------------------------------------------
+
 // DependencyOrder returns service names in topological order (dependencies first).
-// Returns an error if there are circular dependencies.
 func DependencyOrder(services map[string]ServiceConfig) ([]string, error) {
 	visited := make(map[string]bool)
 	visiting := make(map[string]bool)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,400 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadTopology_NewFormat(t *testing.T) {
+	yaml := `
+version: "1"
+services:
+  db:
+    binary: /usr/bin/db
+    interfaces:
+      main:
+        protocol: tcp
+        port: 5432
+    healthcheck:
+      test: tcp://localhost:5432
+      timeout: 10s
+  api:
+    binary: /usr/bin/api
+    interfaces:
+      public:
+        protocol: http
+        port: 8080
+    depends_on: [db]
+    environment:
+      DB_ADDR: "{{db.main.addr}}"
+    healthcheck:
+      test: http://localhost:8080/health
+      timeout: 10s
+`
+	cfg := mustLoadTopologyString(t, yaml)
+
+	// Check db service.
+	db := cfg.Services["db"]
+	if db.Binary != "/usr/bin/db" {
+		t.Fatalf("db.Binary = %q, want /usr/bin/db", db.Binary)
+	}
+	if db.Interfaces["main"].Protocol != "tcp" {
+		t.Fatalf("db interface protocol = %q, want tcp", db.Interfaces["main"].Protocol)
+	}
+	if db.Interfaces["main"].Port != 5432 {
+		t.Fatalf("db interface port = %d, want 5432", db.Interfaces["main"].Port)
+	}
+	if db.Healthcheck == nil || db.Healthcheck.Test != "tcp://localhost:5432" {
+		t.Fatalf("db healthcheck = %v, want tcp://localhost:5432", db.Healthcheck)
+	}
+
+	// Check api service.
+	api := cfg.Services["api"]
+	if len(api.DependsOn) != 1 || api.DependsOn[0] != "db" {
+		t.Fatalf("api depends_on = %v, want [db]", api.DependsOn)
+	}
+	if api.Environment["DB_ADDR"] != "{{db.main.addr}}" {
+		t.Fatalf("api env DB_ADDR = %q, want template", api.Environment["DB_ADDR"])
+	}
+}
+
+func TestLoadTopology_LegacyFormat(t *testing.T) {
+	yaml := `
+version: "1"
+services:
+  db:
+    binary: /usr/bin/db
+    port: 5432
+    env:
+      PORT: "5432"
+    ready: tcp://localhost:5432
+`
+	cfg := mustLoadTopologyString(t, yaml)
+	db := cfg.Services["db"]
+
+	// Legacy port should migrate to interfaces.default.
+	if db.Interfaces["default"].Port != 5432 {
+		t.Fatalf("migrated port = %d, want 5432", db.Interfaces["default"].Port)
+	}
+	if db.Interfaces["default"].Protocol != "tcp" {
+		t.Fatalf("migrated protocol = %q, want tcp", db.Interfaces["default"].Protocol)
+	}
+
+	// Legacy env should migrate to environment.
+	if db.Environment["PORT"] != "5432" {
+		t.Fatalf("migrated env PORT = %q, want 5432", db.Environment["PORT"])
+	}
+
+	// Legacy ready should migrate to healthcheck.
+	if db.Healthcheck == nil || db.Healthcheck.Test != "tcp://localhost:5432" {
+		t.Fatalf("migrated healthcheck = %v", db.Healthcheck)
+	}
+}
+
+func TestLoadTopology_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "no services",
+			yaml: `version: "1"
+services: {}`,
+			want: "no services defined",
+		},
+		{
+			name: "missing binary",
+			yaml: `version: "1"
+services:
+  db:
+    interfaces:
+      main: { protocol: tcp, port: 5432 }`,
+			want: "binary is required",
+		},
+		{
+			name: "missing interface port",
+			yaml: `version: "1"
+services:
+  db:
+    binary: /usr/bin/db
+    interfaces:
+      main: { protocol: tcp }`,
+			want: "port is required",
+		},
+		{
+			name: "missing interface protocol",
+			yaml: `version: "1"
+services:
+  db:
+    binary: /usr/bin/db
+    interfaces:
+      main: { port: 5432 }`,
+			want: "protocol is required",
+		},
+		{
+			name: "bad depends_on",
+			yaml: `version: "1"
+services:
+  api:
+    binary: /usr/bin/api
+    interfaces:
+      main: { protocol: http, port: 8080 }
+    depends_on: [nonexistent]`,
+			want: "depends_on \"nonexistent\" not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadTopologyString(tt.yaml)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q should contain %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadSpec_WithSteps(t *testing.T) {
+	yaml := `
+version: "1"
+system: faultbox.yaml
+traces:
+  test-trace:
+    description: "test"
+    faults:
+      db:
+        - "write=delay:500ms:100%"
+        - syscall: connect
+          action: deny
+          errno: ECONNREFUSED
+          probability: "100%"
+    steps:
+      - api.post:
+          path: /data/key1
+          body: "value1"
+          expect:
+            status: 200
+      - db.main.send:
+          data: "PING"
+          expect:
+            equals: "PONG"
+      - sleep: 1s
+    assert:
+      - exit_code: { service: api, equals: 0 }
+    timeout: "15s"
+`
+	cfg := mustLoadSpecString(t, yaml)
+	trace := cfg.Traces["test-trace"]
+
+	// Check mixed fault formats.
+	faults := trace.Faults["db"]
+	if len(faults) != 2 {
+		t.Fatalf("fault count = %d, want 2", len(faults))
+	}
+	// String form.
+	if faults[0].Raw != "write=delay:500ms:100%" {
+		t.Fatalf("fault[0].Raw = %q", faults[0].Raw)
+	}
+	// Object form.
+	if faults[1].Syscall != "connect" || faults[1].Action != "deny" {
+		t.Fatalf("fault[1] = %+v", faults[1])
+	}
+
+	// Check ToRuleStrings.
+	rules := faults.ToRuleStrings()
+	if rules[0] != "write=delay:500ms:100%" {
+		t.Fatalf("rule[0] = %q", rules[0])
+	}
+	if !strings.Contains(rules[1], "connect=ECONNREFUSED:100%") {
+		t.Fatalf("rule[1] = %q", rules[1])
+	}
+
+	// Check steps.
+	if len(trace.Steps) != 3 {
+		t.Fatalf("step count = %d, want 3", len(trace.Steps))
+	}
+	if trace.Steps[0].Action != "api.post" {
+		t.Fatalf("step[0].Action = %q, want api.post", trace.Steps[0].Action)
+	}
+	if trace.Steps[1].Action != "db.main.send" {
+		t.Fatalf("step[1].Action = %q, want db.main.send", trace.Steps[1].Action)
+	}
+	if trace.Steps[2].Sleep == nil {
+		t.Fatal("step[2].Sleep is nil, want 1s")
+	}
+}
+
+func TestResolveServiceAddr(t *testing.T) {
+	cfg := &TopologyConfig{
+		Services: map[string]ServiceConfig{
+			"db": {
+				Interfaces: map[string]InterfaceConfig{
+					"main": {Protocol: "tcp", Port: 5432},
+				},
+			},
+			"api": {
+				Interfaces: map[string]InterfaceConfig{
+					"public":   {Protocol: "http", Port: 8080},
+					"internal": {Protocol: "grpc", Port: 9090},
+				},
+			},
+		},
+	}
+
+	// Single interface — no name needed.
+	addr, err := ResolveServiceAddr(cfg, "db", "")
+	if err != nil {
+		t.Fatalf("resolve db: %v", err)
+	}
+	if addr != "localhost:5432" {
+		t.Fatalf("db addr = %q, want localhost:5432", addr)
+	}
+
+	// Multiple interfaces — name required.
+	_, err = ResolveServiceAddr(cfg, "api", "")
+	if err == nil {
+		t.Fatal("expected error for ambiguous interface")
+	}
+
+	// Explicit interface.
+	addr, err = ResolveServiceAddr(cfg, "api", "public")
+	if err != nil {
+		t.Fatalf("resolve api.public: %v", err)
+	}
+	if addr != "localhost:8080" {
+		t.Fatalf("api.public addr = %q, want localhost:8080", addr)
+	}
+}
+
+func TestResolveEnv(t *testing.T) {
+	cfg := &TopologyConfig{
+		Services: map[string]ServiceConfig{
+			"db": {
+				Interfaces: map[string]InterfaceConfig{
+					"main": {Protocol: "tcp", Port: 5432},
+				},
+				Environment: map[string]string{"PORT": "5432"},
+			},
+			"api": {
+				Interfaces: map[string]InterfaceConfig{
+					"public": {Protocol: "http", Port: 8080},
+				},
+				Environment: map[string]string{
+					"PORT":    "8080",
+					"DB_ADDR": "{{db.main.addr}}",
+				},
+			},
+		},
+	}
+
+	env, err := ResolveEnv(cfg, "api")
+	if err != nil {
+		t.Fatalf("resolve env: %v", err)
+	}
+
+	envMap := make(map[string]string)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		envMap[parts[0]] = parts[1]
+	}
+
+	// Check template resolution.
+	if envMap["DB_ADDR"] != "localhost:5432" {
+		t.Fatalf("DB_ADDR = %q, want localhost:5432", envMap["DB_ADDR"])
+	}
+
+	// Check auto-injected vars.
+	if envMap["FAULTBOX_DB_MAIN_ADDR"] != "localhost:5432" {
+		t.Fatalf("FAULTBOX_DB_MAIN_ADDR = %q", envMap["FAULTBOX_DB_MAIN_ADDR"])
+	}
+	if envMap["FAULTBOX_API_PUBLIC_PORT"] != "8080" {
+		t.Fatalf("FAULTBOX_API_PUBLIC_PORT = %q", envMap["FAULTBOX_API_PUBLIC_PORT"])
+	}
+}
+
+func TestDependencyOrder(t *testing.T) {
+	services := map[string]ServiceConfig{
+		"api":   {DependsOn: []string{"db", "cache"}},
+		"db":    {},
+		"cache": {DependsOn: []string{"db"}},
+	}
+	order, err := DependencyOrder(services)
+	if err != nil {
+		t.Fatalf("dependency order: %v", err)
+	}
+
+	indexOf := func(name string) int {
+		for i, n := range order {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+
+	if indexOf("db") >= indexOf("cache") {
+		t.Fatalf("db should come before cache: %v", order)
+	}
+	if indexOf("cache") >= indexOf("api") {
+		t.Fatalf("cache should come before api: %v", order)
+	}
+}
+
+func TestDependencyOrder_Circular(t *testing.T) {
+	services := map[string]ServiceConfig{
+		"a": {DependsOn: []string{"b"}},
+		"b": {DependsOn: []string{"a"}},
+	}
+	_, err := DependencyOrder(services)
+	if err == nil {
+		t.Fatal("expected circular dependency error")
+	}
+}
+
+// --- helpers ---
+
+func mustLoadTopologyString(t *testing.T, content string) *TopologyConfig {
+	t.Helper()
+	cfg, err := loadTopologyString(content)
+	if err != nil {
+		t.Fatalf("load topology: %v", err)
+	}
+	return cfg
+}
+
+func loadTopologyString(content string) (*TopologyConfig, error) {
+	dir, err := os.MkdirTemp("", "faultbox-test-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "faultbox.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return nil, err
+	}
+	return LoadTopology(path)
+}
+
+func mustLoadSpecString(t *testing.T, content string) *SpecConfig {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "faultbox-test-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "spec.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	cfg, err := LoadSpec(path)
+	if err != nil {
+		t.Fatalf("load spec: %v", err)
+	}
+	return cfg
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var templateRe = regexp.MustCompile(`\{\{([^}]+)\}\}`)
+
+// ResolveEnv builds the final environment variable list for a service.
+// It merges user-defined env vars with auto-injected FAULTBOX_* vars for
+// service discovery, and resolves {{service.interface.addr}} templates.
+func ResolveEnv(topo *TopologyConfig, serviceName string) ([]string, error) {
+	svc := topo.Services[serviceName]
+	env := make(map[string]string)
+
+	// 1. Auto-inject FAULTBOX_<SERVICE>_<INTERFACE>_* for all services.
+	for name, s := range topo.Services {
+		upper := strings.ToUpper(name)
+		for ifName, iface := range s.Interfaces {
+			ifUpper := strings.ToUpper(ifName)
+			prefix := fmt.Sprintf("FAULTBOX_%s_%s", upper, ifUpper)
+			env[prefix+"_HOST"] = "localhost"
+			env[prefix+"_PORT"] = fmt.Sprintf("%d", iface.Port)
+			env[prefix+"_ADDR"] = fmt.Sprintf("localhost:%d", iface.Port)
+		}
+	}
+
+	// 2. Merge user-defined env vars (override auto-injected if same key).
+	for k, v := range svc.Environment {
+		resolved, err := resolveTemplates(topo, v)
+		if err != nil {
+			return nil, fmt.Errorf("service %q env %q: %w", serviceName, k, err)
+		}
+		env[k] = resolved
+	}
+
+	// 3. Convert to KEY=VALUE slice.
+	result := make([]string, 0, len(env))
+	for k, v := range env {
+		result = append(result, k+"="+v)
+	}
+	return result, nil
+}
+
+// resolveTemplates replaces {{service.interface.field}} with actual values.
+// Supported: {{service.interface.addr}}, {{service.interface.host}}, {{service.interface.port}}
+// Shorthand: {{service.addr}} when service has a single interface.
+func resolveTemplates(topo *TopologyConfig, s string) (string, error) {
+	var resolveErr error
+	result := templateRe.ReplaceAllStringFunc(s, func(match string) string {
+		if resolveErr != nil {
+			return match
+		}
+		inner := strings.TrimSpace(match[2 : len(match)-2])
+		parts := strings.Split(inner, ".")
+
+		var svcName, ifName, field string
+		switch len(parts) {
+		case 2:
+			// {{service.field}} — shorthand for single-interface services
+			svcName, field = parts[0], parts[1]
+		case 3:
+			// {{service.interface.field}}
+			svcName, ifName, field = parts[0], parts[1], parts[2]
+		default:
+			resolveErr = fmt.Errorf("invalid template %q: expected service.field or service.interface.field", match)
+			return match
+		}
+
+		svc, ok := topo.Services[svcName]
+		if !ok {
+			resolveErr = fmt.Errorf("template %q: service %q not found", match, svcName)
+			return match
+		}
+
+		// Resolve interface.
+		var iface InterfaceConfig
+		if ifName == "" {
+			if len(svc.Interfaces) == 1 {
+				for _, ic := range svc.Interfaces {
+					iface = ic
+				}
+			} else if ic, ok := svc.Interfaces["default"]; ok {
+				iface = ic
+			} else {
+				resolveErr = fmt.Errorf("template %q: service %q has multiple interfaces, specify which one", match, svcName)
+				return match
+			}
+		} else {
+			ic, ok := svc.Interfaces[ifName]
+			if !ok {
+				resolveErr = fmt.Errorf("template %q: service %q interface %q not found", match, svcName, ifName)
+				return match
+			}
+			iface = ic
+		}
+
+		switch field {
+		case "addr":
+			return fmt.Sprintf("localhost:%d", iface.Port)
+		case "host":
+			return "localhost"
+		case "port":
+			return fmt.Sprintf("%d", iface.Port)
+		default:
+			resolveErr = fmt.Errorf("template %q: unknown field %q (use addr, host, or port)", match, field)
+			return match
+		}
+	})
+
+	return result, resolveErr
+}

--- a/internal/engine/launch_linux.go
+++ b/internal/engine/launch_linux.go
@@ -151,6 +151,15 @@ func (s *Session) launch(ctx context.Context) (*Result, error) {
 		close(notifDone)
 	}
 
+	// Kill child when context is cancelled.
+	go func() {
+		<-ctx.Done()
+		// Send SIGTERM first, then SIGKILL after 2s.
+		unix.Kill(childPid, unix.SIGTERM)
+		time.Sleep(2 * time.Second)
+		unix.Kill(childPid, unix.SIGKILL)
+	}()
+
 	// Wait for the child process.
 	exitCode := 0
 	var waitErr error

--- a/internal/engine/simulation.go
+++ b/internal/engine/simulation.go
@@ -17,26 +17,27 @@ import (
 
 // SimulationResult captures the outcome of running all traces.
 type SimulationResult struct {
-	SimulationID string                    `json:"simulation_id"`
-	DurationMs   int64                     `json:"duration_ms"`
-	Traces       []TraceResult             `json:"traces"`
-	Pass         int                       `json:"pass"`
-	Fail         int                       `json:"fail"`
+	SimulationID string        `json:"simulation_id"`
+	DurationMs   int64         `json:"duration_ms"`
+	Traces       []TraceResult `json:"traces"`
+	Pass         int           `json:"pass"`
+	Fail         int           `json:"fail"`
 }
 
 // TraceResult captures the outcome of a single trace execution.
 type TraceResult struct {
-	Name       string                    `json:"name"`
-	Result     string                    `json:"result"` // "pass" or "fail"
-	Reason     string                    `json:"reason,omitempty"`
-	DurationMs int64                     `json:"duration_ms"`
-	Services   map[string]ServiceResult  `json:"services"`
+	Name       string                   `json:"name"`
+	Result     string                   `json:"result"` // "pass" or "fail"
+	Reason     string                   `json:"reason,omitempty"`
+	DurationMs int64                    `json:"duration_ms"`
+	Services   map[string]ServiceResult `json:"services"`
+	Steps      []StepResult             `json:"steps,omitempty"`
 }
 
 // ServiceResult captures per-service outcome in a trace.
 type ServiceResult struct {
-	ExitCode      int  `json:"exit_code"`
-	FaultsApplied int  `json:"faults_applied"`
+	ExitCode      int `json:"exit_code"`
+	FaultsApplied int `json:"faults_applied"`
 }
 
 // RunSimulation executes all traces from a spec against a topology.
@@ -106,7 +107,7 @@ func (e *Engine) RunSimulation(ctx context.Context, topo *config.TopologyConfig,
 	return result, nil
 }
 
-// runTrace starts all services, applies faults, waits, checks assertions.
+// runTrace starts all services, runs steps, checks assertions.
 func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name string, trace *config.TraceConfig, log *slog.Logger) (*TraceResult, error) {
 	traceStart := time.Now()
 
@@ -127,10 +128,10 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 
 	// Start services in dependency order.
 	type runningService struct {
-		name    string
+		name   string
 		session *Session
-		cancel  context.CancelFunc
-		done    chan *Result
+		cancel context.CancelFunc
+		done   chan *Result
 	}
 	var running []runningService
 
@@ -150,17 +151,17 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 
 		// Build fault rules for this service in this trace.
 		var faultRules []FaultRule
-		if faultSpecs, ok := trace.Faults[svcName]; ok {
-			faultRules, err = ParseFaultRules(faultSpecs)
+		if faultSet, ok := trace.Faults[svcName]; ok {
+			faultRules, err = ParseFaultRules(faultSet.ToRuleStrings())
 			if err != nil {
 				return nil, fmt.Errorf("service %q faults: %w", svcName, err)
 			}
 		}
 
-		// Build env vars.
-		var envVars []string
-		for k, v := range svcCfg.Env {
-			envVars = append(envVars, k+"="+v)
+		// Resolve env vars with auto-injection and templates.
+		envVars, err := config.ResolveEnv(topo, svcName)
+		if err != nil {
+			return nil, fmt.Errorf("service %q env: %w", svcName, err)
 		}
 
 		// Multi-service: skip NET namespace (shared host network).
@@ -201,8 +202,12 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 		})
 
 		// Wait for readiness.
-		if svcCfg.Ready != "" {
-			if err := waitReady(traceCtx, svcCfg.Ready, 10*time.Second, svcLog); err != nil {
+		if svcCfg.Healthcheck != nil {
+			hcTimeout := svcCfg.Healthcheck.Timeout.Duration
+			if hcTimeout <= 0 {
+				hcTimeout = 10 * time.Second
+			}
+			if err := waitReady(traceCtx, svcCfg.Healthcheck.Test, hcTimeout, svcLog); err != nil {
 				return &TraceResult{
 					Name:       name,
 					Result:     "fail",
@@ -210,53 +215,85 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 					DurationMs: time.Since(traceStart).Milliseconds(),
 				}, nil
 			}
-			svcLog.Info("service ready", slog.String("check", svcCfg.Ready))
+			svcLog.Info("service ready", slog.String("check", svcCfg.Healthcheck.Test))
 		}
 	}
 
-	// All services are running. Run assertions while services are alive.
+	// All services are running.
 	trResult := &TraceResult{
 		Name:     name,
 		Result:   "pass",
 		Services: make(map[string]ServiceResult),
 	}
 
-	for _, a := range trace.Assert {
-		if a.Eventually != nil && a.Eventually.HTTP != nil {
-			check := a.Eventually.HTTP
-			evTimeout := 5 * time.Second
-			if a.Eventually.Timeout.Duration > 0 {
-				evTimeout = a.Eventually.Timeout.Duration
+	// Run steps (active scenario driver).
+	if len(trace.Steps) > 0 {
+		stepLog := log.With(slog.String("phase", "steps"))
+		stepResults, err := RunSteps(traceCtx, topo, trace.Steps, stepLog)
+		trResult.Steps = stepResults
+		if err != nil {
+			trResult.Result = "fail"
+			trResult.Reason = fmt.Sprintf("step execution error: %v", err)
+		} else {
+			// Check if any step failed.
+			for _, sr := range stepResults {
+				if !sr.Success {
+					trResult.Result = "fail"
+					trResult.Reason = fmt.Sprintf("step %q failed: %s", sr.Action, sr.Error)
+					break
+				}
 			}
-			if err := waitHTTP(traceCtx, check.URL, check.Status, evTimeout); err != nil {
-				trResult.Result = "fail"
-				trResult.Reason = fmt.Sprintf("assertion: eventually http %s status=%d: %v",
-					check.URL, check.Status, err)
-				break
+		}
+	}
+
+	// Run eventually assertions (while services are still alive).
+	if trResult.Result == "pass" {
+		for _, a := range trace.Assert {
+			if a.Eventually != nil && a.Eventually.HTTP != nil {
+				check := a.Eventually.HTTP
+				evTimeout := 5 * time.Second
+				if a.Eventually.Timeout.Duration > 0 {
+					evTimeout = a.Eventually.Timeout.Duration
+				}
+				if err := waitHTTP(traceCtx, check.URL, check.Status, evTimeout); err != nil {
+					trResult.Result = "fail"
+					trResult.Reason = fmt.Sprintf("assertion: eventually http %s status=%d: %v",
+						check.URL, check.Status, err)
+					break
+				}
 			}
 		}
 	}
 
 	// Stop all services and collect exit codes.
-	// Services that were still running when we stop them are considered successful
-	// (they didn't crash — we intentionally stopped them).
+	// First, check which services already exited on their own (before we kill them).
+	alreadyExited := make(map[string]*Result)
+	for _, rs := range running {
+		select {
+		case r := <-rs.done:
+			alreadyExited[rs.name] = r
+		default:
+			// Still running — will be killed below.
+		}
+	}
 	for _, rs := range running {
 		rs.cancel()
 	}
 	for _, rs := range running {
-		exitCode := 0 // default: still-running = success
-		select {
-		case r := <-rs.done:
+		exitCode := 0
+		if r, exited := alreadyExited[rs.name]; exited {
+			// Service exited on its own before we cancelled — use real exit code.
 			if r != nil {
-				// If service exited on its own before we cancelled, use its real exit code.
-				// If it was killed by our cancel (signal), treat as 0 (orderly shutdown).
-				if r.ExitCode > 0 && r.ExitCode < 128 {
-					exitCode = r.ExitCode
-				}
-				// exit codes 128+ are signal kills (from our cancel) → treat as 0
+				exitCode = r.ExitCode
 			}
-		case <-time.After(5 * time.Second):
-			exitCode = 0 // timed out stopping = still considered ok
+		} else {
+			// Service was still running — we killed it. Wait for it to finish.
+			select {
+			case <-rs.done:
+			case <-time.After(5 * time.Second):
+			}
+			// Killed by us = orderly shutdown = exit code 0.
+			exitCode = 0
 		}
 		faultCount := 0
 		if faults, ok := trace.Faults[rs.name]; ok {
@@ -267,7 +304,6 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 			FaultsApplied: faultCount,
 		}
 	}
-	// Clear running so defer doesn't double-stop.
 	running = nil
 
 	// Check exit code assertions (after services stopped).
@@ -369,19 +405,24 @@ func generateSimID() (string, error) {
 	return id, nil
 }
 
-// waitPortsFree waits until all service ports are available (no lingering listeners).
+// waitPortsFree waits until all service ports are available.
 func waitPortsFree(topo *config.TopologyConfig, timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		allFree := true
 		for _, svc := range topo.Services {
-			if svc.Port > 0 {
-				conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", svc.Port), 100*time.Millisecond)
-				if err == nil {
-					conn.Close()
-					allFree = false
-					break
+			for _, iface := range svc.Interfaces {
+				if iface.Port > 0 {
+					conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", iface.Port), 100*time.Millisecond)
+					if err == nil {
+						conn.Close()
+						allFree = false
+						break
+					}
 				}
+			}
+			if !allFree {
+				break
 			}
 		}
 		if allFree {
@@ -396,7 +437,6 @@ func sortedKeys[V any](m map[string]V) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	// Sort for deterministic order.
 	for i := 0; i < len(keys); i++ {
 		for j := i + 1; j < len(keys); j++ {
 			if keys[i] > keys[j] {

--- a/internal/engine/step.go
+++ b/internal/engine/step.go
@@ -1,0 +1,345 @@
+package engine
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/faultbox/Faultbox/internal/config"
+)
+
+// StepResult captures the outcome of a single step execution.
+type StepResult struct {
+	Action     string `json:"action"`
+	Success    bool   `json:"success"`
+	StatusCode int    `json:"status_code,omitempty"`
+	Body       string `json:"body,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+}
+
+// RunSteps executes trace steps sequentially against running services.
+func RunSteps(ctx context.Context, topo *config.TopologyConfig, steps []config.StepConfig, log *slog.Logger) ([]StepResult, error) {
+	results := make([]StepResult, 0, len(steps))
+	for i, step := range steps {
+		select {
+		case <-ctx.Done():
+			return results, ctx.Err()
+		default:
+		}
+
+		var result StepResult
+		var err error
+
+		if step.Sleep != nil {
+			result, err = runSleepStep(ctx, step.Sleep.Duration)
+		} else if step.Action != "" {
+			result, err = runActionStep(ctx, topo, step, log)
+		} else {
+			return results, fmt.Errorf("step[%d]: no action specified", i)
+		}
+
+		if err != nil {
+			return results, fmt.Errorf("step[%d] %s: %w", i, stepName(step), err)
+		}
+
+		log.Info("step completed",
+			slog.Int("step", i),
+			slog.String("action", stepName(step)),
+			slog.Bool("success", result.Success),
+			slog.Int64("duration_ms", result.DurationMs),
+		)
+
+		results = append(results, result)
+		if !result.Success {
+			return results, nil
+		}
+	}
+	return results, nil
+}
+
+func stepName(s config.StepConfig) string {
+	if s.Sleep != nil {
+		return fmt.Sprintf("sleep(%s)", s.Sleep.Duration)
+	}
+	return s.Action
+}
+
+func runSleepStep(ctx context.Context, d time.Duration) (StepResult, error) {
+	start := time.Now()
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+		return StepResult{}, ctx.Err()
+	}
+	return StepResult{
+		Action:     fmt.Sprintf("sleep(%s)", d),
+		Success:    true,
+		DurationMs: time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// runActionStep resolves "service[.interface].operation" and dispatches.
+func runActionStep(ctx context.Context, topo *config.TopologyConfig, step config.StepConfig, log *slog.Logger) (StepResult, error) {
+	svcName, ifName, operation, err := parseStepAction(step.Action)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	addr, err := config.ResolveServiceAddr(topo, svcName, ifName)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	protocol, err := config.ResolveInterfaceProtocol(topo, svcName, ifName)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	switch protocol {
+	case "http":
+		return runHTTPStep(ctx, addr, operation, step.Args)
+	case "tcp":
+		return runTCPStep(ctx, addr, operation, step.Args)
+	default:
+		return StepResult{}, fmt.Errorf("unsupported protocol %q for step %s", protocol, step.Action)
+	}
+}
+
+// parseStepAction splits "service.operation" or "service.interface.operation".
+func parseStepAction(action string) (service, iface, operation string, err error) {
+	parts := strings.Split(action, ".")
+	switch len(parts) {
+	case 2:
+		return parts[0], "", parts[1], nil
+	case 3:
+		return parts[0], parts[1], parts[2], nil
+	default:
+		return "", "", "", fmt.Errorf("invalid step action %q: expected service.operation or service.interface.operation", action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP step handler
+// ---------------------------------------------------------------------------
+
+func runHTTPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
+	method := strings.ToUpper(operation)
+	switch method {
+	case "GET", "POST", "PUT", "DELETE", "PATCH":
+	default:
+		return StepResult{}, fmt.Errorf("unsupported HTTP operation %q", operation)
+	}
+
+	path := getStringArg(args, "path", "/")
+	url := fmt.Sprintf("http://%s%s", addr, path)
+
+	var bodyReader io.Reader
+	if body := getStringArg(args, "body", ""); body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	start := time.Now()
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return StepResult{}, fmt.Errorf("create request: %w", err)
+	}
+
+	// Apply headers.
+	if headers, ok := args["headers"].(map[string]any); ok {
+		for k, v := range headers {
+			req.Header.Set(k, fmt.Sprint(v))
+		}
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	elapsed := time.Since(start).Milliseconds()
+	if err != nil {
+		return StepResult{
+			Action:     fmt.Sprintf("HTTP %s %s", method, path),
+			Success:    false,
+			Error:      err.Error(),
+			DurationMs: elapsed,
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	bodyStr := strings.TrimSpace(string(respBody))
+
+	result := StepResult{
+		Action:     fmt.Sprintf("HTTP %s %s", method, path),
+		Success:    true,
+		StatusCode: resp.StatusCode,
+		Body:       bodyStr,
+		DurationMs: elapsed,
+	}
+
+	// Check expectations.
+	if expect, ok := args["expect"].(map[string]any); ok {
+		if err := checkHTTPExpect(expect, resp.StatusCode, bodyStr); err != nil {
+			result.Success = false
+			result.Error = err.Error()
+		}
+	}
+
+	return result, nil
+}
+
+func checkHTTPExpect(expect map[string]any, status int, body string) error {
+	if v, ok := expectInt(expect, "status"); ok {
+		if status != v {
+			return fmt.Errorf("expected status %d, got %d", v, status)
+		}
+	}
+	if v := getStringFromAny(expect, "body_contains"); v != "" {
+		if !strings.Contains(body, v) {
+			return fmt.Errorf("expected body to contain %q, got %q", v, truncate(body, 200))
+		}
+	}
+	if v := getStringFromAny(expect, "body_equals"); v != "" {
+		if body != v {
+			return fmt.Errorf("expected body %q, got %q", v, truncate(body, 200))
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// TCP step handler
+// ---------------------------------------------------------------------------
+
+func runTCPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
+	switch operation {
+	case "send":
+	default:
+		return StepResult{}, fmt.Errorf("unsupported TCP operation %q (supported: send)", operation)
+	}
+
+	data := getStringArg(args, "data", "")
+	if data == "" {
+		return StepResult{}, fmt.Errorf("tcp.send requires 'data' argument")
+	}
+
+	start := time.Now()
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return StepResult{
+			Action:     fmt.Sprintf("TCP send to %s", addr),
+			Success:    false,
+			Error:      err.Error(),
+			DurationMs: time.Since(start).Milliseconds(),
+		}, nil
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	// Send data (ensure newline terminated).
+	if !strings.HasSuffix(data, "\n") {
+		data += "\n"
+	}
+	if _, err := fmt.Fprint(conn, data); err != nil {
+		return StepResult{
+			Action:     fmt.Sprintf("TCP send to %s", addr),
+			Success:    false,
+			Error:      fmt.Sprintf("write: %v", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}, nil
+	}
+
+	// Read one line response.
+	scanner := bufio.NewScanner(conn)
+	var respLine string
+	if scanner.Scan() {
+		respLine = strings.TrimSpace(scanner.Text())
+	} else if err := scanner.Err(); err != nil {
+		return StepResult{
+			Action:     fmt.Sprintf("TCP send to %s", addr),
+			Success:    false,
+			Error:      fmt.Sprintf("read: %v", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}, nil
+	}
+
+	elapsed := time.Since(start).Milliseconds()
+	result := StepResult{
+		Action:     fmt.Sprintf("TCP send to %s", addr),
+		Success:    true,
+		Body:       respLine,
+		DurationMs: elapsed,
+	}
+
+	// Check expectations.
+	if expect, ok := args["expect"].(map[string]any); ok {
+		if err := checkTCPExpect(expect, respLine); err != nil {
+			result.Success = false
+			result.Error = err.Error()
+		}
+	}
+
+	return result, nil
+}
+
+func checkTCPExpect(expect map[string]any, response string) error {
+	if v := getStringFromAny(expect, "contains"); v != "" {
+		if !strings.Contains(response, v) {
+			return fmt.Errorf("expected response to contain %q, got %q", v, response)
+		}
+	}
+	if v := getStringFromAny(expect, "equals"); v != "" {
+		if response != v {
+			return fmt.Errorf("expected response %q, got %q", v, response)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Arg helpers
+// ---------------------------------------------------------------------------
+
+func getStringArg(args map[string]any, key, defaultVal string) string {
+	if v := getStringFromAny(args, key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func getStringFromAny(m map[string]any, key string) string {
+	if v, ok := m[key]; ok {
+		return fmt.Sprint(v)
+	}
+	return ""
+}
+
+func expectInt(m map[string]any, key string) (int, bool) {
+	v, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case float64:
+		return int(n), true
+	case int64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/engine/step_test.go
+++ b/internal/engine/step_test.go
@@ -1,0 +1,248 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/faultbox/Faultbox/internal/config"
+)
+
+func TestRunHTTPStep_GET(t *testing.T) {
+	// Start a test HTTP server.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "ok")
+	})
+	mux.HandleFunc("/data/key1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(200)
+			fmt.Fprintln(w, "stored: key1=value1")
+			return
+		}
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "value1")
+	})
+	ln, port := listenOnFreePort(t)
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	topo := &config.TopologyConfig{
+		Services: map[string]config.ServiceConfig{
+			"api": {
+				Interfaces: map[string]config.InterfaceConfig{
+					"public": {Protocol: "http", Port: port},
+				},
+			},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	steps := []config.StepConfig{
+		{Action: "api.get", Args: map[string]any{
+			"path":   "/health",
+			"expect": map[string]any{"status": 200, "body_contains": "ok"},
+		}},
+		{Action: "api.post", Args: map[string]any{
+			"path":   "/data/key1",
+			"body":   "value1",
+			"expect": map[string]any{"status": 200},
+		}},
+		{Action: "api.get", Args: map[string]any{
+			"path":   "/data/key1",
+			"expect": map[string]any{"status": 200, "body_equals": "value1"},
+		}},
+	}
+
+	results, err := RunSteps(context.Background(), topo, steps, log)
+	if err != nil {
+		t.Fatalf("RunSteps: %v", err)
+	}
+
+	for i, r := range results {
+		if !r.Success {
+			t.Errorf("step[%d] %s failed: %s", i, r.Action, r.Error)
+		}
+	}
+}
+
+func TestRunHTTPStep_ExpectFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "not found")
+	})
+	ln, port := listenOnFreePort(t)
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	topo := &config.TopologyConfig{
+		Services: map[string]config.ServiceConfig{
+			"api": {
+				Interfaces: map[string]config.InterfaceConfig{
+					"public": {Protocol: "http", Port: port},
+				},
+			},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	steps := []config.StepConfig{
+		{Action: "api.get", Args: map[string]any{
+			"path":   "/missing",
+			"expect": map[string]any{"status": 200},
+		}},
+	}
+
+	results, err := RunSteps(context.Background(), topo, steps, log)
+	if err != nil {
+		t.Fatalf("RunSteps: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Success {
+		t.Fatal("expected step to fail (status 404 vs expected 200)")
+	}
+	if !strings.Contains(results[0].Error, "expected status 200, got 404") {
+		t.Fatalf("unexpected error: %s", results[0].Error)
+	}
+}
+
+func TestRunTCPStep(t *testing.T) {
+	// Start a simple TCP echo server.
+	ln, port := listenTCPFreePort(t)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				n, _ := c.Read(buf)
+				line := strings.TrimSpace(string(buf[:n]))
+				if line == "PING" {
+					fmt.Fprintln(c, "PONG")
+				} else {
+					fmt.Fprintln(c, "ERR")
+				}
+			}(conn)
+		}
+	}()
+	defer ln.Close()
+
+	topo := &config.TopologyConfig{
+		Services: map[string]config.ServiceConfig{
+			"db": {
+				Interfaces: map[string]config.InterfaceConfig{
+					"main": {Protocol: "tcp", Port: port},
+				},
+			},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	steps := []config.StepConfig{
+		{Action: "db.send", Args: map[string]any{
+			"data":   "PING",
+			"expect": map[string]any{"equals": "PONG"},
+		}},
+	}
+
+	results, err := RunSteps(context.Background(), topo, steps, log)
+	if err != nil {
+		t.Fatalf("RunSteps: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("expected success, got %+v", results)
+	}
+}
+
+func TestParseStepAction(t *testing.T) {
+	tests := []struct {
+		input   string
+		service string
+		iface   string
+		op      string
+		wantErr bool
+	}{
+		{"api.get", "api", "", "get", false},
+		{"api.public.post", "api", "public", "post", false},
+		{"db.main.send", "db", "main", "send", false},
+		{"bad", "", "", "", true},
+		{"a.b.c.d", "", "", "", true},
+	}
+	for _, tt := range tests {
+		svc, iface, op, err := parseStepAction(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseStepAction(%q) should fail", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseStepAction(%q): %v", tt.input, err)
+			continue
+		}
+		if svc != tt.service || iface != tt.iface || op != tt.op {
+			t.Errorf("parseStepAction(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				tt.input, svc, iface, op, tt.service, tt.iface, tt.op)
+		}
+	}
+}
+
+func TestSleepStep(t *testing.T) {
+	topo := &config.TopologyConfig{
+		Services: map[string]config.ServiceConfig{},
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	dur := config.Duration{}
+	dur.Duration = 50 * 1e6 // 50ms
+	steps := []config.StepConfig{
+		{Sleep: &dur},
+	}
+
+	results, err := RunSteps(context.Background(), topo, steps, log)
+	if err != nil {
+		t.Fatalf("RunSteps: %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("expected success, got %+v", results)
+	}
+}
+
+// --- helpers ---
+
+func listenOnFreePort(t *testing.T) (net.Listener, int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln, ln.Addr().(*net.TCPAddr).Port
+}
+
+func listenTCPFreePort(t *testing.T) (*net.TCPListener, int) {
+	t.Helper()
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln, ln.Addr().(*net.TCPAddr).Port
+}

--- a/poc/example/faultbox.yaml
+++ b/poc/example/faultbox.yaml
@@ -3,16 +3,26 @@ version: "1"
 services:
   db:
     binary: /tmp/mock-db
-    port: 5432
-    env:
+    interfaces:
+      main:
+        protocol: tcp
+        port: 5432
+    environment:
       PORT: "5432"
-    ready: tcp://localhost:5432
+    healthcheck:
+      test: tcp://localhost:5432
+      timeout: 10s
 
   api:
     binary: /tmp/mock-api
-    port: 8080
-    env:
+    interfaces:
+      public:
+        protocol: http
+        port: 8080
+    environment:
       PORT: "8080"
-      DB_ADDR: "localhost:5432"
+      DB_ADDR: "{{db.main.addr}}"
     depends_on: [db]
-    ready: http://localhost:8080/health
+    healthcheck:
+      test: http://localhost:8080/health
+      timeout: 10s

--- a/poc/example/spec.yaml
+++ b/poc/example/spec.yaml
@@ -6,17 +6,65 @@ traces:
     description: "Normal operation — API and DB both healthy"
     faults: {}
     timeout: "15s"
+    steps:
+      - db.main.send:
+          data: "PING"
+          expect:
+            equals: "PONG"
+      - api.public.post:
+          path: /data/testkey
+          body: "hello"
+          expect:
+            status: 200
+            body_contains: "stored"
+      - api.public.get:
+          path: /data/testkey
+          expect:
+            status: 200
+            body_contains: "hello"
     assert:
       - exit_code:
           service: api
           equals: 0
 
   db-slow-response:
-    description: "DB response delayed — API should still work"
+    description: "DB response delayed — API should handle gracefully"
     faults:
       db:
-        - "write=delay:500ms:100%"
+        - syscall: write
+          action: delay
+          delay: 500ms
+          probability: "100%"
     timeout: "15s"
+    steps:
+      - api.public.post:
+          path: /data/slowkey
+          body: "value1"
+          expect:
+            status: 200
+      - api.public.get:
+          path: /data/slowkey
+          expect:
+            status: 200
+            body_contains: "value1"
+    assert:
+      - exit_code:
+          service: api
+          equals: 0
+
+  api-cannot-reach-db:
+    description: "API cannot connect to DB — returns 500"
+    faults:
+      api:
+        - "connect=ECONNREFUSED:100%"
+    timeout: "15s"
+    steps:
+      - api.public.post:
+          path: /data/failkey
+          body: "value1"
+          expect:
+            status: 500
+            body_contains: "db error"
     assert:
       - exit_code:
           service: api


### PR DESCRIPTION
## Summary
- Multi-interface service topology: services expose named interfaces (protocol + port)
- Active scenario driver (`steps`) with `service[.interface].operation` addressing
- Auto-injected `FAULTBOX_*` env vars + `{{template}}` resolution for service discovery
- HTTP and TCP step handlers with expect assertions (status, body_contains, body_equals)
- Object-form fault syntax alongside existing string form
- Backward compatibility with legacy topology format
- Fix: proper child process cleanup (SIGTERM/SIGKILL on context cancel)
- Fix: distinguish self-exited vs killed-by-us for exit code assertions

## Test plan
- [x] Config parsing tests (new format, legacy migration, validation errors)
- [x] Step executor tests (HTTP GET/POST, TCP send, sleep, expect failures)
- [x] Env resolution tests (auto-injection, template resolution)
- [x] All 3 example traces pass in Lima VM (happy-path, db-slow-response, api-cannot-reach-db)
- [x] No zombie processes after simulation (verified with ps/ss)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)