### PR TITLE
feat: Step 8 — Starlark runtime (single-file config and tests)

### DIFF
--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/faultbox/Faultbox/internal/engine"
 	"github.com/faultbox/Faultbox/internal/logging"
 	"github.com/faultbox/Faultbox/internal/seccomp"
+	"github.com/faultbox/Faultbox/internal/star"
 )
 
 func main() {
@@ -125,11 +126,14 @@ doneFlags:
 	return result.ExitCode
 }
 
-// testCmd handles: faultbox test --config faultbox.yaml --spec spec.yaml [--output results.json]
+// testCmd handles:
+//   faultbox test faultbox.star [--test name] [--output results.json]
+//   faultbox test --config faultbox.yaml --spec spec.yaml [--output results.json]
 func testCmd(args []string) int {
 	logFormat := logging.FormatAuto
 	logLevel := slog.LevelInfo
-	var configPath, specPath, outputPath string
+	var configPath, specPath, outputPath, testFilter string
+	var starFile string
 
 	for len(args) > 0 && len(args[0]) > 0 && args[0][0] == '-' {
 		switch {
@@ -154,6 +158,11 @@ func testCmd(args []string) int {
 		case args[0] == "--output" && len(args) > 1:
 			outputPath = args[1]
 			args = args[1:]
+		case strings.HasPrefix(args[0], "--test="):
+			testFilter = strings.TrimPrefix(args[0], "--test=")
+		case args[0] == "--test" && len(args) > 1:
+			testFilter = args[1]
+			args = args[1:]
 		default:
 			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[0])
 			return 1
@@ -161,16 +170,79 @@ func testCmd(args []string) int {
 		args = args[1:]
 	}
 
-	if configPath == "" {
-		fmt.Fprintln(os.Stderr, "error: --config is required")
-		return 1
+	// If positional arg is a .star file, use Starlark runtime.
+	if len(args) > 0 && strings.HasSuffix(args[0], ".star") {
+		starFile = args[0]
 	}
-	if specPath == "" {
-		fmt.Fprintln(os.Stderr, "error: --spec is required")
+
+	if starFile != "" {
+		return testStarCmd(starFile, testFilter, outputPath, logFormat, logLevel)
+	}
+
+	return testYAMLCmd(configPath, specPath, outputPath, logFormat, logLevel)
+}
+
+// testStarCmd runs tests from a .star file.
+func testStarCmd(starFile, testFilter, outputPath string, logFormat logging.Format, logLevel slog.Level) int {
+	logger := logging.New(logging.Config{Format: logFormat, Level: logLevel})
+	rt := star.New(logger)
+
+	if err := rt.LoadFile(starFile); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
 
-	// Load topology and spec.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	result, err := rt.RunAll(ctx, testFilter)
+	if err != nil {
+		logger.Error("test suite failed", slog.String("error", err.Error()))
+		return 1
+	}
+
+	// Write results if requested.
+	if outputPath != "" {
+		simResult := &engine.SimulationResult{
+			DurationMs: result.DurationMs,
+			Pass:       result.Pass,
+			Fail:       result.Fail,
+		}
+		for _, tr := range result.Tests {
+			simResult.Traces = append(simResult.Traces, engine.TraceResult{
+				Name:       tr.Name,
+				Result:     tr.Result,
+				Reason:     tr.Reason,
+				DurationMs: tr.DurationMs,
+			})
+		}
+		if err := engine.WriteResults(outputPath, simResult); err != nil {
+			logger.Error("failed to write results", slog.String("error", err.Error()))
+			return 1
+		}
+		logger.Info("results written", slog.String("path", outputPath))
+	}
+
+	// Print summary.
+	fmt.Fprintf(os.Stderr, "\n%d passed, %d failed\n", result.Pass, result.Fail)
+
+	if result.Fail > 0 {
+		return 2
+	}
+	return 0
+}
+
+// testYAMLCmd runs tests from YAML config + spec files (legacy path).
+func testYAMLCmd(configPath, specPath, outputPath string, logFormat logging.Format, logLevel slog.Level) int {
+	if configPath == "" {
+		fmt.Fprintln(os.Stderr, "error: --config is required (or pass a .star file)")
+		return 1
+	}
+	if specPath == "" {
+		fmt.Fprintln(os.Stderr, "error: --spec is required (or pass a .star file)")
+		return 1
+	}
+
 	topo, err := config.LoadTopology(configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -195,7 +267,6 @@ func testCmd(args []string) int {
 		return 1
 	}
 
-	// Write results file if requested.
 	if outputPath != "" {
 		if err := engine.WriteResults(outputPath, result); err != nil {
 			logger.Error("failed to write results", slog.String("error", err.Error()))
@@ -204,7 +275,6 @@ func testCmd(args []string) int {
 		logger.Info("results written", slog.String("path", outputPath))
 	}
 
-	// Exit code: 0 = all pass, 2 = some failures.
 	if result.Fail > 0 {
 		return 2
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/faultbox/Faultbox
 go 1.26.1
 
 require (
-	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	golang.org/x/sys v0.42.0
+	golang.org/x/term v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 )
+
+require go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,14 @@
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a h1:w7OMj6r/AoxBpbfncRXaV18hjzIAFRytYaRILymmMRE=
+go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -32,7 +32,7 @@ func New(logger *slog.Logger) *Engine {
 // Run creates a session and executes the target binary. It blocks until the
 // target exits or the context is cancelled.
 func (e *Engine) Run(ctx context.Context, cfg SessionConfig) (*Result, error) {
-	session, err := newSession(cfg, e.log)
+	session, err := NewSession(cfg, e.log)
 	if err != nil {
 		return nil, fmt.Errorf("create session: %w", err)
 	}
@@ -47,7 +47,7 @@ func (e *Engine) Run(ctx context.Context, cfg SessionConfig) (*Result, error) {
 		e.mu.Unlock()
 	}()
 
-	return session.run(ctx)
+	return session.Run(ctx)
 }
 
 // Status returns the current state of a session.

--- a/internal/engine/launch_linux.go
+++ b/internal/engine/launch_linux.go
@@ -287,8 +287,15 @@ func (s *Session) handleNotification(listenerFd int, req *seccomp.NotifReq, rule
 
 	decision := "allow"
 
+	// Merge static + dynamic fault rules for this syscall.
+	allRules := ruleMap[req.Data.Nr]
+	if dynRules := s.getDynamicRules(req.Data.Nr); len(dynRules) > 0 {
+		allRules = append(allRules, dynRules...)
+	}
+
 	// Check fault rules for this syscall.
-	if rules, ok := ruleMap[req.Data.Nr]; ok {
+	if len(allRules) > 0 {
+		rules := allRules
 		for _, rule := range rules {
 			// Path-based filtering for file syscalls.
 			if IsFileSyscall(syscallName) && path != "" {

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/faultbox/Faultbox/internal/seccomp"
 )
 
 // State represents the lifecycle of a session.
@@ -77,9 +79,13 @@ type Session struct {
 	log   *slog.Logger
 	state State
 	mu    sync.RWMutex
+
+	// Dynamic fault rules — can be modified while session is running.
+	dynamicRulesMu sync.RWMutex
+	dynamicRules   map[int32][]*FaultRule
 }
 
-func newSession(cfg SessionConfig, parentLog *slog.Logger) (*Session, error) {
+func NewSession(cfg SessionConfig, parentLog *slog.Logger) (*Session, error) {
 	id, err := generateID()
 	if err != nil {
 		return nil, fmt.Errorf("generate session ID: %w", err)
@@ -107,10 +113,43 @@ func (s *Session) setState(state State) {
 	s.log.Info("state changed", slog.String("state", string(state)))
 }
 
-// run launches the target via the unified shim path.
+// Run launches the target via the unified shim path.
 // Platform-specific implementation in launch_linux.go / launch_other.go.
-func (s *Session) run(ctx context.Context) (*Result, error) {
+func (s *Session) Run(ctx context.Context) (*Result, error) {
 	return s.launch(ctx)
+}
+
+// SetDynamicFaultRules replaces the dynamic fault rules for the session.
+// These rules are checked by the notification loop alongside static rules.
+func (s *Session) SetDynamicFaultRules(rules []FaultRule) {
+	s.dynamicRulesMu.Lock()
+	defer s.dynamicRulesMu.Unlock()
+	ruleMap := make(map[int32][]*FaultRule)
+	for i := range rules {
+		nr := seccomp.SyscallNumber(rules[i].Syscall)
+		if nr < 0 {
+			continue
+		}
+		ruleMap[nr] = append(ruleMap[nr], &rules[i])
+	}
+	s.dynamicRules = ruleMap
+}
+
+// ClearDynamicFaultRules removes all dynamic fault rules.
+func (s *Session) ClearDynamicFaultRules() {
+	s.dynamicRulesMu.Lock()
+	defer s.dynamicRulesMu.Unlock()
+	s.dynamicRules = nil
+}
+
+// getDynamicRules returns dynamic rules for a syscall number.
+func (s *Session) getDynamicRules(nr int32) []*FaultRule {
+	s.dynamicRulesMu.RLock()
+	defer s.dynamicRulesMu.RUnlock()
+	if s.dynamicRules == nil {
+		return nil
+	}
+	return s.dynamicRules[nr]
 }
 
 func generateID() (string, error) {

--- a/internal/engine/simulation.go
+++ b/internal/engine/simulation.go
@@ -182,7 +182,7 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 		}
 
 		svcLog := log.With(slog.String("service", svcName))
-		session, err := newSession(sessCfg, svcLog)
+		session, err := NewSession(sessCfg, svcLog)
 		if err != nil {
 			return nil, fmt.Errorf("create session for %q: %w", svcName, err)
 		}
@@ -190,7 +190,7 @@ func (e *Engine) runTrace(ctx context.Context, topo *config.TopologyConfig, name
 		svcCtx, svcCancel := context.WithCancel(traceCtx)
 		done := make(chan *Result, 1)
 		go func() {
-			r, _ := session.run(svcCtx)
+			r, _ := session.Run(svcCtx)
 			done <- r
 		}()
 

--- a/internal/engine/step.go
+++ b/internal/engine/step.go
@@ -104,9 +104,9 @@ func runActionStep(ctx context.Context, topo *config.TopologyConfig, step config
 
 	switch protocol {
 	case "http":
-		return runHTTPStep(ctx, addr, operation, step.Args)
+		return RunHTTPStep(ctx, addr, operation, step.Args)
 	case "tcp":
-		return runTCPStep(ctx, addr, operation, step.Args)
+		return RunTCPStep(ctx, addr, operation, step.Args)
 	default:
 		return StepResult{}, fmt.Errorf("unsupported protocol %q for step %s", protocol, step.Action)
 	}
@@ -129,7 +129,7 @@ func parseStepAction(action string) (service, iface, operation string, err error
 // HTTP step handler
 // ---------------------------------------------------------------------------
 
-func runHTTPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
+func RunHTTPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
 	method := strings.ToUpper(operation)
 	switch method {
 	case "GET", "POST", "PUT", "DELETE", "PATCH":
@@ -216,7 +216,7 @@ func checkHTTPExpect(expect map[string]any, status int, body string) error {
 // TCP step handler
 // ---------------------------------------------------------------------------
 
-func runTCPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
+func RunTCPStep(ctx context.Context, addr, operation string, args map[string]any) (StepResult, error) {
 	switch operation {
 	case "send":
 	default:

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -1,0 +1,340 @@
+package star
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+// builtins returns all Starlark built-in functions for a runtime.
+func (rt *Runtime) builtins() starlark.StringDict {
+	return starlark.StringDict{
+		"service":     starlark.NewBuiltin("service", rt.builtinService),
+		"interface":   starlark.NewBuiltin("interface", builtinInterface),
+		"tcp":         starlark.NewBuiltin("tcp", builtinTCP),
+		"http":        starlark.NewBuiltin("http", builtinHTTP),
+		"delay":       starlark.NewBuiltin("delay", builtinDelay),
+		"deny":        starlark.NewBuiltin("deny", builtinDeny),
+		"allow":       starlark.NewBuiltin("allow", builtinAllow),
+		"fault":       starlark.NewBuiltin("fault", rt.builtinFault),
+		"fault_start": starlark.NewBuiltin("fault_start", rt.builtinFaultStart),
+		"fault_stop":  starlark.NewBuiltin("fault_stop", rt.builtinFaultStop),
+		"assert_true": starlark.NewBuiltin("assert_true", builtinAssertTrue),
+		"assert_eq":   starlark.NewBuiltin("assert_eq", builtinAssertEq),
+	}
+}
+
+// service(name, binary, *interfaces, healthcheck=, env=, depends_on=, spec=)
+func (rt *Runtime) builtinService(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("service() requires at least name and binary")
+	}
+
+	name, ok := starlark.AsString(args[0])
+	if !ok {
+		return nil, fmt.Errorf("service() name must be a string")
+	}
+	binary, ok := starlark.AsString(args[1])
+	if !ok {
+		return nil, fmt.Errorf("service() binary must be a string")
+	}
+
+	svc := &ServiceDef{
+		Name:       name,
+		Binary:     binary,
+		Interfaces: make(map[string]*InterfaceDef),
+		Env:        make(map[string]string),
+	}
+
+	// Positional args after name and binary are interfaces.
+	for i := 2; i < len(args); i++ {
+		iface, ok := args[i].(*InterfaceDef)
+		if !ok {
+			return nil, fmt.Errorf("service() positional arg %d must be an interface(), got %s", i, args[i].Type())
+		}
+		svc.Interfaces[iface.Name] = iface
+	}
+
+	// Keyword args.
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		switch key {
+		case "healthcheck":
+			hc, ok := kv[1].(*HealthcheckDef)
+			if !ok {
+				return nil, fmt.Errorf("service() healthcheck must be a tcp() or http() value")
+			}
+			svc.Healthcheck = hc
+		case "env":
+			dict, ok := kv[1].(*starlark.Dict)
+			if !ok {
+				return nil, fmt.Errorf("service() env must be a dict")
+			}
+			for _, item := range dict.Items() {
+				k, _ := starlark.AsString(item[0])
+				v, _ := starlark.AsString(item[1])
+				svc.Env[k] = v
+			}
+		case "depends_on":
+			list, ok := kv[1].(*starlark.List)
+			if !ok {
+				return nil, fmt.Errorf("service() depends_on must be a list")
+			}
+			iter := list.Iterate()
+			defer iter.Done()
+			var val starlark.Value
+			for iter.Next(&val) {
+				switch dep := val.(type) {
+				case *ServiceDef:
+					svc.DependsOn = append(svc.DependsOn, dep.Name)
+				case starlark.String:
+					svc.DependsOn = append(svc.DependsOn, string(dep))
+				default:
+					return nil, fmt.Errorf("depends_on items must be services or strings, got %s", val.Type())
+				}
+			}
+		}
+	}
+
+	rt.registerService(svc)
+	return svc, nil
+}
+
+// interface(name, protocol, port, spec=)
+func builtinInterface(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name, protocol string
+	var port int
+	if err := starlark.UnpackPositionalArgs("interface", args, kwargs, 3, &name, &protocol, &port); err != nil {
+		// Try with kwargs for spec.
+		if err := starlark.UnpackArgs("interface", args, kwargs, "name", &name, "protocol", &protocol, "port", &port); err != nil {
+			return nil, err
+		}
+	}
+
+	iface := &InterfaceDef{
+		Name:     name,
+		Protocol: protocol,
+		Port:     port,
+	}
+
+	if spec, ok := starKwarg(kwargs, "spec"); ok {
+		s, _ := starlark.AsString(spec)
+		iface.Spec = s
+	}
+
+	return iface, nil
+}
+
+// tcp(addr, timeout=)
+func builtinTCP(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var addr string
+	if err := starlark.UnpackPositionalArgs("tcp", args, nil, 1, &addr); err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(addr, "tcp://") {
+		addr = "tcp://" + addr
+	}
+	timeout := 10 * time.Second
+	if ts, ok := starKwarg(kwargs, "timeout"); ok {
+		s, _ := starlark.AsString(ts)
+		d, err := parseStarDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("tcp() bad timeout: %w", err)
+		}
+		timeout = d
+	}
+	return &HealthcheckDef{Test: addr, Timeout: timeout}, nil
+}
+
+// http(url, timeout=)
+func builtinHTTP(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var url string
+	if err := starlark.UnpackPositionalArgs("http", args, nil, 1, &url); err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		url = "http://" + url
+	}
+	timeout := 10 * time.Second
+	if ts, ok := starKwarg(kwargs, "timeout"); ok {
+		s, _ := starlark.AsString(ts)
+		d, err := parseStarDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("http() bad timeout: %w", err)
+		}
+		timeout = d
+	}
+	return &HealthcheckDef{Test: url, Timeout: timeout}, nil
+}
+
+// delay(duration, probability=)
+func builtinDelay(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var durStr string
+	if err := starlark.UnpackPositionalArgs("delay", args, nil, 1, &durStr); err != nil {
+		return nil, err
+	}
+	dur, err := parseStarDuration(durStr)
+	if err != nil {
+		return nil, fmt.Errorf("delay() bad duration %q: %w", durStr, err)
+	}
+	prob := 1.0
+	if ps, ok := starKwarg(kwargs, "probability"); ok {
+		s, _ := starlark.AsString(ps)
+		s = strings.TrimSuffix(s, "%")
+		fmt.Sscanf(s, "%f", &prob)
+		if prob > 1 {
+			prob /= 100.0
+		}
+	}
+	return &FaultDef{Action: "delay", Delay: dur, Probability: prob}, nil
+}
+
+// deny(errno, probability=)
+func builtinDeny(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var errno string
+	if err := starlark.UnpackPositionalArgs("deny", args, nil, 1, &errno); err != nil {
+		return nil, err
+	}
+	prob := 1.0
+	if ps, ok := starKwarg(kwargs, "probability"); ok {
+		s, _ := starlark.AsString(ps)
+		s = strings.TrimSuffix(s, "%")
+		fmt.Sscanf(s, "%f", &prob)
+		if prob > 1 {
+			prob /= 100.0
+		}
+	}
+	return &FaultDef{Action: "deny", Errno: strings.ToUpper(errno), Probability: prob}, nil
+}
+
+// allow()
+func builtinAllow(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return &FaultDef{Action: "allow"}, nil
+}
+
+// fault(service, run=body_fn, **syscall_faults)
+// Example: fault(db, write=delay("500ms"), run=my_func)
+func (rt *Runtime) builtinFault(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("fault() requires a service argument")
+	}
+	svc, ok := args[0].(*ServiceDef)
+	if !ok {
+		return nil, fmt.Errorf("fault() first arg must be a service, got %s", args[0].Type())
+	}
+
+	// Extract run= callback and fault specs from kwargs.
+	var bodyFn starlark.Callable
+	faults := make(map[string]*FaultDef)
+
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		if key == "run" {
+			cb, ok := kv[1].(starlark.Callable)
+			if !ok {
+				return nil, fmt.Errorf("fault() run= must be a callable")
+			}
+			bodyFn = cb
+		} else {
+			fd, ok := kv[1].(*FaultDef)
+			if !ok {
+				return nil, fmt.Errorf("fault() %s= must be a fault (delay/deny), got %s", key, kv[1].Type())
+			}
+			faults[key] = fd
+		}
+	}
+
+	if bodyFn == nil {
+		return nil, fmt.Errorf("fault() requires run= keyword with a callback function")
+	}
+
+	// Apply faults, run body, remove faults.
+	if err := rt.applyFaults(svc.Name, faults); err != nil {
+		return nil, fmt.Errorf("fault(): %w", err)
+	}
+	defer rt.removeFaults(svc.Name)
+
+	result, err := starlark.Call(thread, bodyFn, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return starlark.None, nil
+	}
+	return result, nil
+}
+
+// fault_start(service, **syscall_faults)
+func (rt *Runtime) builtinFaultStart(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("fault_start() requires a service argument")
+	}
+	svc, ok := args[0].(*ServiceDef)
+	if !ok {
+		return nil, fmt.Errorf("fault_start() first arg must be a service, got %s", args[0].Type())
+	}
+
+	faults := make(map[string]*FaultDef)
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		fd, ok := kv[1].(*FaultDef)
+		if !ok {
+			return nil, fmt.Errorf("fault_start() %s= must be a fault, got %s", key, kv[1].Type())
+		}
+		faults[key] = fd
+	}
+
+	if err := rt.applyFaults(svc.Name, faults); err != nil {
+		return nil, err
+	}
+	return starlark.None, nil
+}
+
+// fault_stop(service)
+func (rt *Runtime) builtinFaultStop(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("fault_stop() requires a service argument")
+	}
+	svc, ok := args[0].(*ServiceDef)
+	if !ok {
+		return nil, fmt.Errorf("fault_stop() first arg must be a service, got %s", args[0].Type())
+	}
+	rt.removeFaults(svc.Name)
+	return starlark.None, nil
+}
+
+// assert_true(condition, msg=)
+func builtinAssertTrue(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("assert_true() requires a condition")
+	}
+	if !args[0].Truth() {
+		msg := "assertion failed"
+		if len(args) > 1 {
+			msg, _ = starlark.AsString(args[1])
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+	return starlark.None, nil
+}
+
+// assert_eq(a, b, msg=)
+func builtinAssertEq(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("assert_eq() requires two arguments")
+	}
+	eq, err := starlark.Equal(args[0], args[1])
+	if err != nil {
+		return nil, err
+	}
+	if !eq {
+		msg := fmt.Sprintf("assert_eq failed: %s != %s", args[0], args[1])
+		if len(args) > 2 {
+			msg, _ = starlark.AsString(args[2])
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+	return starlark.None, nil
+}

--- a/internal/star/events.go
+++ b/internal/star/events.go
@@ -1,0 +1,57 @@
+package star
+
+import (
+	"sync"
+	"time"
+)
+
+// Event is a single entry in the event log.
+type Event struct {
+	Seq       int64             `json:"seq"`
+	Timestamp time.Time         `json:"timestamp"`
+	Type      string            `json:"type"`
+	Service   string            `json:"service,omitempty"`
+	Fields    map[string]string `json:"fields,omitempty"`
+}
+
+// EventLog is a thread-safe, append-only ordered event log.
+type EventLog struct {
+	mu     sync.RWMutex
+	events []Event
+	seq    int64
+}
+
+// NewEventLog creates a new empty event log.
+func NewEventLog() *EventLog {
+	return &EventLog{}
+}
+
+// Emit appends an event to the log.
+func (l *EventLog) Emit(typ, service string, fields map[string]string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.seq++
+	l.events = append(l.events, Event{
+		Seq:       l.seq,
+		Timestamp: time.Now(),
+		Type:      typ,
+		Service:   service,
+		Fields:    fields,
+	})
+}
+
+// Events returns a snapshot of all events.
+func (l *EventLog) Events() []Event {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	out := make([]Event, len(l.events))
+	copy(out, l.events)
+	return out
+}
+
+// Len returns the number of events.
+func (l *EventLog) Len() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.events)
+}

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1,0 +1,571 @@
+package star
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/config"
+	"github.com/faultbox/Faultbox/internal/engine"
+	"github.com/faultbox/Faultbox/internal/logging"
+)
+
+// TestResult captures the outcome of one test function.
+type TestResult struct {
+	Name       string `json:"name"`
+	Result     string `json:"result"` // "pass" or "fail"
+	Reason     string `json:"reason,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+}
+
+// SuiteResult captures the outcome of all test functions.
+type SuiteResult struct {
+	DurationMs int64        `json:"duration_ms"`
+	Tests      []TestResult `json:"tests"`
+	Pass       int          `json:"pass"`
+	Fail       int          `json:"fail"`
+}
+
+// Runtime is the Starlark execution environment.
+type Runtime struct {
+	log      *slog.Logger
+	events   *EventLog
+	eng      *engine.Engine
+
+	// Service registry — populated during .star file load.
+	mu       sync.Mutex
+	services map[string]*ServiceDef
+	order    []string // dependency order
+
+	// Running sessions — populated during test execution.
+	sessions map[string]*runningSession
+
+	// Active faults per service — modified by fault_start/fault_stop.
+	faultsMu sync.Mutex
+	faults   map[string]map[string]*FaultDef // service -> syscall -> fault
+
+	// Starlark globals — test functions discovered after load.
+	globals starlark.StringDict
+}
+
+type runningSession struct {
+	session *engine.Session
+	cancel  context.CancelFunc
+	done    chan *engine.Result
+}
+
+// New creates a new Starlark runtime.
+func New(logger *slog.Logger) *Runtime {
+	return &Runtime{
+		log:      logging.WithComponent(logger, "starlark"),
+		events:   NewEventLog(),
+		eng:      engine.New(logger),
+		services: make(map[string]*ServiceDef),
+		sessions: make(map[string]*runningSession),
+		faults:   make(map[string]map[string]*FaultDef),
+	}
+}
+
+// LoadFile executes a .star file, populating the service registry and
+// discovering test_* functions.
+func (rt *Runtime) LoadFile(path string) error {
+	thread := &starlark.Thread{Name: "load"}
+
+	globals, err := starlark.ExecFile(thread, path, nil, rt.builtins())
+	if err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+
+	rt.globals = globals
+	return nil
+}
+
+// LoadString executes Starlark source from a string (for testing).
+func (rt *Runtime) LoadString(name, src string) error {
+	thread := &starlark.Thread{Name: "load"}
+	globals, err := starlark.ExecFile(thread, name, src, rt.builtins())
+	if err != nil {
+		return fmt.Errorf("load: %w", err)
+	}
+	rt.globals = globals
+	return nil
+}
+
+// DiscoverTests returns sorted test function names (test_* globals).
+func (rt *Runtime) DiscoverTests() []string {
+	var names []string
+	for name, val := range rt.globals {
+		if strings.HasPrefix(name, "test_") {
+			if _, ok := val.(starlark.Callable); ok {
+				names = append(names, name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Services returns the registered services in dependency order.
+func (rt *Runtime) Services() []*ServiceDef {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	result := make([]*ServiceDef, 0, len(rt.order))
+	for _, name := range rt.order {
+		result = append(result, rt.services[name])
+	}
+	return result
+}
+
+// RunAll executes all (or filtered) test functions.
+func (rt *Runtime) RunAll(ctx context.Context, filter string) (*SuiteResult, error) {
+	start := time.Now()
+	tests := rt.DiscoverTests()
+
+	suite := &SuiteResult{
+		Tests: make([]TestResult, 0, len(tests)),
+	}
+
+	for _, name := range tests {
+		if filter != "" && name != "test_"+filter && name != filter {
+			continue
+		}
+
+		rt.log.Info("running test", slog.String("test", name))
+		tr := rt.RunTest(ctx, name)
+		suite.Tests = append(suite.Tests, tr)
+		if tr.Result == "pass" {
+			suite.Pass++
+		} else {
+			suite.Fail++
+		}
+		rt.log.Info("test completed",
+			slog.String("test", name),
+			slog.String("result", tr.Result),
+			slog.Int64("duration_ms", tr.DurationMs),
+		)
+	}
+
+	suite.DurationMs = time.Since(start).Milliseconds()
+	return suite, nil
+}
+
+// RunTest executes a single test function with fresh services.
+func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
+	start := time.Now()
+
+	fn, ok := rt.globals[name].(starlark.Callable)
+	if !ok {
+		return TestResult{
+			Name: name, Result: "fail",
+			Reason:     fmt.Sprintf("test %q not found or not callable", name),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	// Wait for ports to be free.
+	rt.waitPortsFree(10 * time.Second)
+
+	// Start services.
+	testCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := rt.startServices(testCtx); err != nil {
+		rt.stopServices()
+		return TestResult{
+			Name: name, Result: "fail",
+			Reason:     fmt.Sprintf("failed to start services: %v", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	// Run the test function.
+	thread := &starlark.Thread{Name: name}
+	_, err := starlark.Call(thread, fn, nil, nil)
+
+	// Stop services.
+	rt.stopServices()
+
+	if err != nil {
+		return TestResult{
+			Name: name, Result: "fail",
+			Reason:     err.Error(),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+
+	return TestResult{
+		Name: name, Result: "pass",
+		DurationMs: time.Since(start).Milliseconds(),
+	}
+}
+
+// registerService adds a service to the registry.
+func (rt *Runtime) registerService(svc *ServiceDef) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	svc.rt = rt
+	rt.services[svc.Name] = svc
+	// Rebuild dependency order.
+	rt.order = rt.dependencyOrder()
+}
+
+// dependencyOrder returns service names in topological order.
+func (rt *Runtime) dependencyOrder() []string {
+	cfgServices := make(map[string]config.ServiceConfig)
+	for name, svc := range rt.services {
+		cfgServices[name] = config.ServiceConfig{
+			DependsOn: svc.DependsOn,
+		}
+	}
+	order, err := config.DependencyOrder(cfgServices)
+	if err != nil {
+		// Fall back to insertion order on error.
+		var names []string
+		for name := range rt.services {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return names
+	}
+	return order
+}
+
+// startServices starts all registered services in dependency order.
+func (rt *Runtime) startServices(ctx context.Context) error {
+	rt.mu.Lock()
+	order := make([]string, len(rt.order))
+	copy(order, rt.order)
+	rt.mu.Unlock()
+
+	for _, svcName := range order {
+		svc := rt.services[svcName]
+
+		// Build env vars with auto-injection.
+		envVars := rt.buildEnv(svc)
+
+		// Collect all faultable syscalls for pre-installed seccomp filter.
+		var faultRules []engine.FaultRule
+		faultRules = append(faultRules, rt.preinstallRules()...)
+
+		ns := engine.NamespaceConfig{
+			PID:   true,
+			Mount: true,
+			User:  true,
+		}
+
+		sessCfg := engine.SessionConfig{
+			Binary:     svc.Binary,
+			Args:       nil,
+			Env:        envVars,
+			Stdout:     os.Stdout,
+			Stderr:     os.Stderr,
+			Namespaces: ns,
+			FaultRules: faultRules,
+		}
+
+		svcLog := rt.log.With(slog.String("service", svcName))
+		session, err := engine.NewSession(sessCfg, svcLog)
+		if err != nil {
+			return fmt.Errorf("create session for %q: %w", svcName, err)
+		}
+
+		svcCtx, svcCancel := context.WithCancel(ctx)
+		done := make(chan *engine.Result, 1)
+		go func() {
+			r, _ := session.Run(svcCtx)
+			done <- r
+		}()
+
+		rt.sessions[svcName] = &runningSession{
+			session: session,
+			cancel:  svcCancel,
+			done:    done,
+		}
+
+		rt.events.Emit("service_started", svcName, nil)
+
+		// Bind InterfaceRef.runtime for step execution.
+		for _, iface := range svc.Interfaces {
+			// Ensure InterfaceRefs have runtime pointer.
+			_ = iface // bindings happen through Attr calls
+		}
+
+		// Wait for healthcheck.
+		if svc.Healthcheck != nil {
+			timeout := svc.Healthcheck.Timeout
+			if timeout <= 0 {
+				timeout = 10 * time.Second
+			}
+			if err := waitReady(ctx, svc.Healthcheck.Test, timeout); err != nil {
+				return fmt.Errorf("service %q not ready: %w", svcName, err)
+			}
+			rt.events.Emit("service_ready", svcName, nil)
+			svcLog.Info("service ready", slog.String("check", svc.Healthcheck.Test))
+		}
+	}
+	return nil
+}
+
+// stopServices stops all running services.
+func (rt *Runtime) stopServices() {
+	for _, rs := range rt.sessions {
+		rs.cancel()
+	}
+	for _, rs := range rt.sessions {
+		select {
+		case <-rs.done:
+		case <-time.After(5 * time.Second):
+		}
+	}
+	rt.sessions = make(map[string]*runningSession)
+
+	// Clear active faults.
+	rt.faultsMu.Lock()
+	rt.faults = make(map[string]map[string]*FaultDef)
+	rt.faultsMu.Unlock()
+}
+
+// buildEnv creates the environment for a service with auto-injection.
+func (rt *Runtime) buildEnv(svc *ServiceDef) []string {
+	env := make(map[string]string)
+
+	// Auto-inject FAULTBOX_* vars for all services.
+	for name, s := range rt.services {
+		upper := strings.ToUpper(name)
+		for ifName, iface := range s.Interfaces {
+			ifUpper := strings.ToUpper(ifName)
+			prefix := fmt.Sprintf("FAULTBOX_%s_%s", upper, ifUpper)
+			env[prefix+"_HOST"] = "localhost"
+			env[prefix+"_PORT"] = fmt.Sprintf("%d", iface.Port)
+			env[prefix+"_ADDR"] = fmt.Sprintf("localhost:%d", iface.Port)
+		}
+	}
+
+	// User-defined env (templates already resolved in Starlark via .addr).
+	for k, v := range svc.Env {
+		env[k] = v
+	}
+
+	result := make([]string, 0, len(env))
+	for k, v := range env {
+		result = append(result, k+"="+v)
+	}
+	return result
+}
+
+// preinstallRules returns empty fault rules for common syscalls so the seccomp
+// filter is pre-installed. Actual faults are applied dynamically.
+func (rt *Runtime) preinstallRules() []engine.FaultRule {
+	// Pre-install filter for common faultable syscalls.
+	// Rules with Probability=0 will never fire but ensure the syscall is intercepted.
+	syscalls := []string{"write", "read", "connect", "openat", "fsync", "sendto", "recvfrom", "writev"}
+	var rules []engine.FaultRule
+	for _, sc := range syscalls {
+		rules = append(rules, engine.FaultRule{
+			Syscall:     sc,
+			Action:      engine.ActionDeny,
+			Probability: 0, // never fires — just pre-installs the seccomp filter
+		})
+	}
+	return rules
+}
+
+// applyFaults sets fault rules for a service's running session.
+func (rt *Runtime) applyFaults(svcName string, faults map[string]*FaultDef) error {
+	rt.faultsMu.Lock()
+	rt.faults[svcName] = faults
+	rt.faultsMu.Unlock()
+
+	// Convert to engine.FaultRule and inject into running session.
+	rs, ok := rt.sessions[svcName]
+	if !ok {
+		return fmt.Errorf("service %q is not running", svcName)
+	}
+
+	var rules []engine.FaultRule
+	for syscall, fd := range faults {
+		rule := engine.FaultRule{
+			Syscall:     syscall,
+			Probability: fd.Probability,
+		}
+		switch fd.Action {
+		case "delay":
+			rule.Action = engine.ActionDelay
+			rule.Delay = fd.Delay
+		case "deny":
+			rule.Action = engine.ActionDeny
+			parsed, err := engine.ParseFaultRule(syscall + "=" + fd.Errno + ":100%")
+			if err == nil {
+				rule.Errno = parsed.Errno
+			}
+		}
+		rules = append(rules, rule)
+	}
+
+	rs.session.SetDynamicFaultRules(rules)
+	rt.events.Emit("fault_applied", svcName, nil)
+	return nil
+}
+
+// removeFaults clears fault rules for a service.
+func (rt *Runtime) removeFaults(svcName string) {
+	rt.faultsMu.Lock()
+	delete(rt.faults, svcName)
+	rt.faultsMu.Unlock()
+
+	if rs, ok := rt.sessions[svcName]; ok {
+		rs.session.ClearDynamicFaultRules()
+	}
+	rt.events.Emit("fault_removed", svcName, nil)
+}
+
+// executeStep runs an HTTP or TCP step against a running service.
+func (rt *Runtime) executeStep(thread *starlark.Thread, ref *InterfaceRef, method string, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	addr := fmt.Sprintf("localhost:%d", ref.Interface.Port)
+
+	switch ref.Interface.Protocol {
+	case "http":
+		return rt.executeHTTPStep(addr, method, kwargs)
+	case "tcp":
+		return rt.executeTCPStep(addr, method, kwargs)
+	default:
+		return nil, fmt.Errorf("unsupported protocol %q", ref.Interface.Protocol)
+	}
+}
+
+func (rt *Runtime) executeHTTPStep(addr, method string, kwargs []starlark.Tuple) (starlark.Value, error) {
+	stepArgs := make(map[string]any)
+	stepArgs["path"] = "/"
+
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		switch key {
+		case "path":
+			s, _ := starlark.AsString(kv[1])
+			stepArgs["path"] = s
+		case "body":
+			s, _ := starlark.AsString(kv[1])
+			stepArgs["body"] = s
+		case "headers":
+			dict, ok := kv[1].(*starlark.Dict)
+			if ok {
+				headers := make(map[string]any)
+				for _, item := range dict.Items() {
+					k, _ := starlark.AsString(item[0])
+					v, _ := starlark.AsString(item[1])
+					headers[k] = v
+				}
+				stepArgs["headers"] = headers
+			}
+		}
+	}
+
+	result, err := engine.RunHTTPStep(context.Background(), addr, strings.ToUpper(method), stepArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		Status:     result.StatusCode,
+		Body:       result.Body,
+		DurationMs: result.DurationMs,
+		Ok:         result.Success,
+		Error:      result.Error,
+	}, nil
+}
+
+func (rt *Runtime) executeTCPStep(addr, method string, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if method != "send" {
+		return nil, fmt.Errorf("TCP only supports 'send', got %q", method)
+	}
+
+	stepArgs := make(map[string]any)
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		switch key {
+		case "data":
+			s, _ := starlark.AsString(kv[1])
+			stepArgs["data"] = s
+		}
+	}
+
+	result, err := engine.RunTCPStep(context.Background(), addr, "send", stepArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// For TCP send, return the response body as a string (simpler API).
+	if result.Success {
+		return starlark.String(result.Body), nil
+	}
+	return nil, fmt.Errorf("tcp send failed: %s", result.Error)
+}
+
+// waitReady polls a readiness check.
+func waitReady(ctx context.Context, check string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if strings.HasPrefix(check, "tcp://") {
+			addr := strings.TrimPrefix(check, "tcp://")
+			conn, err := net.DialTimeout("tcp", addr, time.Second)
+			if err == nil {
+				conn.Close()
+				return nil
+			}
+		} else if strings.HasPrefix(check, "http://") || strings.HasPrefix(check, "https://") {
+			client := &http.Client{Timeout: time.Second}
+			resp, err := client.Get(check)
+			if err == nil {
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+					return nil
+				}
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("readiness check %q timed out after %s", check, timeout)
+}
+
+// waitPortsFree waits for service ports to be available.
+func (rt *Runtime) waitPortsFree(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		allFree := true
+		for _, svc := range rt.services {
+			for _, iface := range svc.Interfaces {
+				conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", iface.Port), 100*time.Millisecond)
+				if err == nil {
+					conn.Close()
+					allFree = false
+					break
+				}
+			}
+			if !allFree {
+				break
+			}
+		}
+		if allFree {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/star/runtime_test.go
+++ b/internal/star/runtime_test.go
@@ -1,0 +1,198 @@
+package star
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func TestLoadAndDiscoverTests(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+api = service("api", "/tmp/mock-api",
+    interface("public", "http", 8080),
+    depends_on = [db],
+)
+
+def test_happy():
+    pass
+
+def test_slow():
+    pass
+
+def helper_func():
+    pass
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	tests := rt.DiscoverTests()
+	if len(tests) != 2 {
+		t.Fatalf("expected 2 tests, got %d: %v", len(tests), tests)
+	}
+	if tests[0] != "test_happy" || tests[1] != "test_slow" {
+		t.Fatalf("unexpected test names: %v", tests)
+	}
+}
+
+func TestServiceRegistration(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    env = {"PORT": "5432"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api", "/tmp/mock-api",
+    interface("public", "http", 8080),
+    interface("internal", "grpc", 9090),
+    env = {"PORT": "8080", "DB_ADDR": db.main.addr},
+    depends_on = [db],
+    healthcheck = http("localhost:8080/health"),
+)
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	services := rt.Services()
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(services))
+	}
+
+	// db should come first (dependency order).
+	if services[0].Name != "db" {
+		t.Fatalf("expected db first, got %s", services[0].Name)
+	}
+
+	db := services[0]
+	if db.Binary != "/tmp/mock-db" {
+		t.Fatalf("db.Binary = %q", db.Binary)
+	}
+	if db.Interfaces["main"].Protocol != "tcp" {
+		t.Fatalf("db.main.Protocol = %q", db.Interfaces["main"].Protocol)
+	}
+	if db.Healthcheck == nil || db.Healthcheck.Test != "tcp://localhost:5432" {
+		t.Fatalf("db.Healthcheck = %v", db.Healthcheck)
+	}
+
+	api := services[1]
+	if len(api.Interfaces) != 2 {
+		t.Fatalf("api should have 2 interfaces, got %d", len(api.Interfaces))
+	}
+	if api.Env["DB_ADDR"] != "localhost:5432" {
+		t.Fatalf("api.Env[DB_ADDR] = %q, want localhost:5432", api.Env["DB_ADDR"])
+	}
+	if len(api.DependsOn) != 1 || api.DependsOn[0] != "db" {
+		t.Fatalf("api.DependsOn = %v", api.DependsOn)
+	}
+}
+
+func TestInterfaceAddrAccess(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+addr = db.main.addr
+port = db.main.port
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	// Check that db.main.addr resolved correctly.
+	addr := rt.globals["addr"]
+	if addr.String() != `"localhost:5432"` {
+		t.Fatalf("addr = %s, want localhost:5432", addr)
+	}
+	port := rt.globals["port"]
+	if port.String() != "5432" {
+		t.Fatalf("port = %s, want 5432", port)
+	}
+}
+
+func TestFaultBuiltins(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+d = delay("500ms")
+dn = deny("ECONNREFUSED", probability="50%")
+a = allow()
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	d := rt.globals["d"].(*FaultDef)
+	if d.Action != "delay" || d.Delay.Milliseconds() != 500 {
+		t.Fatalf("delay = %+v", d)
+	}
+
+	dn := rt.globals["dn"].(*FaultDef)
+	if dn.Action != "deny" || dn.Errno != "ECONNREFUSED" || dn.Probability != 0.5 {
+		t.Fatalf("deny = %+v", dn)
+	}
+
+	a := rt.globals["a"].(*FaultDef)
+	if a.Action != "allow" {
+		t.Fatalf("allow = %+v", a)
+	}
+}
+
+func TestAssertBuiltins(t *testing.T) {
+	rt := New(testLogger())
+
+	// assert_true passing.
+	err := rt.LoadString("test.star", `assert_true(1 == 1)`)
+	if err != nil {
+		t.Fatalf("assert_true(true): %v", err)
+	}
+
+	// assert_true failing.
+	err = rt.LoadString("test.star", `assert_true(1 == 2, "one != two")`)
+	if err == nil {
+		t.Fatal("expected assert_true to fail")
+	}
+
+	// assert_eq passing.
+	err = rt.LoadString("test.star", `assert_eq(42, 42)`)
+	if err != nil {
+		t.Fatalf("assert_eq(42, 42): %v", err)
+	}
+
+	// assert_eq failing.
+	err = rt.LoadString("test.star", `assert_eq(1, 2)`)
+	if err == nil {
+		t.Fatal("expected assert_eq to fail")
+	}
+}
+
+func TestEventLog(t *testing.T) {
+	log := NewEventLog()
+	log.Emit("test_event", "svc1", map[string]string{"key": "val"})
+	log.Emit("test_event2", "svc2", nil)
+
+	events := log.Events()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != "test_event" || events[0].Service != "svc1" {
+		t.Fatalf("event[0] = %+v", events[0])
+	}
+	if events[0].Fields["key"] != "val" {
+		t.Fatalf("event[0].Fields = %v", events[0].Fields)
+	}
+	if events[1].Seq != 2 {
+		t.Fatalf("event[1].Seq = %d, want 2", events[1].Seq)
+	}
+}

--- a/internal/star/types.go
+++ b/internal/star/types.go
@@ -1,0 +1,297 @@
+// Package star provides a Starlark runtime for Faultbox configuration and tests.
+package star
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+// ---------------------------------------------------------------------------
+// ServiceDef — returned by service() builtin, used in Starlark scripts
+// ---------------------------------------------------------------------------
+
+// ServiceDef is the Starlark representation of a service declaration.
+type ServiceDef struct {
+	Name       string
+	Binary     string
+	Interfaces map[string]*InterfaceDef
+	Env        map[string]string
+	DependsOn  []string
+	Healthcheck *HealthcheckDef
+	rt         *Runtime // set by runtime after registration
+}
+
+var _ starlark.Value = (*ServiceDef)(nil)
+var _ starlark.HasAttrs = (*ServiceDef)(nil)
+
+func (s *ServiceDef) String() string        { return fmt.Sprintf("<service %s>", s.Name) }
+func (s *ServiceDef) Type() string           { return "service" }
+func (s *ServiceDef) Freeze()                {}
+func (s *ServiceDef) Truth() starlark.Bool   { return true }
+func (s *ServiceDef) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: service") }
+
+func (s *ServiceDef) Attr(name string) (starlark.Value, error) {
+	// Direct interface access: service.main, service.public, etc.
+	if iface, ok := s.Interfaces[name]; ok {
+		return &InterfaceRef{Service: s, Interface: iface, runtime: s.rt}, nil
+	}
+	switch name {
+	case "name":
+		return starlark.String(s.Name), nil
+	case "get", "post", "put", "delete", "patch", "send":
+		// Shorthand: api.post(...) when service has a single interface.
+		iface, err := s.DefaultInterface()
+		if err != nil {
+			return nil, err
+		}
+		ref := &InterfaceRef{Service: s, Interface: iface, runtime: s.rt}
+		return &StepMethod{Ref: ref, Method: name}, nil
+	}
+	return nil, starlark.NoSuchAttrError(fmt.Sprintf("service has no .%s attribute", name))
+}
+
+func (s *ServiceDef) AttrNames() []string {
+	names := []string{"name"}
+	for k := range s.Interfaces {
+		names = append(names, k)
+	}
+	return names
+}
+
+// DefaultInterface returns the single interface or "default" interface.
+func (s *ServiceDef) DefaultInterface() (*InterfaceDef, error) {
+	if len(s.Interfaces) == 1 {
+		for _, iface := range s.Interfaces {
+			return iface, nil
+		}
+	}
+	if iface, ok := s.Interfaces["default"]; ok {
+		return iface, nil
+	}
+	return nil, fmt.Errorf("service %q has multiple interfaces, specify which one", s.Name)
+}
+
+// ---------------------------------------------------------------------------
+// InterfaceDef — returned by interface() builtin
+// ---------------------------------------------------------------------------
+
+type InterfaceDef struct {
+	Name     string
+	Protocol string
+	Port     int
+	Spec     string // path to protocol spec file (swagger, proto, etc.)
+}
+
+var _ starlark.Value = (*InterfaceDef)(nil)
+
+func (i *InterfaceDef) String() string        { return fmt.Sprintf("<interface %s %s:%d>", i.Name, i.Protocol, i.Port) }
+func (i *InterfaceDef) Type() string           { return "interface" }
+func (i *InterfaceDef) Freeze()                {}
+func (i *InterfaceDef) Truth() starlark.Bool   { return true }
+func (i *InterfaceDef) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: interface") }
+
+// ---------------------------------------------------------------------------
+// InterfaceRef — service.main, exposes .addr, .post(), .get(), .send()
+// ---------------------------------------------------------------------------
+
+// InterfaceRef binds a service to a specific interface for step execution.
+// It is also callable for steps: api.public.post(...) calls through runtime.
+type InterfaceRef struct {
+	Service   *ServiceDef
+	Interface *InterfaceDef
+	runtime   *Runtime // set when runtime is available
+}
+
+var _ starlark.Value = (*InterfaceRef)(nil)
+var _ starlark.HasAttrs = (*InterfaceRef)(nil)
+
+func (r *InterfaceRef) String() string        { return fmt.Sprintf("<interface_ref %s.%s>", r.Service.Name, r.Interface.Name) }
+func (r *InterfaceRef) Type() string           { return "interface_ref" }
+func (r *InterfaceRef) Freeze()                {}
+func (r *InterfaceRef) Truth() starlark.Bool   { return true }
+func (r *InterfaceRef) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: interface_ref") }
+
+func (r *InterfaceRef) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "addr":
+		return starlark.String(fmt.Sprintf("localhost:%d", r.Interface.Port)), nil
+	case "host":
+		return starlark.String("localhost"), nil
+	case "port":
+		return starlark.MakeInt(r.Interface.Port), nil
+	case "get", "post", "put", "delete", "patch":
+		return &StepMethod{Ref: r, Method: name}, nil
+	case "send":
+		return &StepMethod{Ref: r, Method: "send"}, nil
+	}
+	return nil, starlark.NoSuchAttrError(fmt.Sprintf("interface_ref has no .%s attribute", name))
+}
+
+func (r *InterfaceRef) AttrNames() []string {
+	if r.Interface.Protocol == "tcp" {
+		return []string{"addr", "host", "port", "send"}
+	}
+	return []string{"addr", "host", "port", "get", "post", "put", "delete", "patch"}
+}
+
+// ---------------------------------------------------------------------------
+// StepMethod — callable step like api.public.post(path="/health")
+// ---------------------------------------------------------------------------
+
+type StepMethod struct {
+	Ref    *InterfaceRef
+	Method string
+}
+
+var _ starlark.Callable = (*StepMethod)(nil)
+
+func (m *StepMethod) String() string  { return fmt.Sprintf("<step %s.%s.%s>", m.Ref.Service.Name, m.Ref.Interface.Name, m.Method) }
+func (m *StepMethod) Type() string    { return "step_method" }
+func (m *StepMethod) Freeze()         {}
+func (m *StepMethod) Truth() starlark.Bool { return true }
+func (m *StepMethod) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: step_method") }
+func (m *StepMethod) Name() string    { return m.Method }
+
+func (m *StepMethod) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	rt := m.Ref.runtime
+	if rt == nil {
+		return nil, fmt.Errorf("step %s: runtime not available (services not started)", m.String())
+	}
+	return rt.executeStep(thread, m.Ref, m.Method, args, kwargs)
+}
+
+// ---------------------------------------------------------------------------
+// Response — wraps step result for Starlark access
+// ---------------------------------------------------------------------------
+
+type Response struct {
+	Status     int
+	Body       string
+	DurationMs int64
+	Ok         bool
+	Error      string
+}
+
+var _ starlark.Value = (*Response)(nil)
+var _ starlark.HasAttrs = (*Response)(nil)
+
+func (r *Response) String() string {
+	if r.Ok {
+		return fmt.Sprintf("<response status=%d>", r.Status)
+	}
+	return fmt.Sprintf("<response error=%q>", r.Error)
+}
+func (r *Response) Type() string           { return "response" }
+func (r *Response) Freeze()                {}
+func (r *Response) Truth() starlark.Bool   { return starlark.Bool(r.Ok) }
+func (r *Response) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: response") }
+
+func (r *Response) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "status":
+		return starlark.MakeInt(r.Status), nil
+	case "body":
+		return starlark.String(r.Body), nil
+	case "ok":
+		return starlark.Bool(r.Ok), nil
+	case "error":
+		return starlark.String(r.Error), nil
+	case "duration_ms":
+		return starlark.MakeInt64(r.DurationMs), nil
+	}
+	return nil, starlark.NoSuchAttrError(fmt.Sprintf("response has no .%s attribute", name))
+}
+
+func (r *Response) AttrNames() []string {
+	return []string{"status", "body", "ok", "error", "duration_ms"}
+}
+
+// ---------------------------------------------------------------------------
+// HealthcheckDef
+// ---------------------------------------------------------------------------
+
+type HealthcheckDef struct {
+	Test    string        // "tcp://host:port" or "http://host/path"
+	Timeout time.Duration
+}
+
+var _ starlark.Value = (*HealthcheckDef)(nil)
+
+func (h *HealthcheckDef) String() string        { return fmt.Sprintf("<healthcheck %s>", h.Test) }
+func (h *HealthcheckDef) Type() string           { return "healthcheck" }
+func (h *HealthcheckDef) Freeze()                {}
+func (h *HealthcheckDef) Truth() starlark.Bool   { return true }
+func (h *HealthcheckDef) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: healthcheck") }
+
+// ---------------------------------------------------------------------------
+// FaultDef — returned by delay() / deny() builtins
+// ---------------------------------------------------------------------------
+
+type FaultDef struct {
+	Action      string // "delay" or "deny"
+	Delay       time.Duration
+	Errno       string
+	Probability float64
+}
+
+var _ starlark.Value = (*FaultDef)(nil)
+
+func (f *FaultDef) String() string {
+	if f.Action == "delay" {
+		return fmt.Sprintf("<fault delay=%s prob=%.0f%%>", f.Delay, f.Probability*100)
+	}
+	return fmt.Sprintf("<fault deny=%s prob=%.0f%%>", f.Errno, f.Probability*100)
+}
+func (f *FaultDef) Type() string           { return "fault" }
+func (f *FaultDef) Freeze()                {}
+func (f *FaultDef) Truth() starlark.Bool   { return true }
+func (f *FaultDef) Hash() (uint32, error)  { return 0, fmt.Errorf("unhashable: fault") }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func starStringArg(kwargs []starlark.Tuple, name, defaultVal string) string {
+	for _, kv := range kwargs {
+		if string(kv[0].(starlark.String)) == name {
+			return string(kv[1].(starlark.String))
+		}
+	}
+	return defaultVal
+}
+
+func starStringMapArg(kwargs []starlark.Tuple, name string) map[string]string {
+	for _, kv := range kwargs {
+		if string(kv[0].(starlark.String)) == name {
+			dict, ok := kv[1].(*starlark.Dict)
+			if !ok {
+				return nil
+			}
+			m := make(map[string]string)
+			for _, item := range dict.Items() {
+				k, _ := starlark.AsString(item[0])
+				v, _ := starlark.AsString(item[1])
+				m[k] = v
+			}
+			return m
+		}
+	}
+	return nil
+}
+
+func starKwarg(kwargs []starlark.Tuple, name string) (starlark.Value, bool) {
+	for _, kv := range kwargs {
+		if string(kv[0].(starlark.String)) == name {
+			return kv[1], true
+		}
+	}
+	return nil, false
+}
+
+func parseStarDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	return time.ParseDuration(s)
+}

--- a/poc/example/faultbox.star
+++ b/poc/example/faultbox.star
@@ -1,0 +1,60 @@
+# faultbox.star — Faultbox configuration and tests in Starlark
+#
+# Run all tests:   faultbox test faultbox.star
+# Run one test:    faultbox test faultbox.star --test happy_path
+
+# --- Topology ---
+
+db = service("db",
+    "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    env = {"PORT": "5432"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api",
+    "/tmp/mock-api",
+    interface("public", "http", 8080),
+    env = {"PORT": "8080", "DB_ADDR": db.main.addr},
+    depends_on = [db],
+    healthcheck = http("localhost:8080/health"),
+)
+
+# --- Tests ---
+
+def test_happy_path():
+    """Normal operation — API and DB both healthy."""
+    # TCP: verify DB responds to PING
+    resp = db.main.send(data="PING")
+    assert_eq(resp, "PONG")
+
+    # HTTP: write and read through API
+    resp = api.post(path="/data/testkey", body="hello")
+    assert_eq(resp.status, 200)
+    assert_true("stored" in resp.body, "expected 'stored' in body")
+
+    resp = api.get(path="/data/testkey")
+    assert_eq(resp.status, 200)
+    assert_eq(resp.body, "hello")
+
+def test_db_slow():
+    """DB writes delayed 500ms — API should still work."""
+    def scenario():
+        resp = api.post(path="/data/slowkey", body="value1")
+        assert_eq(resp.status, 200)
+        assert_true(resp.duration_ms > 400, "expected delay > 400ms")
+
+        resp = api.get(path="/data/slowkey")
+        assert_eq(resp.status, 200)
+        assert_eq(resp.body, "value1")
+
+    fault(db, write=delay("500ms"), run=scenario)
+
+def test_api_cannot_reach_db():
+    """API connections to DB refused — returns 500."""
+    def scenario():
+        resp = api.post(path="/data/failkey", body="value1")
+        assert_eq(resp.status, 500)
+        assert_true("db error" in resp.body, "expected 'db error' in body")
+
+    fault(api, connect=deny("ECONNREFUSED"), run=scenario)


### PR DESCRIPTION
## Summary
- Embed go.starlark.net as the configuration and test language
- Single `.star` file replaces both `faultbox.yaml` and `spec.yaml` (XMonad-style)
- Built-in functions: `service()`, `interface()`, `tcp()`, `http()`, `delay()`, `deny()`, `fault()`
- Service step methods: `api.post()`, `db.send()` dispatch to existing HTTP/TCP executors
- Dynamic fault injection: `fault(db, write=delay("500ms"), run=scenario)` activates seccomp rules at runtime
- Event log with auto-emitted lifecycle events
- CLI: `faultbox test faultbox.star [--test name] [--output results.json]`

## Test plan
- [x] 6 unit tests (service registration, interface access, fault builtins, assertions, event log, test discovery)
- [x] All 3 example tests pass in Lima VM (happy_path, db_slow, api_cannot_reach_db)
- [x] Dynamic fault injection confirmed: connect denied, write delayed 500ms
- [x] No zombie processes after test runs
- [x] YAML path still works (backward compatible)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)