### PR TITLE
fix: Session lifetime and HostPort for container E2E

### DIFF
--- a/internal/container/fd_linux.go
+++ b/internal/container/fd_linux.go
@@ -49,5 +49,12 @@ func waitForListenerFd(ctx context.Context, reportPath string, hostPID int) (int
 		return -1, fmt.Errorf("pidfd_getfd(pid=%d, fd=%d): %w", hostPID, childFd, err)
 	}
 
-	return localFd, nil
+	// Dup to a high fd number (>= 500) to avoid conflicts with Go runtime
+	// and Docker client fds.
+	highFd, err := unix.FcntlInt(uintptr(localFd), unix.F_DUPFD, 500)
+	if err != nil {
+		return localFd, nil // fallback to original
+	}
+	unix.Close(localFd)
+	return highFd, nil
 }

--- a/internal/engine/launch_container_linux.go
+++ b/internal/engine/launch_container_linux.go
@@ -63,7 +63,11 @@ func (s *Session) launchExternal(ctx context.Context) (*Result, error) {
 	stopNotif := make(chan struct{})
 	notifDone := make(chan error, 1)
 	go func() {
-		notifDone <- s.notificationLoop(ctx, listenerFd, ruleMap, stopNotif)
+		err := s.notificationLoop(ctx, listenerFd, ruleMap, stopNotif)
+		if err != nil {
+			s.log.Warn("notification loop ended", slog.String("error", err.Error()))
+		}
+		notifDone <- err
 	}()
 
 	// Wait for the process to exit by polling the listener fd.
@@ -103,17 +107,17 @@ func (s *Session) launchExternal(ctx context.Context) (*Result, error) {
 	// Wait for either the process to exit OR the notification loop to end.
 	select {
 	case <-waitDone:
-		// Process exited — stop notification loop.
+		s.log.Debug("session exit: process poller detected exit")
 		close(stopNotif)
 		unix.Close(listenerFd)
 		<-notifDone
-	case <-notifDone:
-		// Notification loop ended (fd closed, error, etc.) — signal process poller to stop.
+	case err := <-notifDone:
+		s.log.Debug("session exit: notification loop ended", slog.Any("error", err))
 		close(stopNotif)
 		unix.Close(listenerFd)
 		<-waitDone
 	case <-ctx.Done():
-		// Context cancelled — clean up both.
+		s.log.Debug("session exit: context cancelled")
 		close(stopNotif)
 		unix.Close(listenerFd)
 		<-notifDone

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -541,7 +541,9 @@ func (rt *Runtime) launchSession(ctx context.Context, svcName string, svc *Servi
 	}
 	session.Service = svcName
 
-	svcCtx, svcCancel := context.WithCancel(ctx)
+	// Sessions use their own context (not tied to startServices/test context).
+	// They are explicitly cancelled by stopServices() via svcCancel.
+	svcCtx, svcCancel := context.WithCancel(context.Background())
 	done := make(chan *engine.Result, 1)
 	go func() {
 		r, _ := session.Run(svcCtx)
@@ -839,7 +841,11 @@ func (rt *Runtime) mergeClocksForNetworkCall(svcName string) {
 
 // executeStep runs an HTTP or TCP step against a running service.
 func (rt *Runtime) executeStep(thread *starlark.Thread, ref *InterfaceRef, method string, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	addr := fmt.Sprintf("localhost:%d", ref.Interface.Port)
+	port := ref.Interface.Port
+	if ref.Interface.HostPort > 0 {
+		port = ref.Interface.HostPort
+	}
+	addr := fmt.Sprintf("localhost:%d", port)
 	targetSvc := ref.Service.Name
 
 	// Emit step_send event from test driver — shows request going out.


### PR DESCRIPTION
## Summary

- Fix HostPort usage in test steps — was hitting container port (8080) instead of Docker-mapped host port (32xxx)
- Dup seccomp listener fd to high number (>= 500) to prevent Go runtime fd reuse
- Decouple session context from test context — sessions live until explicit stopServices()
- Add debug logging for session exit path

## Result

`test_happy_path` now **passes** E2E: 3 containers (Postgres + Redis + API), 681 syscalls, 6.4s.

## Test plan

- [x] `go test ./...` — 61 tests pass
- [x] E2E: `test_happy_path` passes in Lima VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)