### PR TITLE
perf: Skip seccomp shim when no faults in star file

### DIFF
--- a/internal/container/launch.go
+++ b/internal/container/launch.go
@@ -34,12 +34,20 @@ type LaunchResult struct {
 
 // Launch pulls the image, creates and starts a container with the faultbox-shim
 // as entrypoint, waits for the seccomp listener fd, and returns it.
+// Launch pulls the image, creates and starts a container with the faultbox-shim
+// as entrypoint, waits for the seccomp listener fd, and returns it.
+// If SyscallNrs is empty, launches without the shim (no seccomp interception).
 func Launch(ctx context.Context, client *Client, cfg LaunchConfig, log *slog.Logger) (*LaunchResult, error) {
 	// Pull the image (skip for locally built images).
 	if !cfg.SkipPull {
 		if err := client.PullImage(ctx, cfg.Image); err != nil {
 			return nil, err
 		}
+	}
+
+	// No syscalls to intercept — launch without shim for best performance.
+	if len(cfg.SyscallNrs) == 0 {
+		return launchSimple(ctx, client, cfg, log)
 	}
 
 	// Inspect image to get original entrypoint/cmd.
@@ -176,6 +184,60 @@ func Launch(ctx context.Context, client *Client, cfg LaunchConfig, log *slog.Log
 		ContainerID: containerID,
 		HostPID:     hostPID,
 		ListenerFd:  listenerFd,
+		HostPorts:   hostPorts,
+	}, nil
+}
+
+// launchSimple starts a container without the faultbox-shim (no seccomp filter).
+// Used when no fault rules reference any syscalls — pure Docker orchestration.
+func launchSimple(ctx context.Context, client *Client, cfg LaunchConfig, log *slog.Logger) (*LaunchResult, error) {
+	// Build binds from user volumes only (no shim, no socket dir).
+	var binds []string
+	for hostPath, containerPath := range cfg.Volumes {
+		binds = append(binds, hostPath+":"+containerPath)
+	}
+
+	// Build env.
+	var env []string
+	env = append(env, cfg.Env...)
+
+	containerID, err := client.CreateContainer(ctx, CreateOpts{
+		Name:      "faultbox-" + cfg.Name,
+		Image:     cfg.Image,
+		Env:       env,
+		Binds:     binds,
+		Ports:     cfg.Ports,
+		NetworkID: cfg.NetworkID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.StartContainer(ctx, containerID); err != nil {
+		client.RemoveContainer(ctx, containerID)
+		return nil, fmt.Errorf("start container %s: %w", cfg.Name, err)
+	}
+
+	log.Info("container started (no seccomp)",
+		slog.String("name", cfg.Name),
+		slog.String("id", containerID[:12]),
+	)
+
+	// Resolve host ports.
+	hostPorts := make(map[int]int)
+	for containerPort := range cfg.Ports {
+		hp, err := client.ContainerHostPort(ctx, containerID, containerPort)
+		if err != nil {
+			log.Warn("could not resolve host port", slog.Int("container_port", containerPort), slog.String("error", err.Error()))
+			continue
+		}
+		hostPorts[containerPort] = hp
+	}
+
+	return &LaunchResult{
+		ContainerID: containerID,
+		HostPID:     0,  // no seccomp — no PID tracking needed
+		ListenerFd:  -1, // no listener
 		HostPorts:   hostPorts,
 	}, nil
 }

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -493,6 +493,26 @@ func (rt *Runtime) startContainerService(ctx context.Context, svcName string, sv
 		}
 	}
 
+	// If no seccomp filter (no fault rules), skip session — just wait for healthcheck.
+	if result.ListenerFd < 0 {
+		rt.log.Info("container running (no seccomp)", slog.String("service", svcName))
+		rt.events.Emit("service_started", svcName, nil)
+
+		if svc.Healthcheck != nil {
+			timeout := svc.Healthcheck.Timeout
+			if timeout <= 0 {
+				timeout = 10 * time.Second
+			}
+			hcTest := rt.resolveHealthcheck(svc)
+			if err := waitReady(ctx, hcTest, timeout); err != nil {
+				return fmt.Errorf("service %q not ready: %w", svcName, err)
+			}
+			rt.events.Emit("service_ready", svcName, nil)
+			rt.log.Info("service ready", slog.String("service", svcName), slog.String("check", hcTest))
+		}
+		return nil
+	}
+
 	// Create session with external listener fd.
 	onSyscall := rt.makeSyscallCallback(svcName)
 	faultRules := rt.requiredFaultRules()


### PR DESCRIPTION
## Summary

When a .star file has no `fault()` or `partition()` calls, containers now launch
without the faultbox-shim — pure Docker orchestration with zero seccomp overhead.

Adds `launchSimple()` path in container/launch.go and skip-session logic in
runtime.go for the no-listener case.

Note: when ANY faults exist in the file, all services still get the filter
(per-file scanning). Per-service selective filtering is a future optimization.

## Test plan
- [x] `go test ./...` — 102 tests pass
- [x] E2E: 4/4 container tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)