### PR TITLE
docs: 7-chapter tutorial — first fault to containers

### DIFF
--- a/docs/tutorial/01-first-fault.md
+++ b/docs/tutorial/01-first-fault.md
@@ -1,0 +1,138 @@
+# Chapter 1: Your First Fault
+
+In this chapter you'll inject your first syscall fault into a running process
+and see what happens when the operating system lies to your program.
+
+## What is Faultbox?
+
+Faultbox intercepts system calls using Linux's **seccomp-notify** mechanism.
+When your program calls `write()`, `connect()`, or `read()`, the kernel pauses
+the program and asks Faultbox: "should I allow this?" Faultbox can:
+
+- **Allow** — let the syscall proceed normally
+- **Deny** — return an error code (EIO, ENOSPC, ECONNREFUSED, ...)
+- **Delay** — wait, then allow
+
+This isn't mocking. Your program runs for real. The filesystem, network, and
+kernel are all real. Faultbox only changes what the kernel *returns*.
+
+## Build
+
+```bash
+make build
+# For Lima VM:
+make demo-build
+```
+
+This creates `bin/faultbox` (or `bin/linux-arm64/faultbox` for Lima).
+
+## The target program
+
+`poc/target/main.go` is a simple Go program that:
+1. Writes a file to `/tmp/faultbox-target-test`
+2. Reads it back
+3. Makes an HTTP request to `httpbin.org`
+
+Build it:
+```bash
+go build -o /tmp/target ./poc/target/
+```
+
+Run it normally:
+```bash
+/tmp/target
+```
+
+You'll see output like:
+```
+PID: 12345
+filesystem: write+read OK (2ms)
+network: HTTP 200 OK (150ms)
+```
+
+## Inject a write fault
+
+Now run it through Faultbox, denying every `write()` syscall with EIO (I/O error):
+
+```bash
+faultbox run --fault "write=EIO:100%" /tmp/target
+```
+
+The program fails! `write()` returns EIO, and the file operation errors out.
+Faultbox intercepted the syscall at the kernel level — the program had no way
+to avoid it.
+
+## Probabilistic faults
+
+Real failures aren't 100%. Make writes fail 30% of the time:
+
+```bash
+faultbox run --fault "write=EIO:30%" /tmp/target
+```
+
+Run it several times. Sometimes it works, sometimes it fails. This is how
+real disk errors behave — intermittent and unpredictable.
+
+## Path-targeted faults
+
+Deny opens only for files under `/data/`:
+
+```bash
+faultbox run --fault "openat=ENOENT:100%:/data/*" /tmp/target
+```
+
+The target writes to `/tmp/` (not `/data/`), so it succeeds. Path targeting
+lets you fault specific files without breaking the whole filesystem.
+
+## Delay faults
+
+Slow down every write by 500ms:
+
+```bash
+faultbox run --fault "write=delay:500ms:100%" /tmp/target
+```
+
+The filesystem operation now takes >500ms. Delay faults simulate slow disks,
+overloaded storage, or network congestion.
+
+## How it works
+
+```
+Your program                    Kernel                     Faultbox
+    |                             |                           |
+    |-- write(fd, buf, n) ------->|                           |
+    |                             |-- seccomp notification -->|
+    |                             |                           |-- check rules
+    |                             |                           |-- deny: EIO
+    |                             |<-- return DENY(EIO) ------|
+    |<-- errno = EIO -------------|                           |
+    |                             |                           |
+```
+
+The key insight: this works on **any binary**. C, Rust, Java, Python — anything
+that makes syscalls. No code changes, no special libraries, no mocking frameworks.
+
+## What you learned
+
+- `faultbox run` wraps a binary with syscall interception
+- `--fault "syscall=ERRNO:PROBABILITY%"` denies syscalls
+- `--fault "syscall=delay:DURATION:PROBABILITY%"` slows syscalls
+- Path globs (`:/data/*`) target specific files
+- seccomp-notify works at the kernel level — programs can't bypass it
+
+## Exercises
+
+1. **Network fault**: Run the target with `--fault "connect=ECONNREFUSED:100%"`.
+   What happens to the HTTP request? Does the program crash or handle the error?
+
+2. **Slow network**: Run with `--fault "connect=delay:2s:100%"`. How long does
+   the HTTP request take now? (The target has a 5s timeout — will it succeed?)
+
+3. **Combined faults**: Run with two faults at once:
+   ```bash
+   faultbox run --fault "write=EIO:50%" --fault "connect=delay:1s:100%" /tmp/target
+   ```
+   What's the combined effect?
+
+4. **Explore errno values**: Try `ENOSPC` (disk full), `EPERM` (permission denied),
+   `ETIMEDOUT` (timeout). Which ones does the target handle gracefully?

--- a/docs/tutorial/02-first-test.md
+++ b/docs/tutorial/02-first-test.md
@@ -1,0 +1,182 @@
+# Chapter 2: Writing Your First Test
+
+In chapter 1 you injected faults manually. Now you'll write automated tests
+in Starlark — Faultbox's configuration language.
+
+## Starlark
+
+Starlark is a Python dialect designed for configuration. If you know Python,
+you know Starlark. The key difference: no imports, no classes, no exceptions.
+Just functions, variables, and data.
+
+Faultbox uses a single `.star` file to declare your system topology AND your
+test cases. Configuration is code.
+
+## The mock database
+
+`poc/mock-db/` is a simple TCP key-value store. Build it:
+
+```bash
+go build -o /tmp/mock-db ./poc/mock-db/
+```
+
+It accepts text commands over TCP:
+```
+PING       → PONG
+SET k v    → OK
+GET k      → value or NOT_FOUND
+QUIT       → closes connection
+```
+
+## Your first spec file
+
+Create `my-first-test.star`:
+
+```python
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    healthcheck = tcp("localhost:5432"),
+)
+
+def test_ping():
+    resp = db.main.send(data="PING")
+    assert_eq(resp, "PONG")
+```
+
+This declares:
+- A **service** named "db" that runs `/tmp/mock-db`
+- It has one **interface** called "main" on TCP port 5432
+- A **healthcheck** that verifies it's accepting connections
+- A **test** that sends PING and expects PONG
+
+## Run it
+
+```bash
+faultbox test my-first-test.star
+```
+
+Output:
+```
+--- PASS: test_ping (150ms, seed=0) ---
+  syscall trace (42 events):
+
+1 passed, 0 failed
+```
+
+## What just happened?
+
+For each test, Faultbox:
+
+```
+1. Start all services (in dependency order)
+2. Wait for healthchecks to pass
+3. Run the test function
+4. Stop all services
+5. Report result + syscall trace
+```
+
+The database was started, health-checked, tested, and stopped — automatically.
+
+## Service lifecycle
+
+```python
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    env = {"PORT": "5432"},            # environment variables
+    healthcheck = tcp("localhost:5432"),
+)
+```
+
+| Parameter | Purpose |
+|-----------|---------|
+| `"db"` | Service name (used in logs and traces) |
+| `"/tmp/mock-db"` | Path to the binary |
+| `interface(...)` | Network interface declaration |
+| `env = {...}` | Environment variables for the process |
+| `healthcheck` | How to verify the service is ready |
+
+## Interface addressing
+
+Once declared, access the interface:
+
+```python
+db.main.addr        # "localhost:5432"
+db.main.host        # "localhost"
+db.main.port        # 5432
+```
+
+For TCP interfaces, call `.send()` to exchange data:
+```python
+resp = db.main.send(data="PING")
+```
+
+## Assertions
+
+Faultbox provides two basic assertions:
+
+```python
+assert_eq(actual, expected)           # equality check
+assert_true(condition, "message")     # boolean check
+```
+
+They fail the test immediately with a clear error message.
+
+## Adding more tests
+
+Extend your spec file:
+
+```python
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    healthcheck = tcp("localhost:5432"),
+)
+
+def test_ping():
+    resp = db.main.send(data="PING")
+    assert_eq(resp, "PONG")
+
+def test_set_and_get():
+    db.main.send(data="SET greeting hello")
+    resp = db.main.send(data="GET greeting")
+    assert_eq(resp, "hello")
+```
+
+Run all tests:
+```bash
+faultbox test my-first-test.star
+```
+
+Run one test:
+```bash
+faultbox test my-first-test.star --test set_and_get
+```
+
+## What you learned
+
+- `.star` files declare topology (services) and tests (functions)
+- `service()` defines a binary, its interfaces, env vars, and healthcheck
+- `interface()` declares how services communicate (TCP, HTTP)
+- `test_*` functions are discovered and run automatically
+- `assert_eq` and `assert_true` validate behavior
+- Each test gets fresh service instances (restarted between tests)
+
+## Exercises
+
+1. **Write and read**: Add a test that does `SET mykey myvalue`, then
+   `GET mykey`, and asserts the result is `"myvalue"`.
+
+2. **Missing key**: Add a test that does `GET nonexistent` and asserts
+   the result is `"NOT_FOUND"`.
+
+3. **Overwrite**: Add a test that sets the same key twice with different
+   values, then reads it back. Which value do you get?
+
+4. **Multiple interfaces**: The mock-db could theoretically listen on
+   two ports. Declare a second interface:
+   ```python
+   db = service("db", "/tmp/mock-db",
+       interface("main", "tcp", 5432),
+       interface("admin", "tcp", 5433),
+   )
+   ```
+   What happens when you run this? (Hint: the binary only listens on PORT.)

--- a/docs/tutorial/03-fault-injection.md
+++ b/docs/tutorial/03-fault-injection.md
@@ -1,0 +1,191 @@
+# Chapter 3: Fault Injection in Tests
+
+In chapter 2 you tested happy paths. Now you'll break things on purpose
+and verify your system handles failures correctly.
+
+## Two-service topology
+
+Build both services:
+```bash
+go build -o /tmp/mock-db ./poc/mock-db/
+go build -o /tmp/mock-api ./poc/mock-api/
+```
+
+The mock-api is an HTTP service that stores data in mock-db via TCP.
+Create `fault-test.star`:
+
+```python
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api", "/tmp/mock-api",
+    interface("public", "http", 8080),
+    env = {"PORT": "8080", "DB_ADDR": db.main.addr},
+    depends_on = [db],
+    healthcheck = http("localhost:8080/health"),
+)
+
+def test_happy_path():
+    resp = api.post(path="/data/mykey", body="myvalue")
+    assert_eq(resp.status, 200)
+
+    resp = api.get(path="/data/mykey")
+    assert_eq(resp.status, 200)
+    assert_eq(resp.body, "myvalue")
+```
+
+Run it:
+```bash
+faultbox test fault-test.star
+```
+
+## The `fault()` builtin
+
+`fault()` applies temporary faults to a service while running a callback:
+
+```python
+def test_db_write_failure():
+    """DB writes fail with I/O error."""
+    def scenario():
+        resp = api.post(path="/data/failkey", body="value")
+        assert_true(resp.status >= 500, "expected 5xx on DB write failure")
+    fault(db, write=deny("EIO"), run=scenario)
+```
+
+When `fault()` runs:
+1. Apply `write=deny("EIO")` to the db service's seccomp filter
+2. Run `scenario()`
+3. Remove the fault (even if scenario fails)
+
+The fault is **scoped** — it only exists during the callback. After `fault()`
+returns, the db service works normally again.
+
+## deny() and delay()
+
+Two fault types:
+
+```python
+deny("EIO")                    # fail with I/O error, 100% probability
+deny("ENOSPC")                 # fail with disk full
+deny("ECONNREFUSED")           # fail with connection refused
+deny("EIO", probability="50%") # fail 50% of the time
+
+delay("500ms")                 # slow down by 500ms, then allow
+delay("2s", probability="30%") # 30% chance of 2s delay
+```
+
+## Syscall keywords
+
+The keyword in `fault()` is the syscall name:
+
+```python
+fault(db, write=deny("EIO"), run=fn)      # deny write() syscalls
+fault(db, connect=deny("ECONNREFUSED"), run=fn) # deny connect()
+fault(db, openat=deny("ENOENT"), run=fn)  # deny file opens
+fault(db, fsync=deny("EIO"), run=fn)      # deny fsync
+fault(db, sendto=deny("EPIPE"), run=fn)   # deny network sends
+```
+
+**Syscall families**: `write` automatically covers `write`, `writev`, and
+`pwrite64`. You don't need to know which variant your program uses.
+
+| Keyword | Covers |
+|---------|--------|
+| `write` | write, writev, pwrite64 |
+| `read` | read, readv, pread64 |
+| `fsync` | fsync, fdatasync |
+| `sendto` | sendto, sendmsg |
+| `recvfrom` | recvfrom, recvmsg |
+| `open` | open, openat |
+
+## Multi-fault injection
+
+Apply multiple faults at once:
+
+```python
+def test_everything_broken():
+    def scenario():
+        resp = api.post(path="/data/key", body="val")
+        assert_true(resp.status >= 500)
+    fault(db,
+        write=delay("1s"),
+        fsync=deny("EIO"),
+        run=scenario,
+    )
+```
+
+## Imperative fault control
+
+For more control, use `fault_start()` / `fault_stop()`:
+
+```python
+def test_imperative():
+    # Start with no faults.
+    resp = api.post(path="/data/key1", body="before")
+    assert_eq(resp.status, 200)
+
+    # Enable fault.
+    fault_start(db, write=deny("EIO"))
+
+    resp = api.post(path="/data/key2", body="during")
+    assert_true(resp.status >= 500)
+
+    # Disable fault.
+    fault_stop(db)
+
+    resp = api.post(path="/data/key3", body="after")
+    assert_eq(resp.status, 200)
+```
+
+Prefer `fault()` with `run=` when possible — it guarantees cleanup.
+
+## Diagnostic output
+
+When a fault fires, the trace shows it:
+
+```
+--- PASS: test_db_write_failure (200ms, seed=0) ---
+  syscall trace (85 events):
+    #72  db    write   deny(input/output error)
+    #73  db    write   deny(input/output error)
+  fault applied to db: write=deny(EIO) -> filter:[write,writev,pwrite64]
+```
+
+If a fault was applied but never fired, you'll see a warning:
+
+```
+  fault applied to db: fsync=deny(EIO) -> filter:[fsync,fdatasync]
+  per-service syscall summary:
+    db    120 total, 0 faulted  [write:45 read:30 connect:5 ...]
+```
+
+This tells you the program might use a different syscall than expected.
+
+## What you learned
+
+- `fault(service, syscall=deny/delay, run=fn)` injects scoped faults
+- `deny("ERRNO")` fails syscalls with a specific error code
+- `delay("duration")` slows syscalls before allowing them
+- Syscall families expand automatically (write covers pwrite64, writev)
+- Diagnostic output shows which faults fired and which didn't
+- `fault_start()` / `fault_stop()` for imperative control
+
+## Exercises
+
+1. **Slow database**: Write a test where DB writes take 500ms.
+   Assert that the API response takes more than 400ms:
+   ```python
+   assert_true(resp.duration_ms > 400, "expected slow response")
+   ```
+
+2. **Connection failure**: Write a test where the API can't connect to
+   the DB (`fault(api, connect=deny("ECONNREFUSED"), ...)`).
+   Verify the API returns a 500 error.
+
+3. **Disk full**: Write a test with `write=deny("ENOSPC")` on the DB.
+   What error message does the API return in `resp.body`?
+
+4. **Partial failure**: Use `deny("EIO", probability="50%")` on DB writes.
+   Run the test 10 times (`--runs 10`). How many pass vs fail?

--- a/docs/tutorial/04-traces-assertions.md
+++ b/docs/tutorial/04-traces-assertions.md
@@ -1,0 +1,181 @@
+# Chapter 4: Traces & Assertions
+
+In chapter 3 you broke things. Now you'll verify *exactly what happened* at the
+syscall level — which files were opened, which connections were made, and in
+what order.
+
+## The demo system
+
+Chapters 4-6 use the full demo: an order service that talks to an inventory
+service with a write-ahead log (WAL).
+
+```bash
+make demo-build  # builds order-svc + inventory-svc for Lima VM
+```
+
+The demo spec is at `poc/demo/faultbox.star`. Run it:
+```bash
+faultbox test poc/demo/faultbox.star
+```
+
+## The event log
+
+Every intercepted syscall is recorded as an **event** with:
+- Sequence number
+- Timestamp
+- Service name
+- Syscall name, PID, decision, file path
+- Vector clock (for causality tracking)
+
+Even `allow` decisions are recorded. The trace is a complete record of
+what the system did at the kernel level.
+
+## Temporal assertions
+
+### assert_eventually — "this happened"
+
+Verify that a syscall event occurred during the test:
+
+```python
+def test_wal_written():
+    """Order placement triggers a WAL write."""
+    resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+    assert_eq(resp.status, 200)
+
+    # The inventory service should have opened the WAL file.
+    assert_eventually(
+        service="inventory",
+        syscall="openat",
+        path="/tmp/inventory.wal",
+    )
+```
+
+`assert_eventually` searches the test's event log for a matching event.
+If none found, the test fails.
+
+### assert_never — "this didn't happen"
+
+Verify that something did NOT occur:
+
+```python
+def test_no_wal_when_unreachable():
+    """When inventory is unreachable, no WAL write should occur."""
+    def scenario():
+        resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+        assert_eq(resp.status, 503)
+
+        # No WAL access should have happened.
+        assert_never(
+            service="inventory",
+            syscall="openat",
+            path="/tmp/inventory.wal",
+        )
+    fault(orders, connect=deny("ECONNREFUSED"), run=scenario)
+```
+
+### assert_before — ordering guarantees
+
+Verify that events happened in the right order:
+
+```python
+def test_wal_before_response():
+    """WAL must be opened before order is confirmed."""
+    resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+    assert_eq(resp.status, 200)
+
+    assert_before(
+        first={"service": "inventory", "syscall": "openat", "path": "/tmp/inventory.wal"},
+        then={"service": "inventory", "syscall": "write"},
+    )
+```
+
+### Filter parameters
+
+All temporal assertions accept the same filter keywords:
+
+| Parameter | Matches | Example |
+|-----------|---------|---------|
+| `service` | Service name | `"inventory"` |
+| `syscall` | Syscall name | `"openat"`, `"write"`, `"connect"` |
+| `path` | File path | `"/tmp/inventory.wal"` |
+| `decision` | Fault decision | `"allow"`, `"deny*"` |
+
+Glob matching: `"deny*"` matches `"deny(EIO)"`, `"deny(ENOSPC)"`, etc.
+
+### events() — query the trace
+
+Get a list of matching events for custom logic:
+
+```python
+def test_count_retries():
+    def scenario():
+        resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+        retries = events(service="orders", syscall="connect", decision="deny*")
+        print("connection retries:", len(retries))
+    fault(orders, connect=deny("ECONNREFUSED", probability="50%"), run=scenario)
+```
+
+## Trace output formats
+
+### JSON trace
+
+```bash
+faultbox test poc/demo/faultbox.star --output trace.json
+```
+
+Produces structured JSON with every event, including:
+- `event_type`: dotted notation (`"syscall.write"`, `"lifecycle.started"`)
+- `partition_key`: service name (for PObserve integration)
+- `vector_clock`: per-service logical clocks
+- `replay_command`: for failed tests, the exact command to reproduce
+
+### ShiViz visualization
+
+```bash
+faultbox test poc/demo/faultbox.star --shiviz trace.shiviz
+```
+
+Open at https://bestchai.bitbucket.io/shiviz/ to see a space-time diagram
+with communication arrows between services.
+
+### Normalized trace
+
+```bash
+faultbox test poc/demo/faultbox.star --normalize trace1.norm
+faultbox test poc/demo/faultbox.star --normalize trace2.norm
+faultbox diff trace1.norm trace2.norm
+```
+
+Normalized traces strip timestamps for deterministic comparison.
+Same seed + same binary = same trace.
+
+## What you learned
+
+- `assert_eventually()` verifies something happened in the syscall trace
+- `assert_never()` verifies something did NOT happen
+- `assert_before()` verifies ordering between events
+- `events()` returns matching events for custom logic
+- `--output trace.json` for structured analysis
+- `--shiviz trace.shiviz` for visual causality diagrams
+- `--normalize` + `diff` for determinism verification
+
+## Exercises
+
+1. **WAL ordering**: Write a test that places an order and asserts:
+   - The WAL file was opened (`assert_eventually` with openat)
+   - The WAL was written to (`assert_eventually` with write)
+   - The open happened before the write (`assert_before`)
+
+2. **No denied syscalls**: Write a happy-path test and assert there are
+   zero denied syscalls:
+   ```python
+   denied = events(decision="deny*")
+   assert_eq(len(denied), 0, "no syscalls should be denied in happy path")
+   ```
+
+3. **Count connections**: Write a test that counts how many `connect`
+   syscalls the orders service made. Is it 1? More? Why?
+
+4. **JSON analysis**: Run with `--output trace.json` and look at the JSON.
+   Find the `vector_clock` field. What does `{"inventory": 5, "orders": 3}`
+   mean?

--- a/docs/tutorial/05-concurrency.md
+++ b/docs/tutorial/05-concurrency.md
@@ -1,0 +1,155 @@
+# Chapter 5: Exploring Concurrency
+
+The hardest bugs happen when things run at the same time. In this chapter
+you'll explore concurrent interleavings and find bugs that only appear
+under specific timing.
+
+## The problem
+
+Two orders arrive simultaneously for the last widget in stock. Which wins?
+Do both succeed (overselling)? Does one fail gracefully? Does the system crash?
+
+The answer depends on the *order* in which syscalls execute — and in production,
+that order is random.
+
+## parallel()
+
+Run multiple operations concurrently:
+
+```python
+def test_concurrent_orders():
+    """Two orders at once — no double-spend."""
+    results = parallel(
+        lambda: orders.post(path="/orders", body='{"sku":"widget","qty":1}'),
+        lambda: orders.post(path="/orders", body='{"sku":"widget","qty":1}'),
+    )
+    # At most one should succeed (stock=10, but in a race condition test
+    # with stock=1, exactly one should fail).
+    statuses = [r.status for r in results]
+    ok_count = sum(1 for s in statuses if s == 200)
+    assert_true(ok_count >= 1, "at least one order should succeed")
+```
+
+`parallel()` runs the lambdas in concurrent goroutines. The interleaving of
+their syscalls depends on the **seed**.
+
+## Seed-based replay
+
+Every test run has a seed (default: 0). The seed controls the scheduling
+of held syscalls in `parallel()`:
+
+```bash
+faultbox test poc/demo/faultbox.star --seed 42
+```
+
+Same seed = same interleaving = same result. This makes concurrent bugs
+**reproducible**.
+
+When a test fails, the output includes a replay command:
+```
+--- FAIL: test_concurrent_orders (300ms, seed=7) ---
+  replay: faultbox test poc/demo/faultbox.star --test concurrent_orders --seed 7
+```
+
+## Multi-run discovery
+
+Run the same test many times with different seeds to find failures:
+
+```bash
+faultbox test poc/demo/faultbox.star --test flaky_network --runs 100 --show fail
+```
+
+This runs the test 100 times (seeds 0-99) and only shows failures.
+If seed 7 fails, you can replay it:
+
+```bash
+faultbox test poc/demo/faultbox.star --test flaky_network --seed 7
+```
+
+## Exhaustive exploration
+
+For small numbers of concurrent operations, try ALL possible orderings:
+
+```bash
+faultbox test poc/demo/faultbox.star --test concurrent_orders --explore=all
+```
+
+With 2 concurrent operations that each make 3 syscalls, there are
+`6! / (3! * 3!) = 20` possible interleavings. `--explore=all` tries every one.
+
+For larger state spaces, sample randomly:
+
+```bash
+faultbox test poc/demo/faultbox.star --explore=sample --runs 500
+```
+
+## nondet()
+
+Some services make background syscalls (healthchecks, metrics, logging) that
+aren't part of the test scenario. These add noise to interleaving exploration.
+
+Exclude them:
+
+```python
+def test_concurrent_orders():
+    nondet(monitoring_svc)  # exclude from ordering exploration
+    results = parallel(
+        lambda: orders.post(...),
+        lambda: orders.post(...),
+    )
+```
+
+## Virtual time
+
+When faults use `delay()`, real wall-clock sleeps make exhaustive exploration
+slow. Virtual time skips the sleeps:
+
+```bash
+faultbox test poc/demo/faultbox.star --virtual-time --explore=all
+```
+
+A test with `delay("2s")` completes in milliseconds.
+
+## Combining faults with concurrency
+
+The most powerful tests combine fault injection with concurrent operations:
+
+```python
+def test_concurrent_under_failure():
+    """Concurrent orders while inventory is slow."""
+    def scenario():
+        results = parallel(
+            lambda: orders.post(path="/orders", body='{"sku":"widget","qty":1}'),
+            lambda: orders.post(path="/orders", body='{"sku":"widget","qty":1}'),
+        )
+        # Both should eventually get a response (not hang).
+        for r in results:
+            assert_true(r.status in [200, 503], "expected 200 or 503")
+    fault(inventory, write=delay("500ms"), run=scenario)
+```
+
+## What you learned
+
+- `parallel()` runs operations concurrently
+- Seeds control interleaving — same seed = same result
+- `--runs 100 --show fail` finds flaky failures
+- `--seed N` replays a specific interleaving
+- `--explore=all` tries every permutation
+- `nondet()` excludes services from ordering
+- `--virtual-time` skips delays for fast exploration
+- Faults + concurrency = realistic distributed systems testing
+
+## Exercises
+
+1. **Find the race**: Write a test with two concurrent orders for a
+   limited-stock item. Run with `--runs 50`. Do any fail? If so, what seed?
+
+2. **Exhaustive check**: Take the same test and run with `--explore=all`.
+   How many permutations are tested? Do all pass?
+
+3. **Fault + concurrency**: Write a test where two orders run concurrently
+   while inventory has a 200ms write delay. Does the system still work?
+   Run with `--runs 20` to check.
+
+4. **Virtual time speedup**: Run exercise 3 with `--virtual-time`. How much
+   faster is it? Compare wall-clock times.

--- a/docs/tutorial/06-monitors-partitions.md
+++ b/docs/tutorial/06-monitors-partitions.md
@@ -1,0 +1,138 @@
+# Chapter 6: Monitors & Network Partitions
+
+Previous chapters tested specific scenarios. In this chapter you'll define
+**safety properties** that must hold across all tests, and simulate
+**network partitions** between services.
+
+## Monitors
+
+A monitor is a callback that runs on every matching syscall event.
+If it raises an error, the test fails with "monitor violation".
+
+```python
+def no_unhandled_errors(event):
+    """Safety: denied writes should never go unlogged."""
+    if event["decision"].startswith("deny"):
+        # In a real system, you'd check that the application logged the error.
+        pass
+
+monitor(no_unhandled_errors, service="inventory", syscall="write")
+```
+
+Monitors are registered before tests run and cleared between tests.
+
+## Practical monitor: deny count limit
+
+```python
+deny_count = {"n": 0}
+
+def limit_denials(event):
+    if event["decision"].startswith("deny"):
+        deny_count["n"] += 1
+        if deny_count["n"] > 5:
+            fail("too many denied syscalls: " + str(deny_count["n"]))
+
+monitor(limit_denials, service="inventory", decision="deny*")
+```
+
+This monitor fails the test if more than 5 syscalls are denied on the
+inventory service. It's a safety property: "fault injection shouldn't
+cause unbounded failures."
+
+## Monitor filters
+
+Monitors accept the same filters as temporal assertions:
+
+```python
+monitor(callback, service="inventory")                    # all inventory syscalls
+monitor(callback, service="inventory", syscall="write")   # inventory writes only
+monitor(callback, decision="deny*")                       # any denied syscall
+monitor(callback, service="orders", syscall="connect")    # orders' connections
+```
+
+## Network partitions
+
+`partition()` creates a bidirectional network split between two services:
+
+```python
+def test_network_partition():
+    """Orders can't reach inventory — returns 503."""
+    def scenario():
+        resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+        assert_eq(resp.status, 503)
+
+        # Verify: inventory was never contacted.
+        assert_never(service="inventory", syscall="openat", path="/tmp/inventory.wal")
+
+    partition(orders, inventory, run=scenario)
+```
+
+During the partition:
+- `orders` can't `connect()` to `inventory` (gets ECONNREFUSED)
+- `inventory` can't `connect()` to `orders` (gets ECONNREFUSED)
+- Other connectivity (orders to external APIs) is **not affected**
+
+This is more precise than `fault(orders, connect=deny("ECONNREFUSED"))`,
+which would block ALL outbound connections, not just to inventory.
+
+## Partition vs fault
+
+| | `fault(svc, connect=deny(...))` | `partition(svc_a, svc_b)` |
+|-|---------------------------------|---------------------------|
+| Scope | ALL connections from svc | Only connections between svc_a ↔ svc_b |
+| Direction | One-way | Bidirectional |
+| Other connectivity | Blocked | Preserved |
+| Use case | "Service can't reach anything" | "Network split between two specific services" |
+
+## Combining monitors and partitions
+
+The real power: define a safety property, then create failure scenarios:
+
+```python
+# Safety property: no order should be confirmed when inventory is unreachable.
+def no_phantom_orders(event):
+    """If orders writes 'confirmed', inventory must have been reachable."""
+    if event["syscall"] == "write" and "confirmed" in event.get("path", ""):
+        # This is a simplified check. In practice, you'd verify the
+        # event log shows a successful inventory connection.
+        pass
+
+monitor(no_phantom_orders, service="orders", syscall="write")
+
+def test_partition_safety():
+    def scenario():
+        resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
+        # Order should fail, not succeed with phantom data.
+        assert_true(resp.status != 200, "order should not succeed during partition")
+    partition(orders, inventory, run=scenario)
+```
+
+## What you learned
+
+- `monitor(callback, ...)` runs on every matching syscall event
+- Monitors define safety properties that must hold during the test
+- `partition(svc_a, svc_b, run=fn)` creates bidirectional network splits
+- Partitions only affect connections between the two named services
+- Monitors + partitions = verify safety properties under failure
+
+## Exercises
+
+1. **Denial counter**: Write a monitor that counts denied `write` syscalls
+   on inventory. Then run a test with `write=deny("EIO")` and verify the
+   monitor sees the denials. How many `write` denials occur for a single
+   order?
+
+2. **Partition + assertion**: Write a test that partitions orders from
+   inventory, attempts an order, and then asserts:
+   - `assert_never(service="inventory", syscall="openat")` — inventory
+     was never contacted
+   - The order returns 503
+
+3. **Selective partition**: What happens if you partition orders from
+   inventory, but then access orders' health endpoint? Does `/health`
+   still work? (It should — health doesn't need inventory.)
+
+4. **Monitor as invariant checker**: Write a monitor on the orders service
+   that fails if any `connect` syscall is allowed during a partition test.
+   Then run `partition(orders, inventory, run=scenario)` and verify the
+   monitor catches the denied connections (not allowed ones).

--- a/docs/tutorial/07-containers.md
+++ b/docs/tutorial/07-containers.md
@@ -1,0 +1,174 @@
+# Chapter 7: Containers — Real Infrastructure
+
+Previous chapters used mock binaries. In this chapter you'll test real
+Postgres, Redis, and a Go API — all in Docker containers, with fault injection.
+
+## Prerequisites
+
+- Docker daemon running
+- Linux kernel 5.6+ (Lima VM on macOS)
+- `sudo` access (required for `pidfd_getfd` across Docker namespaces)
+
+## How container mode works
+
+```
+Host (faultbox)                          Docker Container
+┌─────────────────────┐    ┌────────────────────────────────┐
+│ 1. Pull/build image │    │ faultbox-shim (bind-mounted)   │
+│ 2. Override entry-  │    │   ├─ Install seccomp filter    │
+│    point with shim  │    │   ├─ Report listener fd        │
+│ 3. Acquire fd via   │◄───│   ├─ Wait for host ACK         │
+│    pidfd_getfd()    │    │   └─ exec(original entrypoint) │
+│ 4. Run notification │    │                                │
+│    loop (same as    │    │ Real service runs with         │
+│    binary mode)     │    │ seccomp filter active           │
+└─────────────────────┘    └────────────────────────────────┘
+```
+
+The key: a tiny shim binary is injected into the container. It installs the
+seccomp filter, then exec's the original entrypoint. From the service's
+perspective, nothing changed — except faultbox can now intercept its syscalls.
+
+## Container services
+
+Instead of `binary=`, use `image=` or `build=`:
+
+```python
+# Pull from registry
+postgres = service("postgres",
+    interface("main", "tcp", 5432),
+    image = "postgres:16-alpine",
+    env = {"POSTGRES_PASSWORD": "test", "POSTGRES_DB": "testdb"},
+    healthcheck = tcp("localhost:5432", timeout="60s"),
+)
+
+# Build from Dockerfile
+api = service("api",
+    interface("public", "http", 8080),
+    build = "./api",
+    env = {"PORT": "8080", "DATABASE_URL": "postgres://postgres:test@" + postgres.main.internal_addr + "/testdb?sslmode=disable"},
+    depends_on = [postgres],
+    healthcheck = http("localhost:8080/health", timeout="60s"),
+)
+```
+
+Three service sources — exactly one required:
+
+| Parameter | Source |
+|-----------|--------|
+| `"/path/to/binary"` (positional) | Local binary (PoC 1) |
+| `image = "postgres:16"` | Docker image from registry |
+| `build = "./api"` | Build from Dockerfile directory |
+
+## Container networking
+
+Containers run on a Docker bridge network (`faultbox-net`). They reach each
+other by service name:
+
+```python
+# internal_addr returns "postgres:5432" (container hostname)
+env = {"DATABASE_URL": "postgres://test@" + postgres.main.internal_addr + "/db"}
+
+# addr returns "localhost:32847" (host-mapped random port)
+# Used by: healthchecks, test step execution (api.get(...))
+```
+
+| Attribute | Returns | Used by |
+|-----------|---------|---------|
+| `.internal_addr` | `"postgres:5432"` | Container-to-container env vars |
+| `.addr` | `"localhost:32847"` | Faultbox healthchecks and test steps |
+
+## The demo
+
+The container demo is at `poc/demo-container/`. Run it:
+
+```bash
+# Build binaries + demo API image
+make demo-build
+
+# Run in Lima VM with Docker
+sudo bin/linux-arm64/faultbox test poc/demo-container/faultbox.star
+```
+
+It starts Postgres, Redis, and a Go API, then runs 4 tests:
+
+```
+--- PASS: test_happy_path (9.7s) ---
+--- PASS: test_postgres_write_enospc (10.4s) ---
+--- PASS: test_postgres_write_failure (9.4s) ---
+--- PASS: test_write_and_read (9.7s) ---
+```
+
+## Fault injection on containers
+
+Same `fault()` API — Faultbox doesn't care if it's a binary or container:
+
+```python
+def test_postgres_disk_full():
+    """Postgres disk full — API should return 503."""
+    def scenario():
+        resp = api.post(path="/data?key=full&value=test")
+        assert_true(resp.status >= 500, "expected 5xx on ENOSPC")
+    fault(postgres, write=deny("ENOSPC"), run=scenario)
+```
+
+This denies `write`, `writev`, and `pwrite64` on the Postgres container.
+When Postgres tries to write a data page, it gets ENOSPC. The SQL query
+fails, the API returns 503.
+
+## Per-service filtering
+
+Faultbox only installs seccomp filters on services that are actually faulted.
+In the demo, only Postgres gets a filter — Redis and API run at native speed.
+
+This is why fault tests and non-fault tests have similar timing.
+
+## Volumes
+
+Mount host directories into containers:
+
+```python
+pg = service("postgres",
+    interface("main", "tcp", 5432),
+    image = "postgres:16-alpine",
+    volumes = {"./pg-data": "/var/lib/postgresql/data"},
+)
+```
+
+## Why sudo?
+
+`pidfd_getfd()` requires `PTRACE_MODE_ATTACH` permission on the target process.
+Docker containers run in separate PID namespaces. Without root, the kernel
+refuses to copy the seccomp listener fd from the container process.
+
+Future: this could be solved with a setuid helper or Docker plugin.
+
+## What you learned
+
+- `image=` pulls Docker images, `build=` builds from Dockerfile
+- `.internal_addr` for container-to-container references
+- `.addr` for host-side access (healthchecks, test steps)
+- Fault injection works identically on containers and binaries
+- Per-service filtering: only faulted services get seccomp overhead
+- Requires Linux + Docker + sudo
+
+## Exercises
+
+1. **Graceful degradation**: The demo API talks to both Postgres and Redis.
+   Currently Redis is unused. Modify `poc/demo-container/api/main.go` to
+   cache values in Redis. Then write a test that faults Redis with
+   `connect=deny("ECONNREFUSED")` and verifies the API still works
+   (falls back to Postgres).
+
+2. **Read the trace**: Run the write_failure test with `--output trace.json`.
+   Open the JSON and find the `pwrite64` syscall events with
+   `decision: "deny(input/output error)"`. What files was Postgres trying
+   to write to? (Look at the `path` field.)
+
+3. **Build your own**: Create a new directory with a simple Go HTTP server
+   and Dockerfile. Declare it with `build="./my-svc"` in a .star file.
+   Verify it builds and starts correctly.
+
+4. **Multiple faults**: Write a test that faults BOTH Postgres (write=EIO)
+   and the API (connect=delay("1s")). What happens when everything is broken
+   at once?

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,0 +1,41 @@
+# Faultbox Tutorial
+
+Learn fault injection for distributed systems — from your first syscall fault to
+testing real Postgres containers. Each chapter introduces one concept and builds
+on the previous.
+
+## Prerequisites
+
+- **Go 1.24+** installed
+- **Linux** with kernel 5.6+ (seccomp-notify). On macOS, use the Lima VM:
+  ```bash
+  make env-create   # one-time setup
+  make env-start    # start VM
+  ```
+- **Docker** (chapter 7 only)
+
+## Build
+
+```bash
+make build                    # faultbox CLI
+make demo-build               # demo binaries (cross-compile for Lima VM)
+```
+
+For Lima VM, all commands run via:
+```bash
+limactl shell --workdir /host-home/git/Faultbox faultbox-dev -- <command>
+```
+
+## Chapters
+
+| # | Title | Concept | You'll use |
+|---|-------|---------|------------|
+| 1 | [Your First Fault](01-first-fault.md) | `faultbox run`, syscall interception | `poc/target` binary |
+| 2 | [Writing Your First Test](02-first-test.md) | Starlark specs, services, assertions | `poc/mock-db` |
+| 3 | [Fault Injection in Tests](03-fault-injection.md) | `fault()`, `deny()`, `delay()`, multi-service | `poc/mock-api` + `poc/mock-db` |
+| 4 | [Traces & Assertions](04-traces-assertions.md) | Temporal assertions, event log, ShiViz | `poc/demo` (order + inventory) |
+| 5 | [Exploring Concurrency](05-concurrency.md) | `parallel()`, seed replay, exhaustive | `poc/demo` |
+| 6 | [Monitors & Partitions](06-monitors-partitions.md) | `monitor()`, `partition()`, safety | `poc/demo` |
+| 7 | [Containers](07-containers.md) | Docker, `image=`, `build=`, real Postgres | `poc/demo-container` |
+
+Each chapter takes 15-30 minutes and ends with exercises.


### PR DESCRIPTION
## Summary

Progressive tutorial that teaches Faultbox from scratch:

| Ch | Title | Concept |
|----|-------|---------|
| 1 | Your First Fault | `faultbox run`, errno, delay, path targeting |
| 2 | Writing Your First Test | Starlark specs, services, healthchecks, assertions |
| 3 | Fault Injection in Tests | `fault()`, `deny()`, `delay()`, syscall families |
| 4 | Traces & Assertions | Temporal assertions, event log, JSON/ShiViz output |
| 5 | Exploring Concurrency | `parallel()`, seed replay, exhaustive exploration |
| 6 | Monitors & Partitions | `monitor()`, `partition()`, safety properties |
| 7 | Containers | Docker `image=`, `build=`, Postgres + Redis |

Each chapter has exercises. All use existing poc/ binaries — no new code.
1,200 lines, 8 files in `docs/tutorial/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)