### PR TITLE
docs: Add Chapter 0 (Setup), fix all binary paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ demo-build:
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/faultbox-shim  ./cmd/faultbox-shim/
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/inventory-svc  ./poc/demo/inventory-svc/
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/order-svc      ./poc/demo/order-svc/
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/mock-db        ./poc/mock-db/
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/mock-api       ./poc/mock-api/
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o $(LINUX_BIN)/target         ./poc/target/
 	@echo "Binaries: $(LINUX_BIN)/"
 
 demo: demo-build

--- a/docs/tutorial/00-setup.md
+++ b/docs/tutorial/00-setup.md
@@ -1,0 +1,142 @@
+# Chapter 0: Setup
+
+**Duration:** 10 minutes
+
+## Why a setup chapter?
+
+Faultbox uses Linux's seccomp-notify, which only works on Linux kernel 5.6+.
+If you're on macOS, you'll run everything inside a lightweight Linux VM (Lima).
+This chapter gets your environment ready so every subsequent chapter "just works."
+
+## Step 1: Clone and build
+
+```bash
+git clone https://github.com/faultbox/Faultbox.git
+cd Faultbox
+```
+
+## Step 2: Choose your platform
+
+### Linux (native)
+
+You're running directly on Linux. Build everything:
+
+```bash
+make build          # builds bin/faultbox (host binary)
+go build -o bin/target     ./poc/target/
+go build -o bin/mock-db    ./poc/mock-db/
+go build -o bin/mock-api   ./poc/mock-api/
+```
+
+Verify:
+```bash
+bin/faultbox --help
+```
+
+For the rest of the tutorial, all commands use `bin/` paths:
+```bash
+bin/faultbox run ...
+bin/target
+bin/mock-db
+```
+
+### macOS (via Lima VM)
+
+Lima creates a lightweight Linux VM that mounts your Mac's filesystem.
+Faultbox binaries are cross-compiled for Linux and run inside the VM.
+
+**One-time setup:**
+```bash
+brew install lima              # if not installed
+make env-create                # creates and starts the 'faultbox-dev' VM (~2 min)
+```
+
+**Every session:**
+```bash
+make env-start                 # start the VM (if stopped)
+make demo-build                # cross-compile ALL binaries for linux/arm64
+```
+
+This builds into `bin/linux-arm64/`:
+```
+bin/linux-arm64/
+├── faultbox        # CLI
+├── faultbox-shim   # container entrypoint shim
+├── target          # chapter 1
+├── mock-db         # chapters 2-3
+├── mock-api        # chapter 3
+├── inventory-svc   # chapters 4-6
+└── order-svc       # chapters 4-6
+```
+
+**Running commands inside the VM:**
+
+Every faultbox command is wrapped with `limactl shell`:
+```bash
+limactl shell --workdir /host-home/git/Faultbox faultbox-dev -- <command>
+```
+
+For convenience, you can alias it:
+```bash
+alias vm='limactl shell --workdir /host-home/git/Faultbox faultbox-dev --'
+```
+
+Then:
+```bash
+vm bin/linux-arm64/faultbox --help
+vm bin/linux-arm64/target
+```
+
+**Binary paths on macOS:** Throughout the tutorial, when you see `bin/faultbox`
+or `bin/target`, use `bin/linux-arm64/faultbox` or `bin/linux-arm64/target`
+instead, and run inside the VM.
+
+## Step 3: Verify it works
+
+**Linux:**
+```bash
+bin/faultbox --help
+bin/target
+```
+
+**macOS:**
+```bash
+vm bin/linux-arm64/faultbox --help
+vm bin/linux-arm64/target
+```
+
+You should see:
+```
+PID: 12345
+filesystem: write+read OK (2ms)
+network: HTTP 200 OK (150ms)
+```
+
+If you see this, you're ready for Chapter 1.
+
+## Step 4: Docker (chapter 7 only)
+
+Docker is only needed for Chapter 7 (containers). Skip this for now.
+
+**Linux:** Install Docker normally.
+
+**macOS:** Docker is already installed inside the Lima VM. Verify:
+```bash
+vm docker version
+```
+
+Container tests require `sudo`:
+```bash
+vm sudo bin/linux-arm64/faultbox test poc/demo-container/faultbox.star
+```
+
+## Quick reference
+
+| What | Linux | macOS (Lima) |
+|------|-------|-------------|
+| Build | `make build` | `make demo-build` |
+| Faultbox binary | `bin/faultbox` | `bin/linux-arm64/faultbox` (run inside VM) |
+| Target binary | `bin/target` | `bin/linux-arm64/target` (run inside VM) |
+| Run command | `bin/faultbox run ...` | `vm bin/linux-arm64/faultbox run ...` |
+| Test command | `bin/faultbox test ...` | `vm bin/linux-arm64/faultbox test ...` |
+| Container test | `sudo bin/faultbox test ...` | `vm sudo bin/linux-arm64/faultbox test ...` |

--- a/docs/tutorial/01-first-fault.md
+++ b/docs/tutorial/01-first-fault.md
@@ -1,7 +1,7 @@
 # Chapter 1: Your First Fault
 
 **Duration:** 15 minutes
-**Platform:** Linux native, or macOS via Lima VM (noted below)
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 
@@ -37,32 +37,22 @@ Your program                    Kernel                     Faultbox
 This works on **any binary** — Go, Rust, C, Java, Python. No code changes,
 no special libraries. The kernel is the interception point.
 
-## Build
+## Run the target program normally
+
+The `target` binary is a simple Go program that writes a file, reads it back,
+and makes an HTTP request.
 
 **Linux:**
 ```bash
-make build
-go build -o /tmp/target ./poc/target/
+bin/target
 ```
 
-**macOS (Lima VM):**
+**macOS (Lima):**
 ```bash
-make demo-build    # cross-compiles to bin/linux-arm64/
-# All faultbox commands below run inside Lima:
-# limactl shell faultbox-dev -- <command>
+vm bin/linux-arm64/target
 ```
 
-## The target program
-
-`poc/target/main.go` is a simple program that:
-1. Writes a file to `/tmp/faultbox-target-test`
-2. Reads it back
-3. Makes an HTTP request to `httpbin.org`
-
-Run it normally:
-```bash
-/tmp/target
-```
+You'll see:
 ```
 PID: 12345
 filesystem: write+read OK (2ms)
@@ -73,11 +63,17 @@ Everything works. Now break it.
 
 ## Inject a write fault
 
+**Linux:**
 ```bash
-faultbox run --fault "write=EIO:100%" /tmp/target
+bin/faultbox run --fault "write=EIO:100%" bin/target
 ```
 
-The program fails. Every `write()` syscall returns EIO (I/O error). The file
+**macOS (Lima):**
+```bash
+vm bin/linux-arm64/faultbox run --fault "write=EIO:100%" bin/linux-arm64/target
+```
+
+The program fails! Every `write()` syscall returns EIO (I/O error). The file
 operation errors out because the kernel told the program "I/O error" — and
 the program believed it.
 
@@ -89,8 +85,14 @@ answer these questions before production does.
 
 Real failures are intermittent. Make writes fail 30% of the time:
 
+**Linux:**
 ```bash
-faultbox run --fault "write=EIO:30%" /tmp/target
+bin/faultbox run --fault "write=EIO:30%" bin/target
+```
+
+**macOS (Lima):**
+```bash
+vm bin/linux-arm64/faultbox run --fault "write=EIO:30%" bin/linux-arm64/target
 ```
 
 Run it several times. Sometimes it works, sometimes it fails. This is how
@@ -101,8 +103,14 @@ works when failures are 100%, it might not work when they're 5%.
 
 Deny opens only for files under `/data/`:
 
+**Linux:**
 ```bash
-faultbox run --fault "openat=ENOENT:100%:/data/*" /tmp/target
+bin/faultbox run --fault "openat=ENOENT:100%:/data/*" bin/target
+```
+
+**macOS (Lima):**
+```bash
+vm bin/linux-arm64/faultbox run --fault "openat=ENOENT:100%:/data/*" bin/linux-arm64/target
 ```
 
 The target writes to `/tmp/` (not `/data/`), so it succeeds. **The intuition:**
@@ -113,8 +121,14 @@ Path targeting lets you simulate exactly that.
 
 Slow down every write by 500ms:
 
+**Linux:**
 ```bash
-faultbox run --fault "write=delay:500ms:100%" /tmp/target
+bin/faultbox run --fault "write=delay:500ms:100%" bin/target
+```
+
+**macOS (Lima):**
+```bash
+vm bin/linux-arm64/faultbox run --fault "write=delay:500ms:100%" bin/linux-arm64/target
 ```
 
 The filesystem operation now takes >500ms. **The intuition:** slow I/O is
@@ -152,8 +166,10 @@ topology and test scenarios as code.
 
 3. **Combined faults**:
    ```bash
-   faultbox run --fault "write=EIO:50%" --fault "connect=delay:1s:100%" /tmp/target
+   bin/faultbox run --fault "write=EIO:50%" --fault "connect=delay:1s:100%" bin/target
    ```
+   (On macOS, use `vm bin/linux-arm64/faultbox ...` with `bin/linux-arm64/target`)
+
    What's the combined effect? Which fails first?
 
 4. **Explore errno values**: Try `ENOSPC` (disk full), `EPERM` (permission

--- a/docs/tutorial/02-first-test.md
+++ b/docs/tutorial/02-first-test.md
@@ -1,7 +1,7 @@
 # Chapter 2: Writing Your First Test
 
 **Duration:** 20 minutes
-**Platform:** Linux native, or macOS via Lima VM
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 
@@ -29,16 +29,11 @@ Faultbox uses Starlark — a Python dialect designed for configuration.
 If you know Python, you know Starlark. No imports, no classes, no exceptions.
 Just functions, variables, and data. Configuration is code.
 
-## Build the mock database
+## The mock database
 
-**Linux and macOS (same):**
-```bash
-go build -o /tmp/mock-db ./poc/mock-db/
-```
+The mock-db binary was built in Chapter 0 (`make build` or `make demo-build`).
 
-**macOS (Lima):** The binary is already cross-compiled by `make demo-build`.
-
-This is a simple TCP key-value store:
+It's a simple TCP key-value store:
 ```
 PING       -> PONG
 SET k v    -> OK
@@ -48,10 +43,11 @@ QUIT       -> closes connection
 
 ## Your first spec file
 
-Create `my-first-test.star`:
+Create `my-first-test.star`. The binary path depends on your platform:
 
+**Linux:**
 ```python
-db = service("db", "/tmp/mock-db",
+db = service("db", "bin/mock-db",
     interface("main", "tcp", 5432),
     healthcheck = tcp("localhost:5432"),
 )
@@ -59,6 +55,12 @@ db = service("db", "/tmp/mock-db",
 def test_ping():
     resp = db.main.send(data="PING")
     assert_eq(resp, "PONG")
+```
+
+**macOS (Lima):** use the cross-compiled path:
+```python
+db = service("db", "bin/linux-arm64/mock-db",
+    ...
 ```
 
 Let's break this down:
@@ -72,8 +74,14 @@ specification — a concrete, executable claim about system behavior.
 
 ## Run it
 
+**Linux:**
 ```bash
-faultbox test my-first-test.star
+bin/faultbox test my-first-test.star
+```
+
+**macOS (Lima):**
+```bash
+vm bin/linux-arm64/faultbox test my-first-test.star
 ```
 
 ```
@@ -162,14 +170,14 @@ def test_set_and_get():
     assert_eq(resp, "hello")
 ```
 
-Run all:
+Run all (on Linux; on macOS prefix with `vm bin/linux-arm64/`):
 ```bash
-faultbox test my-first-test.star
+bin/faultbox test my-first-test.star
 ```
 
 Run one:
 ```bash
-faultbox test my-first-test.star --test set_and_get
+bin/faultbox test my-first-test.star --test set_and_get
 ```
 
 **Each test is independent.** The database restarts between tests, so

--- a/docs/tutorial/03-fault-injection.md
+++ b/docs/tutorial/03-fault-injection.md
@@ -1,7 +1,7 @@
 # Chapter 3: Fault Injection in Tests
 
 **Duration:** 25 minutes
-**Platform:** Linux native, or macOS via Lima VM
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 
@@ -25,28 +25,24 @@ This chapter teaches you to:
 After this chapter, your mental checklist for any new feature will include:
 "what are the failure modes, and have I tested each one?"
 
-## Build the two-service system
+## The two-service system
 
-**Linux and macOS (same):**
-```bash
-go build -o /tmp/mock-db ./poc/mock-db/
-go build -o /tmp/mock-api ./poc/mock-api/
-```
+Both binaries were built in Chapter 0 (`make build` or `make demo-build`).
 
 The mock-api is an HTTP service that stores data in mock-db via TCP.
 Two services, one dependency — the simplest distributed system.
 
 ## Topology with dependencies
 
-Create `fault-test.star`:
+Create `fault-test.star` (use `bin/linux-arm64/` paths on macOS):
 
 ```python
-db = service("db", "/tmp/mock-db",
+db = service("db", "bin/mock-db",
     interface("main", "tcp", 5432),
     healthcheck = tcp("localhost:5432"),
 )
 
-api = service("api", "/tmp/mock-api",
+api = service("api", "bin/mock-api",
     interface("public", "http", 8080),
     env = {"PORT": "8080", "DB_ADDR": db.main.addr},
     depends_on = [db],
@@ -60,6 +56,11 @@ def test_happy_path():
     resp = api.get(path="/data/mykey")
     assert_eq(resp.status, 200)
     assert_eq(resp.body, "myvalue")
+```
+
+Run it (on macOS: `vm bin/linux-arm64/faultbox test fault-test.star`):
+```bash
+bin/faultbox test fault-test.star
 ```
 
 Notice: `depends_on = [db]` tells Faultbox to start db before api.

--- a/docs/tutorial/04-traces-assertions.md
+++ b/docs/tutorial/04-traces-assertions.md
@@ -1,7 +1,7 @@
 # Chapter 4: Traces & Assertions
 
 **Duration:** 25 minutes
-**Platform:** Linux native, or macOS via Lima VM
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 
@@ -32,17 +32,10 @@ verify the *mechanism* that produced them.
 Chapters 4-6 use the full demo: an order service that talks to an inventory
 service with a write-ahead log (WAL).
 
-**Linux:**
-```bash
-make demo-build
-cp bin/linux-arm64/order-svc bin/linux-arm64/inventory-svc /tmp/
-```
+Binaries were built in Chapter 0. Run the demo (on macOS: prefix with `vm`):
 
-**macOS (Lima):** Binaries are already in `bin/linux-arm64/` after `make demo-build`.
-
-Run the demo:
 ```bash
-faultbox test poc/demo/faultbox.star
+bin/faultbox test poc/demo/faultbox.star
 ```
 
 ## The event log

--- a/docs/tutorial/05-concurrency.md
+++ b/docs/tutorial/05-concurrency.md
@@ -1,7 +1,7 @@
 # Chapter 5: Exploring Concurrency
 
 **Duration:** 25 minutes
-**Platform:** Linux native, or macOS via Lima VM
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 

--- a/docs/tutorial/06-monitors-partitions.md
+++ b/docs/tutorial/06-monitors-partitions.md
@@ -1,7 +1,7 @@
 # Chapter 6: Monitors & Network Partitions
 
 **Duration:** 20 minutes
-**Platform:** Linux native, or macOS via Lima VM
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed
 
 ## Goals & Purpose
 

--- a/docs/tutorial/07-containers.md
+++ b/docs/tutorial/07-containers.md
@@ -1,7 +1,7 @@
 # Chapter 7: Containers — Real Infrastructure
 
 **Duration:** 30 minutes
-**Platform:** Linux with Docker, or macOS via Lima VM (Docker inside VM)
+**Prerequisites:** [Chapter 0 (Setup)](00-setup.md) completed, Docker running
 
 ## Goals & Purpose
 

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -35,6 +35,7 @@ make demo-build     # cross-compile for Lima VM (linux/arm64)
 
 | # | Title | Duration | You'll learn why |
 |---|-------|----------|-----------------|
+| 0 | [Setup](00-setup.md) | 10 min | Build binaries, configure Lima VM (macOS), verify everything works |
 | 1 | [Your First Fault](01-first-fault.md) | 15 min | How the OS can lie to your program — and why that's useful |
 | 2 | [Writing Your First Test](02-first-test.md) | 20 min | How to codify "this system works" as a repeatable spec |
 | 3 | [Fault Injection in Tests](03-fault-injection.md) | 25 min | How to answer "what happens when X fails?" systematically |


### PR DESCRIPTION
## Summary

Fixes two problems found while doing Chapter 1:
1. No build/install step — `faultbox` not found
2. Binary paths (`/tmp/target`) don't exist on macOS/Lima

Changes:
- **New Chapter 0 (Setup):** Platform-specific build, Lima VM alias, path reference table
- **All chapters:** Prerequisites link to Ch 0, correct `bin/` paths, Linux/macOS variants
- **Makefile:** `demo-build` now builds all 7 tutorial binaries (was missing mock-db, mock-api, target)

Verified: `make demo-build` produces all binaries, `target` runs in Lima VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)