### PR TITLE
fix: faultbox run was broken — ExternalListenerFd zero-value trap

### DIFF
--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -115,13 +115,14 @@ doneFlags:
 	ctx = logging.NewContext(ctx, logger)
 
 	cfg := engine.SessionConfig{
-		Binary:     args[0],
-		Args:       args[1:],
-		Env:        envVars,
-		Stdout:     os.Stdout,
-		Stderr:     os.Stderr,
-		Namespaces: engine.DefaultNamespaces(),
-		FaultRules: faultRules,
+		Binary:             args[0],
+		Args:               args[1:],
+		Env:                envVars,
+		Stdout:             os.Stdout,
+		Stderr:             os.Stderr,
+		Namespaces:         engine.DefaultNamespaces(),
+		FaultRules:         faultRules,
+		ExternalListenerFd: -1, // not external — launch the binary
 	}
 
 	result, err := eng.Run(ctx, cfg)

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -97,6 +97,8 @@ type SessionConfig struct {
 	// ExternalListenerFd is set when the seccomp listener was created externally
 	// (e.g., by a container shim). When >= 0, the session skips binary launch and
 	// runs only the notification loop on this fd.
+	// IMPORTANT: Set to -1 for normal binary launch. Go's zero value (0) is a
+	// valid fd and would incorrectly trigger the external path.
 	ExternalListenerFd int
 	// ExternalPID is the target process PID (host namespace) when using an
 	// external listener. Used for process memory reads in the notification loop.


### PR DESCRIPTION
## Summary

`faultbox run --fault "write=EIO:100%" bin/target` did nothing — session
started and immediately exited with `pid=0, listener_fd=0, duration=1ms`.

**Root cause:** `SessionConfig.ExternalListenerFd` defaults to 0 (Go zero
value), which is a valid fd (stdin). The session check `>= 0` triggered
the external/container path instead of launching the binary.

**Fix:** Set `ExternalListenerFd: -1` in runCmd. Added warning comment
on the struct field.

Found while testing Chapter 1 of the tutorial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)