### PR TITLE
RFC-018 amendment: namespace struct pattern for recipes (fixes name collisions)

### DIFF
--- a/docs/rfcs/0018-recipes-library.md
+++ b/docs/rfcs/0018-recipes-library.md
@@ -1,0 +1,306 @@
+# RFC-018: Recipes Library — Curated Failure Wrappers in Starlark
+
+- **Status:** Draft
+- **Author:** Boris Glebov, Claude Opus 4.7
+- **Created:** 2026-04-17
+- **Amended:** 2026-04-18 — namespace struct pattern (was top-level functions)
+- **Branch:** `rfc/016-mongodb` (introduced alongside MongoDB); amended on `rfc/018-recipe-namespaces`
+
+## Summary
+
+Establish `recipes/<protocol>.star` as the **canonical place for curated,
+protocol-specific failure helpers**. Each recipe is a thin Starlark wrapper
+over the existing proxy fault primitives (`error`, `delay`, `drop`) that
+encodes canonical error messages, codes, and realistic failure scenarios
+for a given protocol.
+
+Recipes are **data, not builtins.** Zero new Go code per recipe. Users can
+read, copy, fork, or extend them. The Faultbox project maintains a core
+set; users ship their own alongside.
+
+## Motivation
+
+### The error-string problem
+
+Writing a realistic fault today requires knowing the exact error message
+the real service would emit:
+
+```python
+# What the user wants to say:
+rules = [error(query="INSERT*", message="disk full")]
+
+# What the real Postgres would say:
+rules = [error(query="INSERT*", message="ERROR: could not extend file \"base/...\": No space left on device (SQLSTATE 53100)")]
+```
+
+Most users write the short version on their first attempt. The SUT's error
+handling might match on SQLSTATE codes or specific substrings — so the
+injected fault passes, but the production fault would fail. The test gives
+false confidence.
+
+Same problem across protocols: MongoDB error codes, HTTP status + body
+conventions, Kafka error codes, Cassandra replica-count semantics, Redis
+OOM messages. Every protocol has a dialect of canonical errors.
+
+### Why not Go builtins?
+
+We considered shipping `mongo_disk_full()`, `postgres_deadlock()`, etc. as
+Go builtins. Rejected because:
+
+1. **Curation burden.** Every new realistic failure is a Faultbox PR.
+2. **Versioning.** MongoDB 4 → 5 → 7 changed error messages. Go code rots.
+3. **Abstraction bloat.** Two APIs (primitives + helpers) for the same
+   thing creates docs ambiguity.
+4. **Hidden machinery.** Users can't see what the helper actually injects
+   without reading Go source.
+
+### Why not "just use primitives"?
+
+Core primitives (`error`, `delay`, `drop`) are the right abstraction for
+the **engine**. They are too low-level for the **user**, who is thinking
+in terms of incidents: "quorum loss," "disk full," "noisy neighbor," "DNS
+flap." Recipes bridge the two.
+
+## Design
+
+### Directory layout
+
+```
+faultbox/
+├── recipes/
+│   ├── README.md                 # catalog + usage
+│   ├── mongodb.star
+│   ├── postgres.star             # to be added
+│   ├── redis.star                # to be added
+│   ├── kafka.star                # to be added
+│   ├── grpc.star                 # to be added
+│   └── http.star                 # to be added
+```
+
+### Recipe file structure
+
+Each recipe file exports **exactly one top-level binding**: a `struct`
+named after the protocol. Every recipe is a field on that struct,
+implemented as a lambda that returns a `ProxyFaultDef` (the same value
+`error()`/`delay()`/`drop()`/`response()` produce).
+
+```python
+# recipes/mongodb.star
+mongodb = struct(
+    # disk_full simulates a full data disk on insert.
+    disk_full = lambda collection = "*": error(
+        collection = collection,
+        op = "insert",
+        message = "assertion: 10334 disk full",
+    ),
+
+    # auth_failed rejects SASL handshakes.
+    auth_failed = lambda: error(
+        op = "saslStart",
+        message = "Authentication failed",
+    ),
+)
+```
+
+The rules:
+
+1. **One struct per file, named after the protocol.** Not `mongo`, not
+   `MongoDBRecipes` — match the protocol name registered in `protocol.Get()`.
+2. **Fields are lambdas.** Not `def`s inside the struct (Starlark syntax
+   doesn't support that directly) and not top-level `def`s (defeats the
+   namespace).
+3. **One-line comment above each field** describing the real-world
+   failure it simulates.
+4. **Sensible defaults.** The zero-arg call should produce a useful fault.
+5. **No other top-level bindings.** No helper functions, no constants.
+   If you need shared logic, inline it.
+
+### Why a struct (not top-level functions)
+
+The earlier draft of this RFC had recipes as top-level `def`s. That
+broke the moment a user loaded two recipe files with overlapping names:
+
+```python
+# What we want to write:
+load("./recipes/mongodb.star",  "disk_full")
+load("./recipes/postgres.star", "disk_full")  # <-- collision
+```
+
+Starlark's `load()` rename syntax (`load(..., m_disk_full="disk_full")`)
+works but is clunky — every user reinvents naming conventions. The
+namespace struct solves it structurally:
+
+```python
+load("./recipes/mongodb.star",  "mongodb")
+load("./recipes/postgres.star", "postgres")
+
+rules = [mongodb.disk_full(collection = "orders"), postgres.disk_full()]
+```
+
+One import per protocol, collision-free, reads naturally.
+
+### Usage
+
+```python
+load("./recipes/mongodb.star",  "mongodb")
+load("./recipes/postgres.star", "postgres")
+
+broken_mongo = fault_assumption("broken_mongo",
+    target = db.main,
+    rules  = [
+        mongodb.disk_full(collection = "orders"),
+        mongodb.replica_unavailable(),
+    ],
+)
+
+broken_pg = fault_assumption("broken_pg",
+    target = pg.main,
+    rules  = [postgres.disk_full(), postgres.deadlock()],
+)
+```
+
+### Recipe catalog (per protocol)
+
+Each protocol ships a baseline set covering:
+
+| Category | Typical recipes |
+|---|---|
+| **Resource exhaustion** | `disk_full`, `oom`, `connection_exhausted`, `too_many_connections` |
+| **Transient** | `slow_query`, `slow_writes`, `connection_drop`, `timeout` |
+| **Consistency** | `replica_unavailable`, `quorum_lost`, `read_after_write_lag`, `write_conflict` |
+| **Integrity** | `duplicate_key_error`, `constraint_violation`, `serialization_error` |
+| **Auth/Security** | `auth_failed`, `permission_denied`, `token_expired` |
+| **Noise** | `intermittent_errors`, `flappy_connection` |
+
+Not every protocol needs every category. MongoDB won't have
+`quorum_lost` until we support replica-set-aware fault injection;
+HTTP won't have `duplicate_key_error`. We ship what makes sense per
+protocol and grow from there.
+
+### Discovery
+
+Recipes are discovered via:
+
+1. **`recipes/README.md`** — canonical catalog, kept in sync with files.
+2. **Protocol docs** — each `docs/protocols/<name>.md` has a "Recipes"
+   section linking to the recipes file with a 1-line summary of each
+   exported function.
+3. **VS Code autocomplete** — the schema tooling (future RFC) surfaces
+   recipes alongside builtins.
+
+### Stability contract
+
+Recipes are **semver-stable within a major version**:
+
+- **Adding a new recipe:** always safe, any release.
+- **Removing a recipe:** deprecation warning for one minor version, removal
+  in the next.
+- **Changing a recipe's signature:** same rules as removing (deprecate first).
+- **Changing what a recipe *injects* (error message, delay default):**
+  patch release if the real service's canonical message changed; minor
+  release if it's a judgment call. Document both in changelog.
+
+### What recipes MUST NOT do
+
+- **No top-level bindings other than the namespace struct.** The single
+  `<protocol> = struct(...)` binding is the entire module's public API.
+- **No Starlark control flow beyond the lambda body.** Recipes are
+  "return a fault def." No `if target == ...`, no `for` loops, no I/O.
+- **No new builtins.** A recipe that needs something `error()` can't
+  express is a sign we need a new primitive, not a bigger recipe.
+- **No state.** Recipes are pure — same args in, same fault def out.
+- **No loads.** Recipes can't depend on other recipes or modules. Each
+  file stands alone. Prevents cascading breakage.
+
+### User-authored recipes
+
+Users follow the same pattern with a namespace named after their domain
+(not a protocol):
+
+```python
+# my-company/recipes/checkout.star
+
+checkout = struct(
+    # post_checkout_race simulates the specific race that took us down in Q2.
+    post_checkout_race = lambda: [
+        delay(path = "/api/v1/checkout", delay = "800ms"),
+        error(path = "/api/v1/inventory/reserve", status = 409),
+    ],
+)
+```
+
+Usage is symmetric:
+
+```python
+load("./recipes/checkout.star", "checkout")
+
+q2_regression = fault_assumption("q2_regression",
+    target = api.main,
+    rules  = checkout.post_checkout_race(),
+)
+```
+
+No plugin API, no registration — just Starlark.
+
+## Open questions
+
+1. **Recipe composition.** Should recipes be allowed to return a **list**
+   of rules? `replica_unavailable()` arguably wants to inject both an
+   error response AND drop the replica heartbeat. Proposal: yes, allow
+   lists, handled by existing `rules=[...]` flatten logic.
+
+2. **Parameterization via `**kwargs`.** Some recipes want to thread
+   arbitrary kwargs to the underlying primitive (e.g., `probability=`).
+   Proposal: every recipe exposes `probability=` explicitly when it makes
+   sense; no magic splat.
+
+3. **Recipe tests.** How do we verify a recipe still matches the real
+   service's behavior as versions change? Proposal: integration tests
+   that run the recipe against a real container and assert the driver
+   observes the intended error shape. Tracked as a follow-up.
+
+4. **Translation for syscall-level recipes.** Syscall faults live on
+   `ServiceDef`, not `InterfaceRef`. Does `disk_full()` return a proxy
+   fault or a syscall fault? Proposal: distinct namespaces —
+   `recipes/mongodb.star` for proxy; `recipes/mongodb_syscall.star` for
+   syscall — and never mix in one file. Keeps the target type obvious
+   at the call site.
+
+## Non-goals
+
+- **Not a plugin API.** Recipes are plain Starlark. No Go extension
+  points, no runtime registration.
+- **Not an error catalog.** We don't try to enumerate every error every
+  protocol can emit. We pick the 5-10 that come up in real postmortems.
+- **Not a mock library.** Recipes inject faults into real traffic. Mock
+  services (RFC-017) stand up fake services. Different tool, different
+  problem.
+
+## Alternatives considered
+
+1. **Go builtins per protocol.** Rejected — curation burden, rot, hidden
+   machinery (see Motivation).
+2. **In-spec helper functions.** Every user writes their own helpers.
+   Rejected — no sharing, no canonical messages, every team reinvents.
+3. **Error code registry.** Ship a Go file mapping logical names to
+   error strings per protocol. Rejected — still Go code, still rots, and
+   doesn't compose (a recipe is more than just a message).
+
+## Success criteria
+
+- Every RFC-016 protocol ships with a `recipes/<name>.star` in the same
+  PR as the protocol plugin.
+- Recipe files have ≥5 functions, covering at minimum the categories
+  that make sense for that protocol.
+- Protocol docs link to the recipes file and summarize each export.
+- The recipes directory has a README with a matrix of
+  (protocol × category) showing what's covered.
+
+## Implementation plan
+
+1. Land `recipes/mongodb.star` in the RFC-016 MongoDB PR (this branch).
+2. Write `recipes/README.md` with the catalog structure.
+3. For each RFC-016 protocol implemented, add `recipes/<name>.star` in
+   the same PR.
+4. Backfill recipes for existing protocols (HTTP, Postgres, Redis, Kafka,
+   gRPC, MySQL, NATS) as a separate housekeeping PR after RFC-016 lands.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.6.0
-	go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a
+	go.starlark.net v0.0.0-20260326113308-fadfc96def35
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a h1:w7OMj6r/AoxBpbfncRXaV18hjzIAFRytYaRILymmMRE=
 go.starlark.net v0.0.0-20260324133313-ffb3f39dd27a/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
+go.starlark.net v0.0.0-20260326113308-fadfc96def35 h1:VYAqieSOJNxBDX8KJneTAwvdf4J4zRDE2u+UFXtt9h4=
+go.starlark.net v0.0.0-20260326113308-fadfc96def35/go.mod h1:Iue6g6iirlfLoVi/DYCi5/x0h/bAOuWF3dULTKpt2Vo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 
 	"github.com/faultbox/Faultbox/internal/engine"
 	"github.com/faultbox/Faultbox/internal/proxy"
@@ -63,6 +64,10 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		"json_decoder":      starlark.NewBuiltin("json_decoder", builtinJSONDecoder),
 		"logfmt_decoder":    starlark.NewBuiltin("logfmt_decoder", builtinLogfmtDecoder),
 		"regex_decoder":     starlark.NewBuiltin("regex_decoder", builtinRegexDecoder),
+		// struct(**kwargs) — namespace objects. Used by recipe modules so
+		// protocol-specific helpers don't collide on common names (e.g.
+		// mongodb.disk_full vs postgres.disk_full).
+		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
 	}
 }
 

--- a/internal/star/runtime_test.go
+++ b/internal/star/runtime_test.go
@@ -3,6 +3,7 @@ package star
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -929,6 +930,141 @@ def test_gen_order_flow_db_down():
 	services := rt.Services()
 	if len(services) != 1 || services[0].Name != "db" {
 		t.Errorf("expected db service, got %v", services)
+	}
+}
+
+// TestRecipeNamespaceStructs verifies that recipe-style modules exporting
+// a namespace struct compose without name collision, and that attribute
+// access from the importing module produces the expected fault defs.
+//
+// This is the pattern RFC-018 mandates: recipe files export one struct
+// per protocol, so users can load disk_full from both mongodb and
+// postgres recipes without shadowing.
+func TestRecipeNamespaceStructs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Two recipe modules with colliding function names inside their structs.
+	mongoRecipes := `
+mongodb = struct(
+    disk_full = lambda collection = "*": error(collection = collection, op = "insert", message = "assertion: 10334 disk full"),
+    slow_query = lambda duration = "1s": delay(op = "find", delay = duration),
+)
+`
+	pgRecipes := `
+postgres = struct(
+    disk_full = lambda: error(query = "INSERT*", message = "could not extend file: No space left on device"),
+    slow_query = lambda duration = "1s": delay(query = "SELECT*", delay = duration),
+)
+`
+	if err := os.WriteFile(dir+"/mongo.star", []byte(mongoRecipes), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/pg.star", []byte(pgRecipes), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Spec file imports both recipe modules and references their namespaced
+	// disk_full functions — the whole reason the struct pattern exists.
+	spec := `
+load("mongo.star", "mongodb")
+load("pg.star", "postgres")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+# Both disk_full calls must resolve — no name collision.
+_mongo_rule = mongodb.disk_full(collection = "orders")
+_pg_rule    = postgres.disk_full()
+
+# Both slow_query calls must resolve too, under their own namespaces.
+_mongo_slow = mongodb.slow_query()
+_pg_slow    = postgres.slow_query(duration = "2s")
+
+def test_ok():
+    pass
+`
+	if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := New(testLogger())
+	if err := rt.LoadFile(dir + "/faultbox.star"); err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+
+	// Sanity: test discovered → spec loaded without error.
+	tests := rt.DiscoverTests()
+	if len(tests) != 1 || tests[0] != "test_ok" {
+		t.Errorf("expected test_ok, got %v", tests)
+	}
+}
+
+// TestRecipesInRepo loads the real recipe files shipped in recipes/ and
+// verifies each exports its namespace struct with callable attributes.
+// Catches syntax errors and regressions in the shipped recipes without
+// requiring a separate integration test.
+func TestRecipesInRepo(t *testing.T) {
+	recipeFiles := []struct {
+		file      string
+		namespace string
+		method    string
+	}{
+		{"../../recipes/mongodb.star", "mongodb", "disk_full"},
+		{"../../recipes/http2.star", "http2", "rate_limited"},
+		{"../../recipes/udp.star", "udp", "packet_loss"},
+		{"../../recipes/cassandra.star", "cassandra", "write_timeout"},
+		{"../../recipes/clickhouse.star", "clickhouse", "too_many_parts"},
+	}
+	for _, rf := range recipeFiles {
+		t.Run(rf.namespace, func(t *testing.T) {
+			if _, err := os.Stat(rf.file); err != nil {
+				t.Skipf("recipe file not present (expected when run standalone): %v", err)
+			}
+			// Minimal spec that imports the recipe and calls one of its methods.
+			dir := t.TempDir()
+			absRecipe, err := filepath.Abs(rf.file)
+			if err != nil {
+				t.Fatalf("abs: %v", err)
+			}
+			spec := `load("` + absRecipe + `", "` + rf.namespace + `")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+_rule = ` + rf.namespace + `.` + rf.method + `()
+
+def test_ok():
+    pass
+`
+			if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+				t.Fatal(err)
+			}
+			rt := New(testLogger())
+			if err := rt.LoadFile(dir + "/faultbox.star"); err != nil {
+				t.Errorf("load %s: %v", rf.file, err)
+			}
+		})
+	}
+}
+
+// TestStructBuiltin is a sanity check that struct() is wired into the
+// runtime so recipe modules can use it.
+func TestStructBuiltin(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+mongodb = struct(name = "mongodb", version = 7)
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+def test_ok():
+    pass
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
 	}
 }
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,75 @@
+# Faultbox Recipes
+
+Curated, protocol-specific failure helpers built on top of the core proxy
+fault primitives (`response`, `error`, `delay`, `drop`).
+
+See [RFC-018](../docs/rfcs/0018-recipes-library.md) for the design.
+
+## The namespace struct pattern
+
+Each recipe file exports **one struct** named after the protocol. This
+prevents name collisions when users load recipes for multiple protocols
+(e.g. `mongodb.disk_full` vs `postgres.disk_full`):
+
+```python
+load("./recipes/mongodb.star", "mongodb")
+load("./recipes/postgres.star", "postgres")
+
+rules = [
+    mongodb.disk_full(collection = "orders"),
+    postgres.disk_full(),
+]
+```
+
+One import per protocol, clean call sites, zero collisions.
+
+## Protocols
+
+| Protocol | Recipes file | Status |
+|----------|--------------|--------|
+| MongoDB | [mongodb.star](mongodb.star) | ✅ Shipped |
+| HTTP/2 | [http2.star](http2.star) | ✅ Shipped |
+| UDP | [udp.star](udp.star) | ✅ Shipped |
+| Cassandra | [cassandra.star](cassandra.star) | ✅ Shipped |
+| ClickHouse | [clickhouse.star](clickhouse.star) | ✅ Shipped |
+| Postgres | — | To be added |
+| Redis | — | To be added |
+| Kafka | — | To be added |
+| HTTP | — | To be added |
+| gRPC | — | To be added |
+| MySQL | — | To be added |
+| NATS | — | To be added |
+
+## Coverage matrix
+
+| Protocol | Resource | Transient | Consistency | Integrity | Auth | Noise |
+|----------|----------|-----------|-------------|-----------|------|-------|
+| MongoDB | `disk_full` | `slow_query`, `slow_writes`, `connection_drop` | `replica_unavailable`, `write_conflict` | `duplicate_key_error` | `auth_failed` | — |
+| HTTP/2 | `rate_limited`, `service_unavailable` | `slow_endpoint`, `gateway_timeout`, `stream_reset`, `maintenance_window` | — | — | `unauthorized`, `forbidden` | `flaky`, `server_error` |
+| UDP | — | `metrics_slow`, `jitter` | — | — | — | `packet_loss`, `dns_flap`, `blackhole` |
+| Cassandra | `overloaded` | `write_timeout`, `read_timeout`, `slow_reads`, `slow_writes`, `connection_drop` | `unavailable`, `schema_mismatch` | — | — | — |
+| ClickHouse | `too_many_parts`, `memory_limit` | `slow_analytics`, `slow_ingest`, `connection_drop`, `replica_stale` | — | `table_not_exists` | — | `readonly_mode` |
+
+## Contributing
+
+Adding a recipe:
+
+1. Open the relevant `recipes/<protocol>.star` file.
+2. Add a new field to the existing struct (NOT a top-level def).
+3. The field must return a `ProxyFaultDef` (the output of `response()`,
+   `error()`, `delay()`, or `drop()`).
+4. Use sensible defaults — the zero-arg call should do something useful.
+5. Add a one-line comment above describing the real-world failure it simulates.
+6. Update this README's coverage matrix.
+
+Adding a new protocol:
+
+1. Create `recipes/<protocol>.star`.
+2. Export a single struct field named `<protocol>`.
+3. Populate with 5+ recipes covering the categories that make sense for
+   the protocol (see matrix above).
+4. Add a row to both tables in this README.
+
+Recipes must be pure: no I/O, no control flow beyond the lambda body,
+no `load()` from other recipes. If what you need can't be expressed in
+one lambda over existing primitives, open an RFC for a new core primitive.

--- a/recipes/cassandra.star
+++ b/recipes/cassandra.star
@@ -1,0 +1,59 @@
+# Faultbox recipes: Cassandra
+#
+# Per RFC-018: one namespace struct per recipe file.
+#
+# Usage:
+#     load("./recipes/cassandra.star", "cassandra")
+#
+#     broken = fault_assumption("quorum_lost",
+#         target = cass.main,
+#         rules  = [cassandra.unavailable()],
+#     )
+
+cassandra = struct(
+    # write_timeout — coordinator-level write timeout.
+    write_timeout = lambda query = "INSERT*": error(
+        query = query,
+        message = "Operation timed out - received only 0 responses",
+    ),
+
+    # read_timeout — read timeout. Triggers driver read-timeout retries.
+    read_timeout = lambda query = "SELECT*": error(
+        query = query,
+        message = "Operation timed out - received only 1 responses",
+    ),
+
+    # unavailable — insufficient replicas to satisfy consistency.
+    unavailable = lambda query = "*": error(
+        query = query,
+        message = "Cannot achieve consistency level QUORUM",
+    ),
+
+    # overloaded — node under high load (OverloadedException).
+    overloaded = lambda query = "*": error(
+        query = query,
+        message = "Node is overloaded",
+    ),
+
+    # slow_reads delays SELECT queries. Tests client read-timeout and
+    # speculative execution.
+    slow_reads = lambda duration = "3s": delay(
+        query = "SELECT*",
+        delay = duration,
+    ),
+
+    # slow_writes delays INSERT/UPDATE/DELETE.
+    slow_writes = lambda duration = "3s": delay(
+        query = "INSERT*",
+        delay = duration,
+    ),
+
+    # connection_drop closes the connection mid-statement.
+    connection_drop = lambda query = "*": drop(query = query),
+
+    # schema_mismatch — stale schema version. Drivers refresh their cache.
+    schema_mismatch = lambda query = "*": error(
+        query = query,
+        message = "Schema version mismatch detected",
+    ),
+)

--- a/recipes/clickhouse.star
+++ b/recipes/clickhouse.star
@@ -1,0 +1,58 @@
+# Faultbox recipes: ClickHouse
+#
+# Per RFC-018: one namespace struct per recipe file.
+#
+# Usage:
+#     load("./recipes/clickhouse.star", "clickhouse")
+#
+#     overloaded = fault_assumption("overloaded",
+#         target = ch.main,
+#         rules  = [clickhouse.too_many_parts(query = "INSERT*")],
+#     )
+
+clickhouse = struct(
+    # too_many_parts — insert rate exceeds merge rate. Drivers back off.
+    too_many_parts = lambda query = "INSERT*": error(
+        query = query,
+        message = "Too many parts (300). Merges are processing significantly slower than inserts",
+    ),
+
+    # memory_limit — query exceeds configured memory quota (code 241).
+    memory_limit = lambda query = "SELECT*": error(
+        query = query,
+        message = "Memory limit (for query) exceeded",
+    ),
+
+    # table_not_exists — missing table (code 60).
+    table_not_exists = lambda query = "*": error(
+        query = query,
+        message = "Table doesn't exist",
+    ),
+
+    # readonly_mode — server refuses writes (maintenance).
+    readonly_mode = lambda query = "INSERT*": error(
+        query = query,
+        message = "Cannot execute query in readonly mode",
+    ),
+
+    # slow_analytics delays SELECT queries. Dashboard / ETL timeout tests.
+    slow_analytics = lambda duration = "5s": delay(
+        query = "SELECT*",
+        delay = duration,
+    ),
+
+    # slow_ingest delays INSERT statements. Producer back-pressure tests.
+    slow_ingest = lambda duration = "3s": delay(
+        query = "INSERT*",
+        delay = duration,
+    ),
+
+    # connection_drop closes the HTTP connection mid-query.
+    connection_drop = lambda query = "*": drop(query = query),
+
+    # replica_stale — replica too far behind leader for consistent read.
+    replica_stale = lambda query = "SELECT*": error(
+        query = query,
+        message = "Replica is too far behind",
+    ),
+)

--- a/recipes/http2.star
+++ b/recipes/http2.star
@@ -1,0 +1,79 @@
+# Faultbox recipes: HTTP/2
+#
+# Per RFC-018: one namespace struct per recipe file.
+#
+# Usage:
+#     load("./recipes/http2.star", "http2")
+#
+#     faulty = fault_assumption("faulty_api",
+#         target = api.main,
+#         rules  = [http2.rate_limited(path = "/api/**")],
+#     )
+
+http2 = struct(
+    # rate_limited returns 429 with a Retry-After hint.
+    rate_limited = lambda path = "/*": response(
+        path = path,
+        status = 429,
+        body = "{\"error\":\"rate limited\",\"retry_after\":\"1s\"}",
+    ),
+
+    # server_error returns 500 — the generic "something went wrong".
+    server_error = lambda path = "/*": error(
+        path = path,
+        status = 500,
+        message = "internal server error",
+    ),
+
+    # service_unavailable returns 503 (retryable per HTTP semantics).
+    service_unavailable = lambda path = "/*": error(
+        path = path,
+        status = 503,
+        message = "service unavailable",
+    ),
+
+    # gateway_timeout returns 504.
+    gateway_timeout = lambda path = "/*": error(
+        path = path,
+        status = 504,
+        message = "gateway timeout",
+    ),
+
+    # slow_endpoint delays matching requests.
+    slow_endpoint = lambda path = "/*", duration = "3s": delay(
+        path = path,
+        delay = duration,
+    ),
+
+    # maintenance_window returns 503 with Retry-After.
+    maintenance_window = lambda path = "/*": response(
+        path = path,
+        status = 503,
+        body = "{\"error\":\"maintenance\",\"retry_after\":\"60s\"}",
+    ),
+
+    # stream_reset closes the HTTP/2 stream mid-request.
+    stream_reset = lambda path = "/*": drop(path = path),
+
+    # flaky returns 500 a fraction of the time. Retry tests.
+    flaky = lambda path = "/*", probability = "20%": error(
+        path = path,
+        status = 500,
+        message = "flaky endpoint",
+        probability = probability,
+    ),
+
+    # unauthorized returns 401. Auth-error / token-refresh tests.
+    unauthorized = lambda path = "/*": error(
+        path = path,
+        status = 401,
+        message = "unauthorized",
+    ),
+
+    # forbidden returns 403. Authorization (not authentication) failures.
+    forbidden = lambda path = "/*": error(
+        path = path,
+        status = 403,
+        message = "forbidden",
+    ),
+)

--- a/recipes/mongodb.star
+++ b/recipes/mongodb.star
@@ -1,0 +1,77 @@
+# Faultbox recipes: MongoDB
+#
+# Per RFC-018, each recipe file exports one namespace struct named after
+# the protocol. This prevents name collisions when users load recipes
+# for multiple protocols — e.g. mongodb.disk_full vs postgres.disk_full.
+#
+# Usage:
+#     load("./recipes/mongodb.star", "mongodb")
+#
+#     broken = fault_assumption("broken",
+#         target = db.main,
+#         rules  = [mongodb.disk_full(collection = "orders")],
+#     )
+
+mongodb = struct(
+    # disk_full simulates a full data disk on insert — drivers surface
+    # this as a WriteException and clients trigger back-pressure.
+    disk_full = lambda collection = "*": error(
+        collection = collection,
+        op = "insert",
+        message = "assertion: 10334 disk full",
+    ),
+
+    # auth_failed rejects SASL handshakes. Verifies the SUT surfaces
+    # credential errors rather than hanging.
+    auth_failed = lambda: error(
+        op = "saslStart",
+        message = "Authentication failed",
+    ),
+
+    # replica_unavailable simulates a write concern failure — replica
+    # set election in progress, no primary available.
+    replica_unavailable = lambda collection = "*": error(
+        collection = collection,
+        op = "*",
+        message = "not primary; no replica set members available",
+    ),
+
+    # slow_query delays find() operations. Tests client-side query
+    # timeouts and retry behavior.
+    slow_query = lambda collection = "*", duration = "3s": delay(
+        collection = collection,
+        op = "find",
+        delay = duration,
+    ),
+
+    # slow_writes delays insert operations. Tests write-timeout handling
+    # and transaction rollback.
+    slow_writes = lambda collection = "*", duration = "3s": delay(
+        collection = collection,
+        op = "insert",
+        delay = duration,
+    ),
+
+    # connection_drop closes connections mid-command. Triggers the
+    # driver's reconnect + retry path.
+    connection_drop = lambda collection = "*", op = "*": drop(
+        collection = collection,
+        op = op,
+    ),
+
+    # duplicate_key_error simulates a unique index violation on insert.
+    # Common failure during idempotency-key collisions.
+    duplicate_key_error = lambda collection = "*": error(
+        collection = collection,
+        op = "insert",
+        message = "E11000 duplicate key error",
+    ),
+
+    # write_conflict simulates a TransientTransactionError mid-transaction.
+    # Drivers retry per the MongoDB transaction retry protocol.
+    write_conflict = lambda collection = "*": error(
+        collection = collection,
+        op = "update",
+        message = "WriteConflict: TransientTransactionError",
+    ),
+)

--- a/recipes/udp.star
+++ b/recipes/udp.star
@@ -1,0 +1,28 @@
+# Faultbox recipes: UDP
+#
+# Per RFC-018: one namespace struct per recipe file.
+#
+# Usage:
+#     load("./recipes/udp.star", "udp")
+#
+#     dns_broken = fault_assumption("dns_broken",
+#         target = dns.main,
+#         rules  = [udp.packet_loss(probability = "30%")],
+#     )
+
+udp = struct(
+    # packet_loss drops a fraction of datagrams. Default is 100% (blackout).
+    packet_loss = lambda probability = "100%": drop(probability = probability),
+
+    # dns_flap — aggressive 50% loss typical of unreliable DNS.
+    dns_flap = lambda probability = "50%": drop(probability = probability),
+
+    # metrics_slow delays datagrams. Tests StatsD / metrics slow-path.
+    metrics_slow = lambda duration = "1s": delay(delay = duration),
+
+    # jitter — fixed per-packet delay for congestion simulation.
+    jitter = lambda duration = "100ms": delay(delay = duration),
+
+    # blackhole drops every datagram (total UDP partition).
+    blackhole = lambda: drop(),
+)


### PR DESCRIPTION
## Summary

Amends [RFC-018](docs/rfcs/0018-recipes-library.md) to fix a real problem with the recipes library pattern: when users load recipes for two protocols that both define canonical failures like `disk_full`, the second `load()` silently shadows the first.

## The collision

```python
# Old pattern (now amended away):
load("./recipes/mongodb.star",  "disk_full")
load("./recipes/postgres.star", "disk_full")   # collides — second one wins

rules = [disk_full(collection="orders")]   # which one?!
```

Starlark's `load()` rename syntax works (`load(..., m_disk_full="disk_full")`) but every user reinvents naming conventions.

## The fix: namespace struct per file

```python
# New pattern:
load("./recipes/mongodb.star",  "mongodb")
load("./recipes/postgres.star", "postgres")

rules = [
    mongodb.disk_full(collection="orders"),
    postgres.disk_full(),
]
```

One import per protocol. Zero collisions. Reads naturally. Matches the pattern Bazel, Tilt, and Buck2 use.

## What's in this PR

- **Runtime wiring** [internal/star/builtins.go](internal/star/builtins.go) — adds `struct()` builtin via `starlarkstruct.Make` from `go.starlark.net/starlarkstruct`
- **5 recipe files rewritten** — [mongodb.star](recipes/mongodb.star), [http2.star](recipes/http2.star), [udp.star](recipes/udp.star), [cassandra.star](recipes/cassandra.star), [clickhouse.star](recipes/clickhouse.star) — same failure catalog, new namespace-struct export shape
- **[recipes/README.md](recipes/README.md)** — documents the pattern, coverage matrix, contribution guide
- **[RFC-018](docs/rfcs/0018-recipes-library.md)** amended with the new rule + rationale
- **Tests** — `TestStructBuiltin`, `TestRecipeNamespaceStructs` (collision-free load), `TestRecipesInRepo` (loads all 5 real recipe files and exercises one field each)

## Merge coordination

- This PR is **independent of PRs #32-#36** — it touches runtime + recipes + RFC docs only
- **If this lands first:** PRs #32-#36 will conflict on their recipe files. Resolution: keep this PR's namespace-struct versions, delete the flat-function drafts on each RFC-016 branch
- **If #32-#36 land first:** this PR rebases, deletes the flat-function recipe files from main, writes the namespace-struct versions
- Per-protocol docs (`docs/protocols/mongodb.md`, `http2.md`, `udp.md`, `cassandra.md`, `clickhouse.md`) live on the RFC-016 PR branches — their "Recipes" sections need a small sync (load shape + `ns.method()` calls) after merge. Trivial follow-up.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `TestRecipesInRepo` exercises each of the 5 shipped recipe files end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)