### PR TITLE
RFC-019: distribute recipes via @faultbox/ prefix + embedded stdlib

### DIFF
--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"sort"
 	"strings"
 
+	faultbox "github.com/faultbox/Faultbox"
 	"github.com/faultbox/Faultbox/internal/compose"
 	"github.com/faultbox/Faultbox/internal/config"
 	"github.com/faultbox/Faultbox/internal/engine"
@@ -73,6 +75,8 @@ func run() int {
 		return selfUpdateCmd(args[1:])
 	case "mcp":
 		return mcpCmd()
+	case "recipes":
+		return recipesCmd(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		printUsage()
@@ -1632,6 +1636,70 @@ class grpc:
     UNAUTHENTICATED: str
 `
 
+// recipesCmd handles: faultbox recipes [list|show <name>]
+// Provides read-only access to the embedded standard recipe library so
+// users can discover what's available without browsing the source tree.
+func recipesCmd(args []string) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprintln(os.Stderr, `Usage:
+  faultbox recipes list              List all available stdlib recipes
+  faultbox recipes show <name>       Print the source of a recipe file
+
+Recipes are loaded in specs via:
+  load("@faultbox/recipes/<name>.star", "<namespace>")`)
+		return 0
+	}
+
+	switch args[0] {
+	case "list":
+		return recipesList()
+	case "show":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: faultbox recipes show <name>")
+			return 1
+		}
+		return recipesShow(args[1])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown recipes subcommand: %s\n", args[0])
+		return 1
+	}
+}
+
+func recipesList() int {
+	entries, err := fs.ReadDir(faultbox.Recipes, "recipes")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read embedded recipes: %v\n", err)
+		return 1
+	}
+	var names []string
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".star") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".star"))
+	}
+	sort.Strings(names)
+
+	fmt.Println("Available stdlib recipes (load via @faultbox/recipes/<name>.star):")
+	for _, name := range names {
+		fmt.Printf("  %s\n", name)
+	}
+	fmt.Printf("\nExample:\n  load(\"@faultbox/recipes/%s.star\", \"%s\")\n", names[0], names[0])
+	return 0
+}
+
+func recipesShow(name string) int {
+	name = strings.TrimSuffix(name, ".star")
+	path := fmt.Sprintf("recipes/%s.star", name)
+	src, err := faultbox.Recipes.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "recipe %q not found in stdlib. Run 'faultbox recipes list' to see available recipes.\n", name)
+		return 1
+	}
+	fmt.Print(string(src))
+	return 0
+}
+
 func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage:
   faultbox run [flags] <binary> [args...]    Run a single service
@@ -1641,6 +1709,8 @@ func printUsage() {
   faultbox diff <trace1> <trace2>            Compare normalized traces
   faultbox self-update                       Update to the latest version
   faultbox mcp                               Start MCP server (for LLM agents)
+  faultbox recipes list                      List embedded stdlib recipes
+  faultbox recipes show <name>               Print a stdlib recipe source
 
 Run flags:
   --log-format=console   Force colored console output

--- a/docs/protocols/cassandra.md
+++ b/docs/protocols/cassandra.md
@@ -118,7 +118,7 @@ See [recipes/cassandra.star](../../recipes/cassandra.star):
 - `schema_mismatch` — stale schema version
 
 ```python
-load("./recipes/cassandra.star", "cassandra")
+load("@faultbox/recipes/cassandra.star", "cassandra")
 
 broken = fault_assumption("quorum_lost",
     target = cass.main,

--- a/docs/protocols/clickhouse.md
+++ b/docs/protocols/clickhouse.md
@@ -117,7 +117,7 @@ See [recipes/clickhouse.star](../../recipes/clickhouse.star):
 - `replica_stale` — replica too far behind leader
 
 ```python
-load("./recipes/clickhouse.star", "clickhouse")
+load("@faultbox/recipes/clickhouse.star", "clickhouse")
 
 broken = fault_assumption("overloaded",
     target = ch.main,

--- a/docs/protocols/http2.md
+++ b/docs/protocols/http2.md
@@ -130,7 +130,7 @@ See [recipes/http2.star](../../recipes/http2.star) for curated wrappers:
 - `unauthorized` / `forbidden` — 401 / 403
 
 ```python
-load("./recipes/http2.star", "http2")
+load("@faultbox/recipes/http2.star", "http2")
 
 faulty = fault_assumption("faulty_api",
     target = api.public,

--- a/docs/protocols/mongodb.md
+++ b/docs/protocols/mongodb.md
@@ -183,7 +183,7 @@ one-line wrappers over the primitives above with the canonical MongoDB
 error text baked in.
 
 ```python
-load("./recipes/mongodb.star", "mongodb")
+load("@faultbox/recipes/mongodb.star", "mongodb")
 
 broken = fault_assumption("broken_mongo",
     target = db.main,

--- a/docs/protocols/udp.md
+++ b/docs/protocols/udp.md
@@ -114,7 +114,7 @@ See [recipes/udp.star](../../recipes/udp.star):
 - `blackhole` — total loss
 
 ```python
-load("./recipes/udp.star", "udp")
+load("@faultbox/recipes/udp.star", "udp")
 
 broken_dns = fault_assumption("broken_dns",
     target = dns.main,

--- a/docs/rfcs/0019-recipe-distribution.md
+++ b/docs/rfcs/0019-recipe-distribution.md
@@ -1,0 +1,219 @@
+# RFC-019: Recipe Distribution via `@faultbox/` Prefix
+
+- **Status:** Draft
+- **Author:** Boris Glebov, Claude Opus 4.7
+- **Created:** 2026-04-18
+- **Branch:** `rfc/019-recipe-distribution`
+
+## Summary
+
+Embed the standard recipe library into the `faultbox` binary and resolve
+`load("@faultbox/recipes/<name>.star", ...)` from that embedded FS. Users
+get the full recipe catalog with their installed `faultbox` binary —
+no filesystem setup, no network fetch, no copy-paste.
+
+## Motivation
+
+RFC-018 defined the recipe library (`recipes/<protocol>.star` files
+exporting namespace structs). It described *what* recipes are but not
+*how users get them*. With the recipes living inside the Faultbox source
+tree at `/recipes/`, a user writing a spec in their own repo has no
+relative path to `load()`:
+
+```python
+# This only works if the user's project happens to have a recipes/
+# directory as a sibling of their spec. It doesn't.
+load("./recipes/mongodb.star", "mongodb")
+```
+
+The practical effect: RFC-018 shipped a pattern that most users can't
+actually use. This RFC fixes that.
+
+## Design
+
+### Embed at the module root
+
+A new file `/stdlib.go` at the repo root uses Go's `//go:embed` to bake
+every file under `recipes/` into the binary:
+
+```go
+// /stdlib.go
+package faultbox
+
+import "embed"
+
+//go:embed recipes/*.star recipes/README.md
+var Recipes embed.FS
+```
+
+The module root package (`faultbox`) mostly exists for this embed. The
+runtime imports it as `faultbox "github.com/faultbox/Faultbox"` and reads
+from `faultbox.Recipes` when resolving stdlib paths.
+
+### `@faultbox/` load prefix
+
+The runtime's `load()` resolver recognizes the prefix:
+
+```python
+load("@faultbox/recipes/mongodb.star", "mongodb")
+```
+
+Resolution order, top to bottom:
+
+1. `@faultbox/<path>` → embedded FS lookup (drop prefix, read `<path>`)
+2. Absolute path → read from filesystem
+3. Relative path → read relative to the spec's base directory
+
+Any existing spec that uses a relative `load("./recipes/X.star", ...)`
+keeps working unchanged — only the new prefix is special-cased.
+
+### CLI discovery commands
+
+```
+$ faultbox recipes list
+Available stdlib recipes (load via @faultbox/recipes/<name>.star):
+  cassandra
+  clickhouse
+  http2
+  mongodb
+  udp
+
+$ faultbox recipes show mongodb
+# Faultbox recipes: MongoDB
+# ...
+mongodb = struct(
+    disk_full = lambda collection = "*": error(...),
+    ...
+)
+```
+
+No local filesystem required. Users can inspect what's shipping in their
+installed binary before they load it.
+
+### Helpful error on typos
+
+```
+load @faultbox/recipes/mongdb.star: not found in faultbox stdlib
+(run 'faultbox recipes list' to see available recipes): ...
+```
+
+The error always points at the CLI command for discovery.
+
+### User-authored recipes: unchanged
+
+Users can still ship their own recipes in their project tree:
+
+```python
+# user-repo/recipes/checkout.star
+checkout = struct(
+    post_q2_race = lambda: ...,
+)
+
+# user-repo/faultbox.star
+load("@faultbox/recipes/mongodb.star", "mongodb")  # stdlib
+load("./recipes/checkout.star", "checkout")        # user-authored
+
+rules = [mongodb.disk_full(), checkout.post_q2_race()]
+```
+
+Both paths work. The runtime only short-circuits on the `@faultbox/`
+prefix; everything else hits the filesystem as before.
+
+### Versioning
+
+Recipes ship with the binary. A user running `faultbox v0.7.0` gets the
+`v0.7.0` recipes, period. Upgrading `faultbox` upgrades the recipes.
+Matches the Go stdlib model (and matches RFC-018's stability contract —
+recipes are semver-stable within a major version, so this is safe).
+
+## Alternatives considered
+
+### Package registry / network fetch
+
+`load("@faultbox/recipes/mongodb.star@v0.7", ...)` resolves via HTTP
+with a lockfile. This is the long-term direction documented in
+[RFC-004 (Package Format & `@scope/` Resolution)](0016-new-protocols.md).
+
+Rejected as the first step because:
+- Adds a network dependency to test runs (flaky CI, airgapped environments)
+- Requires a lockfile story to stabilize versions
+- RFC-004 isn't written yet — designing the full package system just to
+  ship recipes is disproportionate
+
+The embedded approach here is a strict subset of what RFC-004 will do.
+When RFC-004 lands, `@faultbox/` becomes one well-known scope among
+many; third-party recipe bundles (`@stripe/`, `@shopify/`, etc.) work
+identically at that point.
+
+### `faultbox init` copies recipes into the user's project
+
+Users run `faultbox init` and get a local `recipes/` directory with the
+stdlib copied in. Rejected as a primary mechanism:
+
+- Copies drift from upstream the moment the user upgrades `faultbox`
+- Every upgrade requires a re-init or diff/merge
+- Puts non-user-authored code in the user's repo, inviting "fix it
+  locally" commits that diverge from upstream
+
+Worth offering as a **complement** (users who want to fork a recipe can
+copy it with `faultbox recipes show mongodb > recipes/mongodb.star`),
+but not as the distribution mechanism.
+
+### Copy-paste from GitHub
+
+Documented, zero tooling. Rejected — stale on day one, no version pinning,
+requires the user to find the right tag in the GitHub UI.
+
+## Implementation
+
+1. `/stdlib.go` — `//go:embed recipes/*.star recipes/README.md` → `faultbox.Recipes`
+2. `internal/star/runtime.go` — extend `makeLoadFunc` with the stdlib
+   prefix branch (read from `faultbox.Recipes` when prefix matches)
+3. `cmd/faultbox/main.go` — add `recipes` subcommand with `list` and
+   `show` actions
+4. Tests: four new tests in `runtime_test.go` covering embedded load,
+   per-protocol load (exercises all 5 shipped recipes), unknown-recipe
+   error shape, and user-authored-recipe pass-through
+5. Docs:
+   - `recipes/README.md` updated with the `@faultbox/` canonical load
+   - Each `docs/protocols/<name>.md` "Recipes" section shows the new
+     load shape
+   - Recipe file headers updated (`# Usage: load("@faultbox/...", ...)`)
+   - `docs/spec-language.md` gains an "Importing recipes" section
+
+## Open questions
+
+1. **Third-party stdlibs.** Should we reserve `@<anything-else>/` or
+   hard-code only `@faultbox/` for v1? Proposal: hard-code for v1.
+   RFC-004 will formalize the general scope mechanism.
+
+2. **Versioned imports.** `@faultbox/recipes/mongodb.star@v1` — do we
+   need this? Recipes are pinned to the binary, so the user already has
+   version locality. Proposal: no version pinning in v1; revisit when
+   RFC-004 introduces the general package system.
+
+3. **Listing third-party packages via `recipes list`.** If we extend
+   beyond the stdlib, does `recipes list` still make sense as a global
+   command? Proposal: rename to `faultbox stdlib list` when RFC-004
+   lands and introduce `faultbox packages list` for the registry.
+
+## Non-goals
+
+- **Not a package registry.** No network fetch, no lockfiles, no
+  dependency resolution. The embedded approach is intentionally
+  minimal — the full package story is RFC-004.
+- **Not a recipe editor.** `faultbox recipes show` is read-only.
+  Forking a recipe means copying its output and editing locally.
+- **Not a way to extend the stdlib at runtime.** `@faultbox/` resolves
+  only to what was baked into the binary. Users' own recipes live at
+  filesystem paths.
+
+## Success criteria
+
+- A user with only `faultbox` on their PATH (no source checkout) can
+  write a spec that loads any stdlib recipe and have it work.
+- The full recipe catalog is discoverable via a single CLI command
+  without network access.
+- Typo errors point to the CLI discovery command.
+- User-authored recipes via relative paths continue to work unchanged.
+- Binary size impact: embedded recipes are ≤10KB total; negligible.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -51,6 +51,7 @@ Request for Comments for Faultbox v0.3.0 — Domain-Centric Verification Platfor
 | [RFC-016](0016-new-protocols.md) | New Protocols: UDP, QUIC, HTTP/2, MongoDB, ClickHouse, Cassandra | Draft | — |
 | [RFC-017](0017-mock-services.md) | Native Mock Services: Stub Protocols Without Containers | Draft | — |
 | [RFC-018](0018-recipes-library.md) | Recipes Library — Curated Failure Wrappers in Starlark | Draft | — |
+| [RFC-019](0019-recipe-distribution.md) | Recipe Distribution via `@faultbox/` Prefix | Draft | RFC-018 |
 
 ### Phase 3: Trace Equivalence & Specification Mining
 

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -15,6 +15,7 @@ import (
 
 	"go.starlark.net/starlark"
 
+	faultbox "github.com/faultbox/Faultbox"
 	"github.com/faultbox/Faultbox/internal/config"
 	"github.com/faultbox/Faultbox/internal/container"
 	"github.com/faultbox/Faultbox/internal/engine"
@@ -181,9 +182,18 @@ func (rt *Runtime) LoadString(name, src string) error {
 	return nil
 }
 
+// stdlibPrefix is the module prefix that resolves to the embedded standard
+// recipe library. See RFC-019 for the distribution convention.
+const stdlibPrefix = "@faultbox/"
+
 // makeLoadFunc creates a thread.Load handler for Starlark's load() statement.
 // Loaded modules share the same runtime (service registry, builtins).
 // Results are cached — each module is executed at most once.
+//
+// Resolution order:
+//  1. "@faultbox/<path>" → embedded recipes FS (baked into the binary)
+//  2. absolute path → read from filesystem
+//  3. relative path → read from rt.baseDir (typically the spec's directory)
 func (rt *Runtime) makeLoadFunc() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	cache := make(map[string]starlark.StringDict)
 
@@ -193,16 +203,30 @@ func (rt *Runtime) makeLoadFunc() func(thread *starlark.Thread, module string) (
 			return globals, nil
 		}
 
-		// Resolve path relative to the base directory.
-		modPath := module
-		if rt.baseDir != "" && !filepath.IsAbs(module) {
-			modPath = filepath.Join(rt.baseDir, module)
-		}
+		var src []byte
+		var err error
+		var modPath string
 
-		// Read and execute the module with same builtins.
-		src, err := os.ReadFile(modPath)
-		if err != nil {
-			return nil, fmt.Errorf("load %q: %w", module, err)
+		if strings.HasPrefix(module, stdlibPrefix) {
+			// Embedded stdlib lookup. The embed.FS keys drop the leading
+			// "@faultbox/", so "@faultbox/recipes/mongodb.star" becomes
+			// "recipes/mongodb.star" in the FS.
+			embeddedPath := strings.TrimPrefix(module, stdlibPrefix)
+			src, err = faultbox.Recipes.ReadFile(embeddedPath)
+			if err != nil {
+				return nil, fmt.Errorf("load %q: not found in faultbox stdlib (run 'faultbox recipes list' to see available recipes): %w", module, err)
+			}
+			modPath = module // preserve the @faultbox/... display name
+		} else {
+			// Resolve path relative to the base directory.
+			modPath = module
+			if rt.baseDir != "" && !filepath.IsAbs(module) {
+				modPath = filepath.Join(rt.baseDir, module)
+			}
+			src, err = os.ReadFile(modPath)
+			if err != nil {
+				return nil, fmt.Errorf("load %q: %w", module, err)
+			}
 		}
 
 		// Append module source for syscall scanning.

--- a/internal/star/runtime_test.go
+++ b/internal/star/runtime_test.go
@@ -1049,6 +1049,150 @@ def test_ok():
 	}
 }
 
+// TestStdlibLoad_Embedded verifies specs can import recipes via the
+// @faultbox/ prefix without any local recipes/ directory on disk.
+// This is the distribution mechanism from RFC-019.
+func TestStdlibLoad_Embedded(t *testing.T) {
+	// Deliberately use a TempDir with NO recipes/ subdir — this must still
+	// work because the runtime resolves @faultbox/ from the embedded FS.
+	dir := t.TempDir()
+	spec := `
+load("@faultbox/recipes/mongodb.star", "mongodb")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+_disk_full = mongodb.disk_full(collection = "orders")
+_auth_fail = mongodb.auth_failed()
+
+def test_ok():
+    pass
+`
+	if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := New(testLogger())
+	if err := rt.LoadFile(dir + "/faultbox.star"); err != nil {
+		t.Fatalf("LoadFile with embedded stdlib: %v", err)
+	}
+
+	tests := rt.DiscoverTests()
+	if len(tests) != 1 || tests[0] != "test_ok" {
+		t.Errorf("expected test_ok, got %v", tests)
+	}
+}
+
+// TestStdlibLoad_AllProtocols exercises every recipe namespace shipped in
+// the embedded stdlib. Catches regressions where a recipe file stops
+// compiling after a refactor.
+func TestStdlibLoad_AllProtocols(t *testing.T) {
+	cases := []struct {
+		protocol string
+		method   string
+	}{
+		{"mongodb", "disk_full"},
+		{"http2", "rate_limited"},
+		{"udp", "packet_loss"},
+		{"cassandra", "write_timeout"},
+		{"clickhouse", "too_many_parts"},
+	}
+	for _, c := range cases {
+		t.Run(c.protocol, func(t *testing.T) {
+			dir := t.TempDir()
+			spec := `
+load("@faultbox/recipes/` + c.protocol + `.star", "` + c.protocol + `")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+_rule = ` + c.protocol + `.` + c.method + `()
+
+def test_ok():
+    pass
+`
+			if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+				t.Fatal(err)
+			}
+			rt := New(testLogger())
+			if err := rt.LoadFile(dir + "/faultbox.star"); err != nil {
+				t.Errorf("load @faultbox/recipes/%s.star: %v", c.protocol, err)
+			}
+		})
+	}
+}
+
+// TestStdlibLoad_UnknownRecipe verifies the error message surfaces the
+// stdlib context when a user mistypes a recipe name.
+func TestStdlibLoad_UnknownRecipe(t *testing.T) {
+	dir := t.TempDir()
+	spec := `
+load("@faultbox/recipes/nonexistent.star", "nonexistent")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+`
+	if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := New(testLogger())
+	err := rt.LoadFile(dir + "/faultbox.star")
+	if err == nil {
+		t.Fatal("expected load error for unknown recipe")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "faultbox stdlib") {
+		t.Errorf("error should mention 'faultbox stdlib' to orient the user, got: %v", err)
+	}
+	if !strings.Contains(msg, "recipes list") {
+		t.Errorf("error should hint at 'recipes list' CLI command, got: %v", err)
+	}
+}
+
+// TestStdlibLoad_LocalStillWorks verifies that user-authored recipes at
+// relative filesystem paths still resolve, so the @faultbox/ convention
+// doesn't break specs that ship their own recipes alongside.
+func TestStdlibLoad_LocalStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/recipes", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	localRecipe := `
+mycompany = struct(
+    checkout_stall = lambda: delay(path = "/checkout", delay = "1s"),
+)
+`
+	if err := os.WriteFile(dir+"/recipes/mycompany.star", []byte(localRecipe), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	spec := `
+load("recipes/mycompany.star", "mycompany")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+)
+
+_rule = mycompany.checkout_stall()
+
+def test_ok():
+    pass
+`
+	if err := os.WriteFile(dir+"/faultbox.star", []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := New(testLogger())
+	if err := rt.LoadFile(dir + "/faultbox.star"); err != nil {
+		t.Fatalf("local recipe load broke: %v", err)
+	}
+}
+
 // TestStructBuiltin is a sanity check that struct() is wired into the
 // runtime so recipe modules can use it.
 func TestStructBuiltin(t *testing.T) {

--- a/recipes/cassandra.star
+++ b/recipes/cassandra.star
@@ -1,9 +1,10 @@
 # Faultbox recipes: Cassandra
 #
 # Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib is embedded in the faultbox binary (@faultbox/ prefix).
 #
 # Usage:
-#     load("./recipes/cassandra.star", "cassandra")
+#     load("@faultbox/recipes/cassandra.star", "cassandra")
 #
 #     broken = fault_assumption("quorum_lost",
 #         target = cass.main,

--- a/recipes/clickhouse.star
+++ b/recipes/clickhouse.star
@@ -1,9 +1,10 @@
 # Faultbox recipes: ClickHouse
 #
 # Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib is embedded in the faultbox binary (@faultbox/ prefix).
 #
 # Usage:
-#     load("./recipes/clickhouse.star", "clickhouse")
+#     load("@faultbox/recipes/clickhouse.star", "clickhouse")
 #
 #     overloaded = fault_assumption("overloaded",
 #         target = ch.main,

--- a/recipes/http2.star
+++ b/recipes/http2.star
@@ -1,9 +1,10 @@
 # Faultbox recipes: HTTP/2
 #
 # Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib is embedded in the faultbox binary (@faultbox/ prefix).
 #
 # Usage:
-#     load("./recipes/http2.star", "http2")
+#     load("@faultbox/recipes/http2.star", "http2")
 #
 #     faulty = fault_assumption("faulty_api",
 #         target = api.main,

--- a/recipes/mongodb.star
+++ b/recipes/mongodb.star
@@ -1,11 +1,11 @@
 # Faultbox recipes: MongoDB
 #
-# Per RFC-018, each recipe file exports one namespace struct named after
-# the protocol. This prevents name collisions when users load recipes
-# for multiple protocols — e.g. mongodb.disk_full vs postgres.disk_full.
+# Per RFC-018: namespace struct (prevents name collisions across protocols).
+# Per RFC-019: stdlib ships embedded in the faultbox binary, loaded via
+# the @faultbox/ prefix — no local recipes/ directory needed.
 #
 # Usage:
-#     load("./recipes/mongodb.star", "mongodb")
+#     load("@faultbox/recipes/mongodb.star", "mongodb")
 #
 #     broken = fault_assumption("broken",
 #         target = db.main,

--- a/recipes/udp.star
+++ b/recipes/udp.star
@@ -1,9 +1,10 @@
 # Faultbox recipes: UDP
 #
 # Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib is embedded in the faultbox binary (@faultbox/ prefix).
 #
 # Usage:
-#     load("./recipes/udp.star", "udp")
+#     load("@faultbox/recipes/udp.star", "udp")
 #
 #     dns_broken = fault_assumption("dns_broken",
 #         target = dns.main,

--- a/stdlib.go
+++ b/stdlib.go
@@ -1,0 +1,20 @@
+// Package faultbox is the module root. It exists primarily to host the
+// embedded standard recipe library, which gets compiled into the faultbox
+// binary so users' specs can load("@faultbox/recipes/<name>.star", ...)
+// without needing the Faultbox source tree locally.
+//
+// The actual runtime, CLI, and protocol code lives under cmd/ and internal/;
+// this file only exposes the embedded FS.
+package faultbox
+
+import "embed"
+
+// Recipes is the embedded standard recipe library. Each file is a Starlark
+// module that exports a single namespace struct (see RFC-018 for the
+// pattern and RFC-019 for the distribution convention).
+//
+// Access is mediated by the runtime's load() resolver: specs reference
+// recipes as "@faultbox/recipes/<protocol>.star", not by raw path.
+//
+//go:embed recipes/*.star recipes/README.md
+var Recipes embed.FS


### PR DESCRIPTION
## Summary

Fixes the shipping gap from RFC-018. Recipes previously lived only in the Faultbox source tree — users writing specs in their own repos couldn't actually `load()` them. This PR embeds the recipe stdlib into the `faultbox` binary and routes `load(\"@faultbox/recipes/X.star\", ...)` through the embedded FS.

## The problem this solves

```python
# Before — only worked if user's project had a recipes/ sibling dir
load(\"./recipes/mongodb.star\", \"mongodb\")

# After — works anywhere, no filesystem setup
load(\"@faultbox/recipes/mongodb.star\", \"mongodb\")
```

## What's in this PR

- **[stdlib.go](stdlib.go)** at module root — `//go:embed recipes/*.star recipes/README.md` → `faultbox.Recipes`
- **[internal/star/runtime.go](internal/star/runtime.go)** — `makeLoadFunc` gains a stdlib branch that serves `@faultbox/` from the embedded FS. Existing absolute/relative paths unchanged.
- **[cmd/faultbox/main.go](cmd/faultbox/main.go)** — `faultbox recipes list` and `faultbox recipes show <name>` — discoverability without a source checkout
- **[RFC-019](docs/rfcs/0019-recipe-distribution.md)** — pins the convention, explains why this ships now vs. waiting for the full RFC-004 package system
- **4 new runtime tests** — embedded load, per-protocol load (exercises every shipped recipe), unknown-recipe error shape (must mention `recipes list`), user-authored recipe pass-through
- **Doc updates** — all 5 recipe file headers + all 5 protocol docs + recipes/README.md now show `@faultbox/` as canonical

## Try it after merge

```
$ faultbox recipes list
Available stdlib recipes (load via @faultbox/recipes/<name>.star):
  cassandra
  clickhouse
  http2
  mongodb
  udp

$ faultbox recipes show mongodb   # read any recipe without a source checkout
```

## Test plan

- [x] `go test ./...` passes (incl. 4 new stdlib tests)
- [x] `go vet ./...` clean
- [x] Manual: `faultbox recipes list` and `faultbox recipes show <name>` work against the built binary
- [x] Manual: spec with `load(\"@faultbox/recipes/mongodb.star\", \"mongodb\")` loads from a tempdir with no local `recipes/`

## Relationship to other RFCs

- **RFC-018** (recipes library) — this PR implements its distribution story
- **RFC-004** (future package system) — when it lands, `@faultbox/` becomes one registered scope among many; third-party recipe bundles work identically

## Non-goals (noted in RFC-019)

- Not a package registry — no network fetch, no lockfiles
- Not a recipe editor — `recipes show` is read-only
- Not a runtime extension — `@faultbox/` resolves only to what was baked into the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)