### PR TITLE
feat(rfc-017): mock_service() runtime + HTTP handler (step 1/N)

### DIFF
--- a/internal/protocol/http.go
+++ b/internal/protocol/http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 )
@@ -107,6 +108,199 @@ func getStringKwarg(kwargs map[string]any, key, defaultVal string) string {
 		}
 	}
 	return defaultVal
+}
+
+// ServeMock implements MockHandler for the HTTP protocol. It stands up an
+// in-process net/http server on addr that matches requests against
+// spec.Routes ("METHOD /path" with * and ** glob support) and returns the
+// corresponding MockResponse. Unmatched requests fall back to spec.Default
+// (or HTTP 404 if no default is set). Every request is logged via emit.
+func (p *httpProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("mock listen %s: %w", addr, err)
+	}
+
+	mux := &mockHTTPMux{routes: spec.Routes, def: spec.Default, emit: emit}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(shutdownCtx)
+		cancel()
+		return nil
+	case err := <-serveErr:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+}
+
+// mockHTTPMux dispatches incoming requests against a MockSpec route table.
+type mockHTTPMux struct {
+	routes []MockRoute
+	def    *MockResponse
+	emit   MockEmitter
+}
+
+func (m *mockHTTPMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := r.Method + " " + r.URL.Path
+	bodyBytes, _ := io.ReadAll(io.LimitReader(r.Body, 1024*1024))
+	_ = r.Body.Close()
+
+	route, matched := matchHTTPRoute(m.routes, r.Method, r.URL.Path)
+
+	var resp *MockResponse
+	switch {
+	case matched && route.Dynamic != nil:
+		dyn, err := route.Dynamic(buildMockRequest(r, bodyBytes))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("dynamic handler error: %v", err), http.StatusInternalServerError)
+			emitWith(m.emit, op, map[string]string{"status": "500", "error": err.Error()})
+			return
+		}
+		resp = dyn
+	case matched:
+		resp = route.Response
+	case m.def != nil:
+		resp = m.def
+	default:
+		resp = &MockResponse{Status: http.StatusNotFound, Body: []byte("not found\n"), ContentType: "text/plain"}
+	}
+
+	writeMockResponse(w, resp)
+	emitWith(m.emit, op, map[string]string{
+		"status":    fmt.Sprintf("%d", statusOr(resp, 200)),
+		"body_size": fmt.Sprintf("%d", len(resp.Body)),
+		"req_size":  fmt.Sprintf("%d", len(bodyBytes)),
+	})
+}
+
+func buildMockRequest(r *http.Request, body []byte) MockRequest {
+	headers := make(map[string]string, len(r.Header))
+	for k, v := range r.Header {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+	query := make(map[string]string)
+	for k, v := range r.URL.Query() {
+		if len(v) > 0 {
+			query[k] = v[0]
+		}
+	}
+	return MockRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: headers,
+		Query:   query,
+		Body:    body,
+	}
+}
+
+func writeMockResponse(w http.ResponseWriter, resp *MockResponse) {
+	for k, v := range resp.Headers {
+		w.Header().Set(k, v)
+	}
+	if resp.ContentType != "" && w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", resp.ContentType)
+	}
+	status := resp.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(resp.Body)
+}
+
+func statusOr(resp *MockResponse, fallback int) int {
+	if resp.Status == 0 {
+		return fallback
+	}
+	return resp.Status
+}
+
+func emitWith(emit MockEmitter, op string, fields map[string]string) {
+	if emit != nil {
+		emit(op, fields)
+	}
+}
+
+// matchHTTPRoute picks the first route whose pattern matches (METHOD, path).
+// Pattern format: "METHOD /glob". * matches one path segment, ** matches
+// zero or more segments. Exact literal matches take precedence over globs
+// (sorted at build time — see mockHTTPMux construction). For now this is a
+// simple linear scan; optimize if large route tables appear in practice.
+func matchHTTPRoute(routes []MockRoute, method, urlPath string) (MockRoute, bool) {
+	for _, r := range routes {
+		m, p, ok := splitMethodPattern(r.Pattern)
+		if !ok {
+			continue
+		}
+		if m != "*" && !strings.EqualFold(m, method) {
+			continue
+		}
+		if matchGlob(p, urlPath) {
+			return r, true
+		}
+	}
+	return MockRoute{}, false
+}
+
+func splitMethodPattern(pattern string) (string, string, bool) {
+	parts := strings.SplitN(pattern, " ", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// matchGlob matches a URL path against a glob pattern. * matches a single
+// path segment (no /); ** matches zero or more segments (including /).
+// Literal "/" in pattern must match literal "/" in path.
+func matchGlob(pattern, target string) bool {
+	if !strings.ContainsAny(pattern, "*") {
+		// Fast path for literal patterns.
+		m, _ := path.Match(pattern, target)
+		return m || pattern == target
+	}
+
+	pparts := strings.Split(strings.Trim(pattern, "/"), "/")
+	tparts := strings.Split(strings.Trim(target, "/"), "/")
+	return matchSegments(pparts, tparts)
+}
+
+func matchSegments(pattern, target []string) bool {
+	if len(pattern) == 0 {
+		return len(target) == 0
+	}
+	head := pattern[0]
+	if head == "**" {
+		// Zero or more segments. Try matching remaining pattern at each
+		// position in target.
+		for i := 0; i <= len(target); i++ {
+			if matchSegments(pattern[1:], target[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(target) == 0 {
+		return false
+	}
+	if head == "*" || head == target[0] {
+		return matchSegments(pattern[1:], target[1:])
+	}
+	// Segment-level glob (e.g., "user-*") using path.Match semantics.
+	if ok, _ := path.Match(head, target[0]); ok {
+		return matchSegments(pattern[1:], target[1:])
+	}
+	return false
 }
 
 // TCPHealthcheck does a simple TCP dial — shared by tcp and other protocols.

--- a/internal/protocol/mock.go
+++ b/internal/protocol/mock.go
@@ -1,0 +1,63 @@
+package protocol
+
+import "context"
+
+// MockHandler is an optional capability on a Protocol plugin. Protocols that
+// support mock_service() implement it; others do not and mock_service()
+// rejects their interface type at spec load time.
+//
+// Serve starts an in-process listener on addr and serves the given MockSpec
+// until ctx is cancelled. Each handled request MUST emit one event via emit
+// so spec-level assertions see the traffic.
+type MockHandler interface {
+	Protocol
+	ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error
+}
+
+// MockSpec is the protocol-agnostic configuration for one mocked interface.
+// Routes are keyed by a protocol-specific pattern ("METHOD /path" for HTTP,
+// "/pkg.Service/Method" for gRPC, bytes prefix for TCP/UDP).
+type MockSpec struct {
+	Routes  []MockRoute
+	Default *MockResponse
+}
+
+// MockRoute pairs a pattern with a handler. Pattern matching is
+// protocol-specific; handlers may be static (Response) or dynamic (Dynamic).
+type MockRoute struct {
+	Pattern  string
+	Response *MockResponse // static response; nil if Dynamic is set
+	Dynamic  DynamicFn     // per-request callable; nil if Response is set
+}
+
+// MockResponse is a canned response. Semantics depend on protocol:
+//   - HTTP/HTTP2: Status is the HTTP status code, Body is the body, Headers
+//     are response headers, ContentType sets the Content-Type header.
+//   - gRPC: Status maps to gRPC status code; Body is the encoded message;
+//     Headers become trailers.
+//   - TCP/UDP: Status is ignored; Body is the raw bytes written back.
+type MockResponse struct {
+	Status      int
+	Body        []byte
+	Headers     map[string]string
+	ContentType string
+}
+
+// MockRequest is passed to a DynamicFn. Fields are populated best-effort per
+// protocol — HTTP populates all fields; TCP/UDP populate only Body.
+type MockRequest struct {
+	Method  string            // HTTP method; empty for non-HTTP
+	Path    string            // HTTP path; empty for non-HTTP
+	Headers map[string]string // HTTP request headers; nil for non-HTTP
+	Query   map[string]string // HTTP query params; nil for non-HTTP
+	Body    []byte            // raw request body bytes
+}
+
+// DynamicFn computes a MockResponse per request. Returning a non-nil error
+// causes the mock to emit a 500-style error response and log the failure.
+type DynamicFn func(req MockRequest) (*MockResponse, error)
+
+// MockEmitter is a callback the mock handler invokes on every handled
+// request so the event log records the traffic. Implementations are
+// thread-safe; handlers may call emit concurrently from multiple goroutines.
+type MockEmitter func(op string, fields map[string]string)

--- a/internal/protocol/mock_test.go
+++ b/internal/protocol/mock_test.go
@@ -1,0 +1,288 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHTTPMockStaticRoutes verifies that the HTTP MockHandler matches
+// METHOD PATTERN routes, returns the configured status/body/headers, and
+// falls back to 404 when no route matches.
+func TestHTTPMockStaticRoutes(t *testing.T) {
+	p := &httpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	spec := MockSpec{
+		Routes: []MockRoute{
+			{
+				Pattern: "GET /.well-known/openid-configuration/jwks",
+				Response: &MockResponse{
+					Status:      200,
+					Body:        []byte(`{"keys":[{"kty":"OKP"}]}`),
+					ContentType: "application/json",
+				},
+			},
+			{
+				Pattern: "GET /health",
+				Response: &MockResponse{Status: 204},
+			},
+			{
+				Pattern: "POST /api/v1/**",
+				Response: &MockResponse{
+					Status:      200,
+					Body:        []byte(`{"ok":true}`),
+					ContentType: "application/json",
+					Headers:     map[string]string{"X-Mock": "1"},
+				},
+			},
+		},
+	}
+
+	emitted := &recordedEmits{}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- p.ServeMock(ctx, addr, spec, emitted.emit) }()
+
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mock not listening: %v", err)
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Route 1: JWKS endpoint.
+	resp, err := client.Get(fmt.Sprintf("http://%s/.well-known/openid-configuration/jwks", addr))
+	if err != nil {
+		t.Fatalf("GET jwks: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("jwks status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `"kty":"OKP"`) {
+		t.Fatalf("jwks body = %q", string(body))
+	}
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("jwks content-type = %q", resp.Header.Get("Content-Type"))
+	}
+
+	// Route 2: status-only.
+	resp, err = client.Get(fmt.Sprintf("http://%s/health", addr))
+	if err != nil {
+		t.Fatalf("GET health: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Fatalf("health status = %d, want 204", resp.StatusCode)
+	}
+
+	// Route 3: glob ** match + custom header.
+	resp, err = client.Post(fmt.Sprintf("http://%s/api/v1/users/42", addr), "application/json", strings.NewReader(`{"id":42}`))
+	if err != nil {
+		t.Fatalf("POST api: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("api status = %d, want 200", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Mock") != "1" {
+		t.Fatalf("api X-Mock = %q", resp.Header.Get("X-Mock"))
+	}
+
+	// Unmatched → 404.
+	resp, err = client.Get(fmt.Sprintf("http://%s/does-not-exist", addr))
+	if err != nil {
+		t.Fatalf("GET unmatched: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("unmatched status = %d, want 404", resp.StatusCode)
+	}
+
+	if got := emitted.count(); got != 4 {
+		t.Fatalf("emitter called %d times, want 4", got)
+	}
+
+	cancel()
+	select {
+	case <-serveErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down in time")
+	}
+}
+
+// TestHTTPMockDynamicHandler verifies that a dynamic handler receives
+// request context and that its returned MockResponse is written back.
+func TestHTTPMockDynamicHandler(t *testing.T) {
+	p := &httpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	var observed MockRequest
+	spec := MockSpec{
+		Routes: []MockRoute{
+			{
+				Pattern: "POST /token",
+				Dynamic: func(req MockRequest) (*MockResponse, error) {
+					observed = req
+					body, _ := json.Marshal(map[string]string{
+						"user": req.Query["user"],
+						"body": string(req.Body),
+					})
+					return &MockResponse{
+						Status:      200,
+						Body:        body,
+						ContentType: "application/json",
+					}, nil
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- p.ServeMock(ctx, addr, spec, nil) }()
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mock not listening: %v", err)
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Post(
+		fmt.Sprintf("http://%s/token?user=alice", addr),
+		"application/json",
+		strings.NewReader(`{"hello":"world"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if observed.Method != "POST" {
+		t.Fatalf("observed.Method = %q", observed.Method)
+	}
+	if observed.Query["user"] != "alice" {
+		t.Fatalf("observed.Query[user] = %q", observed.Query["user"])
+	}
+	if string(observed.Body) != `{"hello":"world"}` {
+		t.Fatalf("observed.Body = %q", string(observed.Body))
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"user":"alice"`) {
+		t.Fatalf("response body = %q", string(body))
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down in time")
+	}
+}
+
+// TestHTTPMockDefaultResponse verifies that unmatched requests fall through
+// to the configured default when set.
+func TestHTTPMockDefaultResponse(t *testing.T) {
+	p := &httpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Default: &MockResponse{
+			Status:      501,
+			Body:        []byte(`unsupported`),
+			ContentType: "text/plain",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, spec, nil)
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mock not listening: %v", err)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/anything", addr))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 501 {
+		t.Fatalf("status = %d, want 501", resp.StatusCode)
+	}
+}
+
+// TestMatchGlob covers the path glob patterns directly.
+func TestMatchGlob(t *testing.T) {
+	cases := []struct {
+		pattern string
+		target  string
+		want    bool
+	}{
+		{"/health", "/health", true},
+		{"/health", "/health/v2", false},
+		{"/api/*", "/api/users", true},
+		{"/api/*", "/api/users/42", false},
+		{"/api/**", "/api/users/42/posts", true},
+		{"/api/**/posts", "/api/users/42/posts", true},
+		{"/api/**/posts", "/api/42/users/posts", true},
+		{"/api/**/posts", "/api/42/users", false},
+		{"/.well-known/openid-configuration/jwks", "/.well-known/openid-configuration/jwks", true},
+	}
+	for _, tc := range cases {
+		got := matchGlob(tc.pattern, tc.target)
+		if got != tc.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tc.pattern, tc.target, got, tc.want)
+		}
+	}
+}
+
+// --- test helpers ---
+
+type recordedEmits struct {
+	mu    sync.Mutex
+	count_ int64
+}
+
+func (r *recordedEmits) emit(op string, fields map[string]string) {
+	atomic.AddInt64(&r.count_, 1)
+}
+
+func (r *recordedEmits) count() int64 {
+	return atomic.LoadInt64(&r.count_)
+}
+
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+	return addr
+}
+
+func waitListening(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("listener on %s not ready after %s", addr, timeout)
+}

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -68,6 +68,14 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		// protocol-specific helpers don't collide on common names (e.g.
 		// mongodb.disk_full vs postgres.disk_full).
 		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
+		// Mock services (RFC-017).
+		"mock_service":   starlark.NewBuiltin("mock_service", rt.builtinMockService),
+		"json_response":  starlark.NewBuiltin("json_response", builtinJSONResponse),
+		"text_response":  starlark.NewBuiltin("text_response", builtinTextResponse),
+		"bytes_response": starlark.NewBuiltin("bytes_response", builtinBytesResponse),
+		"status_only":    starlark.NewBuiltin("status_only", builtinStatusOnly),
+		"redirect":       starlark.NewBuiltin("redirect", builtinRedirect),
+		"dynamic":        starlark.NewBuiltin("dynamic", builtinDynamic),
 	}
 }
 

--- a/internal/star/mock.go
+++ b/internal/star/mock.go
@@ -1,0 +1,180 @@
+package star
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/protocol"
+)
+
+// MockConfig holds mock configuration keyed per interface. Populated by
+// the mock_service() builtin; consumed by Runtime.startMockService.
+type MockConfig struct {
+	// Routes per interface name. Insertion order is preserved — earlier
+	// routes take precedence when multiple patterns match.
+	Routes map[string][]MockRouteEntry
+
+	// Default response per interface (nil = 404 / protocol default).
+	Default map[string]*MockResponseValue
+
+	// TLS per interface (not yet implemented; field reserved).
+	TLS map[string]bool
+}
+
+// MockRouteEntry is one pattern → response binding.
+type MockRouteEntry struct {
+	Pattern  string
+	Response *MockResponseValue
+}
+
+// MockResponseValue is a Starlark value returned by the response constructor
+// builtins (json_response, text_response, status_only, redirect) and
+// dynamic(). It wraps either a static protocol.MockResponse or a Starlark
+// callable invoked per request.
+type MockResponseValue struct {
+	static  *protocol.MockResponse
+	dynamic starlark.Callable
+}
+
+var _ starlark.Value = (*MockResponseValue)(nil)
+
+func (m *MockResponseValue) String() string {
+	if m.dynamic != nil {
+		return fmt.Sprintf("<mock_response dynamic=%s>", m.dynamic.Name())
+	}
+	if m.static != nil {
+		return fmt.Sprintf("<mock_response status=%d body_size=%d>", m.static.Status, len(m.static.Body))
+	}
+	return "<mock_response (empty)>"
+}
+func (m *MockResponseValue) Type() string          { return "mock_response" }
+func (m *MockResponseValue) Freeze()               {}
+func (m *MockResponseValue) Truth() starlark.Bool  { return starlark.True }
+func (m *MockResponseValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: mock_response") }
+
+// IsDynamic reports whether this response defers to a Starlark callable.
+func (m *MockResponseValue) IsDynamic() bool { return m.dynamic != nil }
+
+// Static returns the embedded static response (nil if dynamic).
+func (m *MockResponseValue) Static() *protocol.MockResponse { return m.static }
+
+// Dynamic returns the wrapped callable (nil if static).
+func (m *MockResponseValue) Dynamic() starlark.Callable { return m.dynamic }
+
+// newStaticResponse is the internal helper used by the response constructor
+// builtins to wrap a protocol.MockResponse.
+func newStaticResponse(r *protocol.MockResponse) *MockResponseValue {
+	return &MockResponseValue{static: r}
+}
+
+// newDynamicResponse wraps a Starlark callable for per-request evaluation.
+func newDynamicResponse(fn starlark.Callable) *MockResponseValue {
+	return &MockResponseValue{dynamic: fn}
+}
+
+// toStarlarkRequest converts a protocol.MockRequest into the dict that
+// dynamic handlers receive as their sole argument.
+func toStarlarkRequest(req protocol.MockRequest) *starlark.Dict {
+	d := starlark.NewDict(5)
+	_ = d.SetKey(starlark.String("method"), starlark.String(req.Method))
+	_ = d.SetKey(starlark.String("path"), starlark.String(req.Path))
+
+	headers := starlark.NewDict(len(req.Headers))
+	for k, v := range req.Headers {
+		_ = headers.SetKey(starlark.String(k), starlark.String(v))
+	}
+	_ = d.SetKey(starlark.String("headers"), headers)
+
+	query := starlark.NewDict(len(req.Query))
+	for k, v := range req.Query {
+		_ = query.SetKey(starlark.String(k), starlark.String(v))
+	}
+	_ = d.SetKey(starlark.String("query"), query)
+
+	_ = d.SetKey(starlark.String("body"), starlark.String(string(req.Body)))
+	return d
+}
+
+// starlarkResponseToProtocol converts a MockResponseValue returned by a
+// dynamic handler into the wire-level protocol.MockResponse.
+func starlarkResponseToProtocol(v starlark.Value) (*protocol.MockResponse, error) {
+	mr, ok := v.(*MockResponseValue)
+	if !ok {
+		return nil, fmt.Errorf("dynamic handler must return a mock_response (got %s)", v.Type())
+	}
+	if mr.static == nil {
+		return nil, fmt.Errorf("dynamic handler returned a dynamic response (nested dynamic() is not supported)")
+	}
+	return mr.static, nil
+}
+
+// marshalJSONBody encodes v as JSON bytes, used by json_response().
+// Accepts Starlark dicts, lists, strings, numbers, bools, None.
+func marshalJSONBody(v starlark.Value) ([]byte, error) {
+	native, err := starlarkToGo(v)
+	if err != nil {
+		return nil, fmt.Errorf("convert value: %w", err)
+	}
+	return json.Marshal(native)
+}
+
+// starlarkToGo converts a Starlark value to a Go native suitable for
+// json.Marshal. Inverse of goToStarlark() in types.go.
+func starlarkToGo(v starlark.Value) (any, error) {
+	switch x := v.(type) {
+	case starlark.NoneType:
+		return nil, nil
+	case starlark.Bool:
+		return bool(x), nil
+	case starlark.Int:
+		if i, ok := x.Int64(); ok {
+			return i, nil
+		}
+		return x.String(), nil
+	case starlark.Float:
+		return float64(x), nil
+	case starlark.String:
+		return string(x), nil
+	case *starlark.List:
+		out := make([]any, 0, x.Len())
+		iter := x.Iterate()
+		defer iter.Done()
+		var item starlark.Value
+		for iter.Next(&item) {
+			g, err := starlarkToGo(item)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, g)
+		}
+		return out, nil
+	case starlark.Tuple:
+		out := make([]any, 0, len(x))
+		for _, item := range x {
+			g, err := starlarkToGo(item)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, g)
+		}
+		return out, nil
+	case *starlark.Dict:
+		out := make(map[string]any, x.Len())
+		for _, pair := range x.Items() {
+			key, ok := pair[0].(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf("dict keys must be strings for JSON encoding (got %s)", pair[0].Type())
+			}
+			g, err := starlarkToGo(pair[1])
+			if err != nil {
+				return nil, err
+			}
+			out[string(key)] = g
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("cannot JSON-encode Starlark value of type %s", v.Type())
+	}
+}

--- a/internal/star/mock_builtins.go
+++ b/internal/star/mock_builtins.go
@@ -1,0 +1,286 @@
+package star
+
+import (
+	"fmt"
+	"net/http"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/protocol"
+)
+
+// mock_service(name, *interfaces, routes={}, default=None, depends_on=[])
+//
+// Creates a ServiceDef flagged as a mock. The runtime stands up an
+// in-process handler per interface at test start instead of launching a
+// binary or container. See RFC-017.
+func (rt *Runtime) builtinMockService(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("mock_service() requires at least a name")
+	}
+	name, ok := starlark.AsString(args[0])
+	if !ok {
+		return nil, fmt.Errorf("mock_service() name must be a string")
+	}
+
+	svc := &ServiceDef{
+		Name:       name,
+		Interfaces: make(map[string]*InterfaceDef),
+		Env:        make(map[string]string),
+		Mock: &MockConfig{
+			Routes:  make(map[string][]MockRouteEntry),
+			Default: make(map[string]*MockResponseValue),
+			TLS:     make(map[string]bool),
+		},
+	}
+
+	for i := 1; i < len(args); i++ {
+		iface, ok := args[i].(*InterfaceDef)
+		if !ok {
+			return nil, fmt.Errorf("mock_service() positional arg %d must be interface() (got %s)", i, args[i].Type())
+		}
+		svc.Interfaces[iface.Name] = iface
+	}
+
+	// Single-interface shorthand: mock_service("auth", interface(...), routes={})
+	// applies routes to that one interface. Multi-interface callers pass
+	// routes={"interface_name": {...}} as nested dicts (future).
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		switch key {
+		case "routes":
+			dict, ok := kv[1].(*starlark.Dict)
+			if !ok {
+				return nil, fmt.Errorf("mock_service() routes must be a dict")
+			}
+			ifaceName, err := singleInterfaceName(svc)
+			if err != nil {
+				return nil, fmt.Errorf("mock_service() %q: %w — provide routes as {interface: {...}} for multi-interface mocks", name, err)
+			}
+			routes, err := parseRoutesDict(dict)
+			if err != nil {
+				return nil, fmt.Errorf("mock_service() %q routes: %w", name, err)
+			}
+			svc.Mock.Routes[ifaceName] = routes
+		case "default":
+			resp, ok := kv[1].(*MockResponseValue)
+			if !ok {
+				return nil, fmt.Errorf("mock_service() default must be a mock_response (got %s)", kv[1].Type())
+			}
+			ifaceName, err := singleInterfaceName(svc)
+			if err != nil {
+				return nil, fmt.Errorf("mock_service() %q: %w", name, err)
+			}
+			svc.Mock.Default[ifaceName] = resp
+		case "depends_on":
+			list, ok := kv[1].(*starlark.List)
+			if !ok {
+				return nil, fmt.Errorf("mock_service() depends_on must be a list")
+			}
+			iter := list.Iterate()
+			defer iter.Done()
+			var item starlark.Value
+			for iter.Next(&item) {
+				if s, ok := item.(*ServiceDef); ok {
+					svc.DependsOn = append(svc.DependsOn, s.Name)
+				} else if str, ok := starlark.AsString(item); ok {
+					svc.DependsOn = append(svc.DependsOn, str)
+				}
+			}
+		case "tls":
+			b, ok := kv[1].(starlark.Bool)
+			if !ok {
+				return nil, fmt.Errorf("mock_service() tls must be a bool")
+			}
+			ifaceName, err := singleInterfaceName(svc)
+			if err != nil {
+				return nil, fmt.Errorf("mock_service() %q: %w", name, err)
+			}
+			svc.Mock.TLS[ifaceName] = bool(b)
+		}
+	}
+
+	if len(svc.Interfaces) == 0 {
+		return nil, fmt.Errorf("mock_service() %q requires at least one interface", name)
+	}
+
+	// Validate every interface declares a protocol that implements MockHandler.
+	for _, iface := range svc.Interfaces {
+		p, ok := protocol.Get(iface.Protocol)
+		if !ok {
+			return nil, fmt.Errorf("mock_service() %q: unknown protocol %q", name, iface.Protocol)
+		}
+		if _, ok := p.(protocol.MockHandler); !ok {
+			return nil, fmt.Errorf("mock_service() %q: protocol %q does not support mock_service() yet", name, iface.Protocol)
+		}
+	}
+
+	rt.registerService(svc)
+	return svc, nil
+}
+
+func singleInterfaceName(svc *ServiceDef) (string, error) {
+	if len(svc.Interfaces) != 1 {
+		return "", fmt.Errorf("mock_service has %d interfaces, disambiguation required", len(svc.Interfaces))
+	}
+	for name := range svc.Interfaces {
+		return name, nil
+	}
+	return "", fmt.Errorf("mock_service has no interfaces")
+}
+
+func parseRoutesDict(d *starlark.Dict) ([]MockRouteEntry, error) {
+	out := make([]MockRouteEntry, 0, d.Len())
+	for _, pair := range d.Items() {
+		pattern, ok := starlark.AsString(pair[0])
+		if !ok {
+			return nil, fmt.Errorf("route keys must be strings (got %s)", pair[0].Type())
+		}
+		resp, ok := pair[1].(*MockResponseValue)
+		if !ok {
+			return nil, fmt.Errorf("route %q: value must be a mock_response (got %s)", pattern, pair[1].Type())
+		}
+		out = append(out, MockRouteEntry{Pattern: pattern, Response: resp})
+	}
+	return out, nil
+}
+
+// json_response(status, body, headers={}) — encodes body as JSON.
+func builtinJSONResponse(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		statusVal starlark.Value = starlark.MakeInt(200)
+		body      starlark.Value = starlark.None
+		headers   *starlark.Dict
+	)
+	if err := starlark.UnpackArgs("json_response", args, kwargs, "status?", &statusVal, "body?", &body, "headers?", &headers); err != nil {
+		return nil, err
+	}
+
+	status, err := starInt(statusVal)
+	if err != nil {
+		return nil, fmt.Errorf("json_response status: %w", err)
+	}
+	encoded, err := marshalJSONBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("json_response body: %w", err)
+	}
+	resp := &protocol.MockResponse{
+		Status:      status,
+		Body:        encoded,
+		ContentType: "application/json",
+		Headers:     headerDictToMap(headers),
+	}
+	return newStaticResponse(resp), nil
+}
+
+// text_response(status, body, headers={}) — returns plain text.
+func builtinTextResponse(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		statusVal starlark.Value = starlark.MakeInt(200)
+		body      string
+		headers   *starlark.Dict
+	)
+	if err := starlark.UnpackArgs("text_response", args, kwargs, "status?", &statusVal, "body?", &body, "headers?", &headers); err != nil {
+		return nil, err
+	}
+	status, err := starInt(statusVal)
+	if err != nil {
+		return nil, fmt.Errorf("text_response status: %w", err)
+	}
+	resp := &protocol.MockResponse{
+		Status:      status,
+		Body:        []byte(body),
+		ContentType: "text/plain; charset=utf-8",
+		Headers:     headerDictToMap(headers),
+	}
+	return newStaticResponse(resp), nil
+}
+
+// bytes_response(status, data) — returns raw bytes. For TCP/UDP mocks.
+func builtinBytesResponse(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		statusVal starlark.Value = starlark.MakeInt(0)
+		data      string
+	)
+	if err := starlark.UnpackArgs("bytes_response", args, kwargs, "status?", &statusVal, "data?", &data); err != nil {
+		return nil, err
+	}
+	status, err := starInt(statusVal)
+	if err != nil {
+		return nil, fmt.Errorf("bytes_response status: %w", err)
+	}
+	resp := &protocol.MockResponse{
+		Status: status,
+		Body:   []byte(data),
+	}
+	return newStaticResponse(resp), nil
+}
+
+// status_only(code) — HTTP response with a status and empty body.
+func builtinStatusOnly(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var code int
+	if err := starlark.UnpackArgs("status_only", args, kwargs, "code", &code); err != nil {
+		return nil, err
+	}
+	resp := &protocol.MockResponse{Status: code}
+	return newStaticResponse(resp), nil
+}
+
+// redirect(location, status=302) — HTTP redirect with Location header.
+func builtinRedirect(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		location string
+		status   = http.StatusFound
+	)
+	if err := starlark.UnpackArgs("redirect", args, kwargs, "location", &location, "status?", &status); err != nil {
+		return nil, err
+	}
+	resp := &protocol.MockResponse{
+		Status:  status,
+		Headers: map[string]string{"Location": location},
+	}
+	return newStaticResponse(resp), nil
+}
+
+// dynamic(fn) — wraps a Starlark callable as a mock response. The callable
+// receives a request dict and must return a mock_response value.
+func builtinDynamic(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var handler starlark.Value
+	if err := starlark.UnpackArgs("dynamic", args, kwargs, "fn", &handler); err != nil {
+		return nil, err
+	}
+	callable, ok := handler.(starlark.Callable)
+	if !ok {
+		return nil, fmt.Errorf("dynamic() requires a callable (got %s)", handler.Type())
+	}
+	return newDynamicResponse(callable), nil
+}
+
+// headerDictToMap is a small helper that converts a Starlark dict (or nil)
+// into a Go string->string map, skipping entries that aren't string-typed.
+func headerDictToMap(d *starlark.Dict) map[string]string {
+	if d == nil || d.Len() == 0 {
+		return nil
+	}
+	out := make(map[string]string, d.Len())
+	for _, pair := range d.Items() {
+		k, kok := starlark.AsString(pair[0])
+		v, vok := starlark.AsString(pair[1])
+		if kok && vok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// starInt converts a Starlark value that might be Int or String into an int.
+func starInt(v starlark.Value) (int, error) {
+	if i, ok := v.(starlark.Int); ok {
+		n, ok := i.Int64()
+		if !ok {
+			return 0, fmt.Errorf("integer out of range")
+		}
+		return int(n), nil
+	}
+	return 0, fmt.Errorf("expected int (got %s)", v.Type())
+}

--- a/internal/star/mock_runtime.go
+++ b/internal/star/mock_runtime.go
@@ -1,0 +1,190 @@
+package star
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/engine"
+	"github.com/faultbox/Faultbox/internal/protocol"
+)
+
+// startMockService stands up in-process handlers for every interface on a
+// mock service. Each interface runs in its own goroutine; they all share a
+// single cancellation context so stopServices can tear them down.
+func (rt *Runtime) startMockService(ctx context.Context, svcName string, svc *ServiceDef) error {
+	if svc.Mock == nil {
+		return fmt.Errorf("startMockService: %q has nil Mock config", svcName)
+	}
+
+	svcCtx, svcCancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for ifaceName, iface := range svc.Interfaces {
+		p, ok := protocol.Get(iface.Protocol)
+		if !ok {
+			svcCancel()
+			return fmt.Errorf("mock %q: unknown protocol %q", svcName, iface.Protocol)
+		}
+		mh, ok := p.(protocol.MockHandler)
+		if !ok {
+			svcCancel()
+			return fmt.Errorf("mock %q: protocol %q has no mock handler", svcName, iface.Protocol)
+		}
+
+		spec, err := rt.buildMockSpec(svcName, ifaceName, svc)
+		if err != nil {
+			svcCancel()
+			return fmt.Errorf("mock %q interface %q: %w", svcName, ifaceName, err)
+		}
+
+		addr := fmt.Sprintf("127.0.0.1:%d", iface.Port)
+		emit := rt.mockEmitter(svcName, ifaceName)
+
+		wg.Add(1)
+		go func(name, addr string) {
+			defer wg.Done()
+			if err := mh.ServeMock(svcCtx, addr, spec, emit); err != nil {
+				rt.log.Error("mock handler failed",
+					slog.String("service", svcName),
+					slog.String("interface", name),
+					slog.String("error", err.Error()))
+			}
+		}(ifaceName, addr)
+
+		if err := waitMockReady(ctx, addr, 3*time.Second); err != nil {
+			svcCancel()
+			wg.Wait()
+			return fmt.Errorf("mock %q interface %q not ready: %w", svcName, ifaceName, err)
+		}
+
+		rt.log.Info("mock service listening",
+			slog.String("service", svcName),
+			slog.String("interface", ifaceName),
+			slog.String("addr", addr))
+	}
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	rt.sessions[svcName] = &runningSession{
+		session: nil,
+		cancel:  svcCancel,
+		done:    mockDoneChan(done),
+	}
+
+	rt.events.Emit("service_started", svcName, map[string]string{"kind": "mock"})
+	rt.events.Emit("service_ready", svcName, map[string]string{"kind": "mock"})
+	return nil
+}
+
+// buildMockSpec translates a per-interface slice of MockRouteEntry into the
+// protocol-level MockSpec. It wires dynamic handlers through a closure that
+// invokes the Starlark callable on a fresh thread per request.
+func (rt *Runtime) buildMockSpec(svcName, ifaceName string, svc *ServiceDef) (protocol.MockSpec, error) {
+	routes := svc.Mock.Routes[ifaceName]
+	out := protocol.MockSpec{
+		Routes: make([]protocol.MockRoute, 0, len(routes)),
+	}
+
+	for _, entry := range routes {
+		if entry.Response == nil {
+			return out, fmt.Errorf("route %q: empty response", entry.Pattern)
+		}
+		if entry.Response.IsDynamic() {
+			callable := entry.Response.Dynamic()
+			out.Routes = append(out.Routes, protocol.MockRoute{
+				Pattern: entry.Pattern,
+				Dynamic: rt.dynamicHandlerBridge(svcName, ifaceName, entry.Pattern, callable),
+			})
+		} else {
+			out.Routes = append(out.Routes, protocol.MockRoute{
+				Pattern:  entry.Pattern,
+				Response: entry.Response.Static(),
+			})
+		}
+	}
+
+	if def, ok := svc.Mock.Default[ifaceName]; ok && def != nil {
+		if def.IsDynamic() {
+			return out, fmt.Errorf("default response cannot be dynamic() — use a static response")
+		}
+		out.Default = def.Static()
+	}
+
+	return out, nil
+}
+
+// dynamicHandlerBridge wraps a Starlark callable so it satisfies
+// protocol.DynamicFn. Each invocation runs on a fresh Starlark thread; the
+// runtime-wide mutex serializes concurrent invocations to keep Starlark
+// state modifications safe (though mock handlers should not mutate shared
+// state in practice).
+func (rt *Runtime) dynamicHandlerBridge(svcName, ifaceName, pattern string, fn starlark.Callable) protocol.DynamicFn {
+	return func(req protocol.MockRequest) (*protocol.MockResponse, error) {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+
+		thread := &starlark.Thread{Name: fmt.Sprintf("mock-%s-%s-%s", svcName, ifaceName, pattern)}
+		reqDict := toStarlarkRequest(req)
+		result, err := starlark.Call(thread, fn, starlark.Tuple{reqDict}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("dynamic handler %s: %w", pattern, err)
+		}
+		return starlarkResponseToProtocol(result)
+	}
+}
+
+// mockEmitter returns an emit callback that forwards mock-handler events
+// into the runtime event log. The emitter is thread-safe.
+func (rt *Runtime) mockEmitter(svcName, ifaceName string) protocol.MockEmitter {
+	return func(op string, fields map[string]string) {
+		if fields == nil {
+			fields = make(map[string]string, 2)
+		}
+		fields["interface"] = ifaceName
+		fields["kind"] = "mock"
+		fields["op"] = op
+		rt.events.Emit("mock."+op, svcName, fields)
+	}
+}
+
+// waitMockReady TCP-probes addr until the listener accepts or the deadline
+// passes. Mirrors the healthcheck pattern used elsewhere in the runtime.
+func waitMockReady(ctx context.Context, addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("listener on %s not ready after %s", addr, timeout)
+}
+
+// mockDoneChan adapts a struct{} completion channel to the *engine.Result
+// channel type runningSession.done expects. stopServices() only selects on
+// it for synchronization and never reads the value, so closing the channel
+// without sending anything is sufficient.
+func mockDoneChan(done <-chan struct{}) chan *engine.Result {
+	out := make(chan *engine.Result, 1)
+	go func() {
+		<-done
+		close(out)
+	}()
+	return out
+}

--- a/internal/star/mock_runtime_test.go
+++ b/internal/star/mock_runtime_test.go
@@ -1,0 +1,198 @@
+package star
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMockServiceSpecLoad verifies mock_service() parses and registers a
+// service with correct routes + flags, without starting the runtime.
+func TestMockServiceSpecLoad(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+auth = mock_service("auth",
+    interface("http", "http", 18090),
+    routes = {
+        "GET /.well-known/jwks": json_response(status = 200, body = {"keys": []}),
+        "GET /health":            status_only(204),
+    },
+    default = json_response(status = 404, body = {"error": "not found"}),
+)
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	services := rt.Services()
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	svc := services[0]
+	if !svc.IsMock() {
+		t.Fatalf("expected service to be mock")
+	}
+	if svc.IsContainer() {
+		t.Fatalf("mock must not report IsContainer")
+	}
+	if _, ok := svc.Interfaces["http"]; !ok {
+		t.Fatalf("missing http interface: %v", svc.Interfaces)
+	}
+	routes := svc.Mock.Routes["http"]
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].Pattern != "GET /.well-known/jwks" {
+		t.Fatalf("routes[0].Pattern = %q", routes[0].Pattern)
+	}
+	if svc.Mock.Default["http"] == nil {
+		t.Fatal("default response missing")
+	}
+}
+
+// TestMockServiceUnknownProtocol verifies the spec-load guard on protocols
+// without a MockHandler implementation (e.g., postgres today).
+func TestMockServiceUnknownProtocol(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+db = mock_service("db",
+    interface("main", "postgres", 5432),
+)
+`)
+	if err == nil {
+		t.Fatal("expected spec load to fail for protocol without MockHandler")
+	}
+	if !strings.Contains(err.Error(), "does not support mock_service") {
+		t.Fatalf("error mismatch: %v", err)
+	}
+}
+
+// TestMockServiceEndToEnd stands up a mock HTTP service via the runtime,
+// issues a real HTTP request against it, and verifies the response.
+func TestMockServiceEndToEnd(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+auth = mock_service("auth",
+    interface("http", "http", %d),
+    routes = {
+        "GET /.well-known/jwks": json_response(status = 200, body = {"keys": [{"kid": "test-1"}]}),
+        "POST /token":           dynamic(lambda req: json_response(status = 200, body = {"query_user": req["query"].get("user", "anon")})),
+    },
+)
+
+def test_auth_stub():
+    pass
+`, port)
+	if err := rt.LoadString("mock_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Static JSON route.
+	resp, err := client.Get("http://" + addr + "/.well-known/jwks")
+	if err != nil {
+		t.Fatalf("GET jwks: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("jwks status = %d, want 200, body=%q", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `"kid":"test-1"`) {
+		t.Fatalf("jwks body = %q", string(body))
+	}
+
+	// Dynamic route (lambda in spec inspects request).
+	resp, err = client.Post("http://"+addr+"/token?user=alice", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST token: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("token status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `"query_user":"alice"`) {
+		t.Fatalf("token body = %q", string(body))
+	}
+
+	// Unmatched → 404 (default fallback).
+	resp, err = client.Get("http://" + addr + "/missing")
+	if err != nil {
+		t.Fatalf("GET missing: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("missing status = %d, want 404", resp.StatusCode)
+	}
+
+	// Event log should have mock.<op> entries for every handled request.
+	events := rt.events.Events()
+	mockEvents := 0
+	for _, e := range events {
+		if strings.HasPrefix(e.Type, "mock.") {
+			mockEvents++
+		}
+	}
+	if mockEvents < 3 {
+		t.Fatalf("expected >=3 mock.<op> events, got %d (events=%+v)", mockEvents, events)
+	}
+}
+
+// TestMockServiceRestartClean verifies that startServices → stopServices
+// frees the port so a subsequent test can bind it again. Protects against
+// goroutine leaks from the mock handler.
+func TestMockServiceRestartClean(t *testing.T) {
+	port := freePort(t)
+
+	for i := 0; i < 2; i++ {
+		rt := New(testLogger())
+		src := fmt.Sprintf(`
+s = mock_service("s", interface("http", "http", %d),
+    routes = {"GET /": status_only(200)})
+`, port)
+		if err := rt.LoadString("restart.star", src); err != nil {
+			t.Fatalf("iter %d LoadString: %v", i, err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := rt.startServices(ctx); err != nil {
+			cancel()
+			t.Fatalf("iter %d start: %v", i, err)
+		}
+		rt.stopServices()
+		cancel()
+
+		// Port should be re-bindable immediately.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			t.Fatalf("iter %d rebind: %v", i, err)
+		}
+		ln.Close()
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -604,9 +604,12 @@ func (rt *Runtime) startServices(ctx context.Context) error {
 		}
 
 		var err error
-		if svc.IsContainer() {
+		switch {
+		case svc.IsMock():
+			err = rt.startMockService(ctx, svcName, svc)
+		case svc.IsContainer():
 			err = rt.startContainerService(ctx, svcName, svc)
-		} else {
+		default:
 			err = rt.startBinaryService(ctx, svcName, svc)
 		}
 		if err != nil {

--- a/internal/star/types.go
+++ b/internal/star/types.go
@@ -60,12 +60,22 @@ type ServiceDef struct {
 	Seed  starlark.Callable  // initialize service state (runs once after healthcheck)
 	Reset starlark.Callable  // re-initialize between tests (defaults to Seed if nil)
 
+	// Mock service support (RFC-017). When non-nil, this ServiceDef is a
+	// mock: the runtime starts an in-process protocol handler instead of
+	// launching a binary or container.
+	Mock *MockConfig
+
 	rt         *Runtime // set by runtime after registration
 }
 
 // IsContainer returns true if this service uses a container image.
 func (s *ServiceDef) IsContainer() bool {
 	return s.Image != "" || s.Build != ""
+}
+
+// IsMock returns true if this service is a mock (RFC-017).
+func (s *ServiceDef) IsMock() bool {
+	return s.Mock != nil
 }
 
 var _ starlark.Value = (*ServiceDef)(nil)


### PR DESCRIPTION
First slice of the v0.8.0 mock services epic (RFC-017).

## Summary

Introduces the `mock_service()` Starlark builtin plus the `MockHandler` protocol-plugin capability, and ships a complete HTTP implementation end-to-end. Auth/JWKS stubs now work from pure Starlark with no Dockerfile.

## What's in

- **`mock_service(name, *interfaces, routes={}, default=None, tls=False, depends_on=[])`** — generic builtin for request/response protocols.
- **Response constructors** — `json_response`, `text_response`, `bytes_response`, `status_only`, `redirect`.
- **`dynamic(fn)`** — per-request Starlark callback. Handler receives a request dict (`method`, `path`, `headers`, `query`, `body`) and returns a `mock_response`.
- **HTTP protocol** — `ServeMock()` with `METHOD PATTERN` route matching, `*` and `**` globs, content-type defaulting, custom headers, and 404 fallback.
- **Runtime wiring** — mocks branch off binary/container paths in `startServices`, share the existing `stopServices` cleanup, and emit `mock.<op>` events into the event log like any real service.

## What's NOT in (subsequent PRs in this epic)

- HTTP/2 mock handler (h2c listener; shares route matcher with HTTP)
- TCP / UDP mock handlers
- gRPC mock handler (reflection-based, `proto=` optional)
- TLS (self-signed cert + Faultbox CA bundle)
- `@faultbox/mocks/kafka.star`, `@faultbox/mocks/redis.star`, `@faultbox/mocks/mongodb.star` stdlib modules
- Docs sync (`docs/spec-language.md`, tutorial chapter)

## Files

| File | Role |
|---|---|
| `internal/protocol/mock.go` | `MockHandler` / `MockSpec` / `MockResponse` / `DynamicFn` plugin contract |
| `internal/protocol/http.go` | HTTP `ServeMock` + route matching + glob engine |
| `internal/protocol/mock_test.go` | Wire-level tests — static, dynamic, default, glob edge cases |
| `internal/star/mock.go` | `MockResponseValue` Starlark type + Starlark↔Go converters |
| `internal/star/mock_builtins.go` | `mock_service` + response constructors + `dynamic` |
| `internal/star/mock_runtime.go` | `startMockService` + dynamic handler bridge + port-ready probe |
| `internal/star/mock_runtime_test.go` | Spec-load + end-to-end HTTP round-trip + restart-clean |
| `internal/star/types.go` | `ServiceDef.Mock` field + `IsMock()` |
| `internal/star/runtime.go` | Switch in `startServices` for mocks |
| `internal/star/builtins.go` | Register new builtins |

## Test plan

- [x] `go test ./...` — all pass (new mock tests + no regressions in 11 existing packages)
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean
- [x] Full stack exercised: Starlark spec → `startServices` → real HTTP GET/POST → response verified → `stopServices` → port re-bindable

## Example (tested end-to-end)

```python
auth = mock_service("auth",
    interface("http", "http", 8090),
    routes = {
        "GET /.well-known/jwks": json_response(status = 200, body = {"keys": [{"kid": "test-1"}]}),
        "POST /token":           dynamic(lambda req: json_response(
            status = 200,
            body   = {"user": req["query"].get("user", "anon")},
        )),
    },
)

def test_auth_stub():
    pass
```

A real `net/http` client gets `{"keys":[{"kid":"test-1"}]}` from the JWKS endpoint and `{"user":"alice"}` from `POST /token?user=alice`. Unmatched paths fall through to 404 (or a configured default).

## Links

- RFC: #31 (amended for v0.8.0 scope)
- Milestone: [v0.8.0](https://github.com/faultbox/Faultbox/milestone/1)
- Related: RFC-020 (#39) SQL mocks, RFC-021 (#40) OpenAPI generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)