### PR TITLE
feat(rfc-017): TCP + UDP mock handlers (step 3/N)

### DIFF
--- a/internal/protocol/mock_test.go
+++ b/internal/protocol/mock_test.go
@@ -369,6 +369,155 @@ func TestHTTP2MockDynamicHandler(t *testing.T) {
 	}
 }
 
+// TestTCPMockLineFramed verifies byte-prefix matching on line-framed input.
+func TestTCPMockLineFramed(t *testing.T) {
+	p := &tcpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Routes: []MockRoute{
+			{Pattern: "PING\n", Response: &MockResponse{Body: []byte("PONG\n")}},
+			{Pattern: "VERSION", Response: &MockResponse{Body: []byte("2.0.0\n")}},
+		},
+		Default: &MockResponse{Body: []byte("ERR unknown\n")},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- p.ServeMock(ctx, addr, spec, nil) }()
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mock not listening: %v", err)
+	}
+
+	cases := []struct {
+		send, want string
+	}{
+		{"PING\n", "PONG\n"},
+		{"VERSION\n", "2.0.0\n"},
+		{"BOGUS\n", "ERR unknown\n"},
+	}
+	for _, tc := range cases {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			t.Fatalf("dial %q: %v", tc.send, err)
+		}
+		_, _ = conn.Write([]byte(tc.send))
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, 64)
+		n, _ := conn.Read(buf)
+		conn.Close()
+		if string(buf[:n]) != tc.want {
+			t.Errorf("send %q: got %q, want %q", tc.send, buf[:n], tc.want)
+		}
+	}
+
+	cancel()
+	select {
+	case <-serveErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down in time")
+	}
+}
+
+// TestTCPMockDynamicHandler exercises the dynamic path for TCP.
+func TestTCPMockDynamicHandler(t *testing.T) {
+	p := &tcpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Routes: []MockRoute{{
+			Pattern: "ECHO ",
+			Dynamic: func(req MockRequest) (*MockResponse, error) {
+				// Reflect the body back, prefixed with ACK.
+				return &MockResponse{Body: append([]byte("ACK "), req.Body...)}, nil
+			},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, spec, nil)
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mock not listening: %v", err)
+	}
+
+	conn, _ := net.DialTimeout("tcp", addr, time.Second)
+	_, _ = conn.Write([]byte("ECHO hello\n"))
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	buf := make([]byte, 64)
+	n, _ := conn.Read(buf)
+	conn.Close()
+	if string(buf[:n]) != "ACK ECHO hello\n" {
+		t.Fatalf("echo response = %q", buf[:n])
+	}
+}
+
+// TestUDPMockSwallowAndRecord verifies the StatsD pattern: no routes, no
+// response, every datagram emitted as an event.
+func TestUDPMockSwallowAndRecord(t *testing.T) {
+	p := &udpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	emitted := &recordedEmits{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, MockSpec{}, emitted.emit)
+
+	// Brief wait for listen.
+	time.Sleep(50 * time.Millisecond)
+
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		_, _ = conn.Write([]byte(fmt.Sprintf("metric:%d|c", i)))
+	}
+	conn.Close()
+
+	// Let the goroutine catch up.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if emitted.count() >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := emitted.count(); got < 3 {
+		t.Fatalf("emitter called %d times, want >=3", got)
+	}
+}
+
+// TestUDPMockPrefixResponse verifies prefix matching + response write-back.
+func TestUDPMockPrefixResponse(t *testing.T) {
+	p := &udpProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Routes: []MockRoute{
+			{Pattern: "PING", Response: &MockResponse{Body: []byte("PONG")}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, spec, nil)
+	time.Sleep(50 * time.Millisecond)
+
+	conn, _ := net.Dial("udp", addr)
+	defer conn.Close()
+	_, _ = conn.Write([]byte("PING\n"))
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	buf := make([]byte, 64)
+	n, _ := conn.Read(buf)
+	if string(buf[:n]) != "PONG" {
+		t.Fatalf("response = %q, want PONG", buf[:n])
+	}
+}
+
 // --- test helpers ---
 
 type recordedEmits struct {

--- a/internal/protocol/tcp.go
+++ b/internal/protocol/tcp.go
@@ -2,8 +2,10 @@ package protocol
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -77,4 +79,96 @@ func (p *tcpProtocol) ExecuteStep(ctx context.Context, addr, method string, kwar
 		Success:    true,
 		DurationMs: time.Since(start).Milliseconds(),
 	}, nil
+}
+
+// ServeMock implements MockHandler for TCP. Each accepted connection is
+// handled on its own goroutine: the handler reads one newline-terminated
+// line, matches it against route patterns as byte prefixes, writes the
+// corresponding response, and closes the connection.
+//
+// Patterns and responses work on raw bytes — typically line-framed ASCII
+// ("PING\n" -> "PONG\n") which is the common pattern for legacy TCP tools.
+// For non-line-framed protocols, users should use a protocol-specific mock
+// from @faultbox/mocks/<name>.star.
+func (p *tcpProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("mock listen %s: %w", addr, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		go handleTCPMockConn(ctx, conn, spec, emit)
+	}
+}
+
+func handleTCPMockConn(ctx context.Context, conn net.Conn, spec MockSpec, emit MockEmitter) {
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadBytes('\n')
+	if err != nil && err != io.EOF {
+		emitWith(emit, "recv_error", map[string]string{"error": err.Error()})
+		return
+	}
+
+	route, matched := matchBytesRoute(spec.Routes, line)
+
+	var resp *MockResponse
+	switch {
+	case matched && route.Dynamic != nil:
+		dyn, derr := route.Dynamic(MockRequest{Body: line})
+		if derr != nil {
+			emitWith(emit, "dynamic_error", map[string]string{"error": derr.Error()})
+			return
+		}
+		resp = dyn
+	case matched:
+		resp = route.Response
+	case spec.Default != nil:
+		resp = spec.Default
+	}
+
+	if resp != nil && len(resp.Body) > 0 {
+		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		if _, werr := conn.Write(resp.Body); werr != nil {
+			emitWith(emit, "write_error", map[string]string{"error": werr.Error()})
+			return
+		}
+	}
+	emitWith(emit, "recv", map[string]string{
+		"req_size":  fmt.Sprintf("%d", len(line)),
+		"resp_size": fmt.Sprintf("%d", bodyLen(resp)),
+		"matched":   fmt.Sprintf("%t", matched),
+	})
+}
+
+// matchBytesRoute returns the first route whose pattern is a byte prefix of
+// target. Used by TCP and UDP mock handlers.
+func matchBytesRoute(routes []MockRoute, target []byte) (MockRoute, bool) {
+	for _, r := range routes {
+		if bytes.HasPrefix(target, []byte(r.Pattern)) {
+			return r, true
+		}
+	}
+	return MockRoute{}, false
+}
+
+func bodyLen(resp *MockResponse) int {
+	if resp == nil {
+		return 0
+	}
+	return len(resp.Body)
 }

--- a/internal/protocol/udp.go
+++ b/internal/protocol/udp.go
@@ -88,6 +88,75 @@ func (p *udpProtocol) ExecuteStep(ctx context.Context, addr, method string, kwar
 	}
 }
 
+// ServeMock implements MockHandler for UDP. The default behavior is
+// swallow-and-record — every received datagram emits an event but nothing
+// is written back. This matches the common StatsD / metrics-sink pattern.
+//
+// If spec.Routes contains patterns, datagrams whose prefix matches receive
+// the configured response (sent back to the source address). If
+// spec.Default is set, unmatched datagrams get the default response.
+func (p *udpProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	pc, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return fmt.Errorf("mock listen %s: %w", addr, err)
+	}
+	defer pc.Close()
+
+	go func() {
+		<-ctx.Done()
+		_ = pc.Close()
+	}()
+
+	buf := make([]byte, 64*1024)
+	for {
+		_ = pc.SetReadDeadline(time.Now().Add(1 * time.Second))
+		n, src, err := pc.ReadFrom(buf)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+
+		datagram := make([]byte, n)
+		copy(datagram, buf[:n])
+		go handleUDPDatagram(pc, src, datagram, spec, emit)
+	}
+}
+
+func handleUDPDatagram(pc net.PacketConn, src net.Addr, datagram []byte, spec MockSpec, emit MockEmitter) {
+	route, matched := matchBytesRoute(spec.Routes, datagram)
+
+	var resp *MockResponse
+	switch {
+	case matched && route.Dynamic != nil:
+		dyn, err := route.Dynamic(MockRequest{Body: datagram})
+		if err != nil {
+			emitWith(emit, "dynamic_error", map[string]string{"error": err.Error()})
+			return
+		}
+		resp = dyn
+	case matched:
+		resp = route.Response
+	case spec.Default != nil:
+		resp = spec.Default
+	}
+
+	if resp != nil && len(resp.Body) > 0 {
+		_, _ = pc.WriteTo(resp.Body, src)
+	}
+
+	emitWith(emit, "recv", map[string]string{
+		"req_size":  fmt.Sprintf("%d", len(datagram)),
+		"resp_size": fmt.Sprintf("%d", bodyLen(resp)),
+		"matched":   fmt.Sprintf("%t", matched),
+		"src":       src.String(),
+	})
+}
+
 // extractUDPPayload reads the `data=` (utf-8 string) or `hex=` kwarg and
 // returns the bytes to send. At least one must be provided.
 func extractUDPPayload(kwargs map[string]any) ([]byte, error) {

--- a/internal/star/mock_runtime.go
+++ b/internal/star/mock_runtime.go
@@ -58,7 +58,7 @@ func (rt *Runtime) startMockService(ctx context.Context, svcName string, svc *Se
 			}
 		}(ifaceName, addr)
 
-		if err := waitMockReady(ctx, addr, 3*time.Second); err != nil {
+		if err := waitMockReady(ctx, iface.Protocol, addr, 3*time.Second); err != nil {
 			svcCancel()
 			wg.Wait()
 			return fmt.Errorf("mock %q interface %q not ready: %w", svcName, ifaceName, err)
@@ -157,23 +157,45 @@ func (rt *Runtime) mockEmitter(svcName, ifaceName string) protocol.MockEmitter {
 	}
 }
 
-// waitMockReady TCP-probes addr until the listener accepts or the deadline
-// passes. Mirrors the healthcheck pattern used elsewhere in the runtime.
-func waitMockReady(ctx context.Context, addr string, timeout time.Duration) error {
+// waitMockReady probes addr until the listener is bound or the deadline
+// passes. TCP-based protocols (tcp, http, http2) use a dial probe; UDP is
+// probed by trying to re-bind the same port — if the bind fails with
+// EADDRINUSE, the mock has claimed it. Unknown protocols fall back to TCP
+// (safest default; fails fast if wrong).
+func waitMockReady(ctx context.Context, proto, addr string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-		if err == nil {
-			conn.Close()
+		if mockListenerUp(proto, addr) {
 			return nil
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(25 * time.Millisecond):
 		}
 	}
-	return fmt.Errorf("listener on %s not ready after %s", addr, timeout)
+	return fmt.Errorf("listener on %s (proto=%s) not ready after %s", addr, proto, timeout)
+}
+
+func mockListenerUp(proto, addr string) bool {
+	switch proto {
+	case "udp":
+		// Attempt to bind the same port — success means nothing is listening,
+		// failure means the mock has the port.
+		pc, err := net.ListenPacket("udp", addr)
+		if err != nil {
+			return true
+		}
+		pc.Close()
+		return false
+	default:
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		return false
+	}
 }
 
 // mockDoneChan adapts a struct{} completion channel to the *engine.Result

--- a/internal/star/mock_runtime_test.go
+++ b/internal/star/mock_runtime_test.go
@@ -250,6 +250,105 @@ def test_h2_stub():
 	}
 }
 
+// TestMockServiceTCP verifies a TCP mock_service stands up and responds to
+// line-framed input according to bytes_response() routes.
+func TestMockServiceTCP(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+legacy = mock_service("legacy",
+    interface("main", "tcp", %d),
+    routes = {
+        "PING\n":    bytes_response(data = "PONG\n"),
+        "VERSION\n": bytes_response(data = "2.0.0\n"),
+    },
+    default = bytes_response(data = "ERR\n"),
+)
+
+def test_tcp():
+    pass
+`, port)
+	if err := rt.LoadString("tcp_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	cases := []struct{ in, want string }{
+		{"PING\n", "PONG\n"},
+		{"VERSION\n", "2.0.0\n"},
+		{"HUH\n", "ERR\n"},
+	}
+	for _, tc := range cases {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		_, _ = conn.Write([]byte(tc.in))
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, 64)
+		n, _ := conn.Read(buf)
+		conn.Close()
+		if string(buf[:n]) != tc.want {
+			t.Errorf("send %q: got %q, want %q", tc.in, buf[:n], tc.want)
+		}
+	}
+}
+
+// TestMockServiceUDP verifies a UDP mock_service swallows datagrams by
+// default and emits one event per datagram into the runtime event log.
+func TestMockServiceUDP(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+statsd = mock_service("statsd",
+    interface("main", "udp", %d),
+)
+`, port)
+	if err := rt.LoadString("udp_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		_, _ = conn.Write([]byte(fmt.Sprintf("gauge.%d:%d|g", i, i)))
+	}
+	conn.Close()
+
+	// Event log should have >=5 mock.recv entries after a brief wait.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		count := 0
+		for _, e := range rt.events.Events() {
+			if e.Type == "mock.recv" {
+				count++
+			}
+		}
+		if count >= 5 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("expected >=5 mock.recv events; final events: %+v", rt.events.Events())
+}
+
 // newTestH2CClient returns an HTTP client that speaks h2c. Local to this
 // file to avoid reaching into the protocol package's unexported helpers.
 func newTestH2CClient() *http.Client {


### PR DESCRIPTION
Third slice of the v0.8.0 mock services epic. Adds `ServeMock()` for the TCP and UDP protocol plugins and fixes the readiness probe for connectionless listeners.

## Summary

| Protocol | Behavior |
|---|---|
| **TCP** | Accept connection → read one newline-terminated line → match as byte prefix → write response → close. 10s read / 5s write deadlines. |
| **UDP** | Default: swallow every datagram, emit `mock.recv` event with src + size. With routes: write response to source addr when prefix matches. |

## Design notes

- **Byte-prefix matching** is shared between TCP and UDP via `matchBytesRoute()` — same helper, two callers.
- **Dynamic handlers** work identically to HTTP — `MockRequest.Body` carries the line (TCP) or datagram (UDP).
- **UDP readiness probe** fixed: `waitMockReady` now branches on protocol name. TCP-based protocols continue to use dial; UDP uses a bind-test (attempt to re-bind → EADDRINUSE means the mock has the port). Without this, every UDP `mock_service()` failed at startup.

## Files

| File | Role |
|---|---|
| `internal/protocol/tcp.go` | `ServeMock()` + `handleTCPMockConn` + `matchBytesRoute` + `bodyLen` |
| `internal/protocol/udp.go` | `ServeMock()` + `handleUDPDatagram` |
| `internal/protocol/mock_test.go` | 4 wire-level tests |
| `internal/star/mock_runtime.go` | Protocol-aware readiness probe |
| `internal/star/mock_runtime_test.go` | 2 spec-level tests |

## Test plan

- [x] `go test ./...` — all pass (17 total mock tests now: 13 existing + 4 new)
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean

## Examples (tested end-to-end)

**TCP legacy echo:**
```python
legacy = mock_service("legacy",
    interface("main", "tcp", 9000),
    routes = {
        "PING\n":    bytes_response(data = "PONG\n"),
        "VERSION\n": bytes_response(data = "2.0.0\n"),
    },
    default = bytes_response(data = "ERR\n"),
)
```

**UDP StatsD sink:**
```python
statsd = mock_service("statsd",
    interface("main", "udp", 8125),
    # no routes → swallow every datagram, assert on events()
)
```

Spec-level test verifies 5 datagrams produce 5 `mock.recv` events in the runtime event log.

## Links

- RFC: #31
- Milestone: [v0.8.0](https://github.com/faultbox/Faultbox/milestone/1)
- Previous PRs: #41 (step 1 — HTTP), #42 (step 2 — HTTP/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)