### PR TITLE
feat(rfc-017): Redis + MongoDB stdlib mocks (step 4b/N)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.21 // indirect
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -60,6 +61,7 @@ require (
 	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.4.21 h1:+6mVbXh4wPzUrl1COX9A+ZCvEpYsOBZ6/+kwDnvLyro=
 github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -135,6 +137,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver/v2 v2.5.1 h1:j2U/Qp+wvueSpqitLCSZPT/+ZpVc1xzuwdHWwl7d8ro=
 go.mongodb.org/mongo-driver/v2 v2.5.1/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/protocol/mock_test.go
+++ b/internal/protocol/mock_test.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	"github.com/segmentio/kafka-go"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	mongoopts "go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // TestHTTPMockStaticRoutes verifies that the HTTP MockHandler matches
@@ -592,6 +595,163 @@ func waitKafkaMockReady(addr string, timeout time.Duration) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("kafka mock not answering at %s", addr)
+}
+
+// TestRedisMockBasic verifies the Redis mock stands up via miniredis and a
+// real redis client (raw RESP over TCP for minimal deps) can GET + SET +
+// INCR + read seeded state.
+func TestRedisMockBasic(t *testing.T) {
+	p := &redisProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Config: map[string]any{
+			"state": map[string]any{
+				"config:timeout": "5000",
+				"flag:new_ui":    "true",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, spec, nil)
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("redis mock not listening: %v", err)
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	// Seeded GET
+	if got := redisRoundtrip(t, conn, "GET", "config:timeout"); got != "5000" {
+		t.Errorf("GET config:timeout = %q, want 5000", got)
+	}
+	// SET + GET
+	if got := redisRoundtrip(t, conn, "SET", "k", "v"); got != "OK" {
+		t.Errorf("SET = %q", got)
+	}
+	if got := redisRoundtrip(t, conn, "GET", "k"); got != "v" {
+		t.Errorf("GET k = %q, want v", got)
+	}
+	// INCR
+	if got := redisRoundtrip(t, conn, "INCR", "counter"); got != "1" {
+		t.Errorf("INCR counter = %q, want 1", got)
+	}
+	if got := redisRoundtrip(t, conn, "INCR", "counter"); got != "2" {
+		t.Errorf("INCR counter (2) = %q, want 2", got)
+	}
+}
+
+// redisRoundtrip sends an inline Redis command and reads one RESP reply.
+// Strips type markers (+, :, $) and returns the raw payload. Minimal
+// parser — sufficient for the string-cache test surface.
+func redisRoundtrip(t *testing.T, conn net.Conn, args ...string) string {
+	t.Helper()
+	// Build a RESP array of bulk strings.
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "*%d\r\n", len(args))
+	for _, a := range args {
+		fmt.Fprintf(&sb, "$%d\r\n%s\r\n", len(a), a)
+	}
+	if _, err := conn.Write([]byte(sb.String())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	buf := make([]byte, 256)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	resp := string(buf[:n])
+	resp = strings.TrimRight(resp, "\r\n")
+	// Trim the RESP type byte and, for bulk strings, the length line.
+	switch {
+	case strings.HasPrefix(resp, "+"):
+		return resp[1:]
+	case strings.HasPrefix(resp, ":"):
+		return resp[1:]
+	case strings.HasPrefix(resp, "$"):
+		lines := strings.SplitN(resp, "\r\n", 2)
+		if len(lines) == 2 {
+			return lines[1]
+		}
+		return resp
+	case strings.HasPrefix(resp, "-"):
+		return "ERR:" + resp[1:]
+	default:
+		return resp
+	}
+}
+
+// TestMongoMockHandshakeAndFind verifies the MongoDB mock completes the
+// driver handshake and returns seeded documents via a raw OP_MSG round-trip.
+func TestMongoMockHandshakeAndFind(t *testing.T) {
+	p := &mongoProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	spec := MockSpec{
+		Config: map[string]any{
+			"collections": map[string]any{
+				"users": []any{
+					map[string]any{"_id": "1", "name": "alice"},
+					map[string]any{"_id": "2", "name": "bob"},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.ServeMock(ctx, addr, spec, nil)
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("mongo mock not listening: %v", err)
+	}
+
+	// Use the real mongo driver to verify end-to-end wire compatibility.
+	clientOpts := mongoopts.Client().
+		ApplyURI("mongodb://" + addr).
+		SetServerSelectionTimeout(3 * time.Second).
+		SetConnectTimeout(3 * time.Second)
+	client, err := mongo.Connect(clientOpts)
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	defer client.Disconnect(context.Background())
+
+	cctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ccancel()
+
+	// Ping exercises the handshake path.
+	if err := client.Ping(cctx, nil); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	// Find on a seeded collection.
+	cur, err := client.Database("mock").Collection("users").Find(cctx, bson.M{})
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	var results []bson.M
+	if err := cur.All(cctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2 (%+v)", len(results), results)
+	}
+	names := map[string]bool{}
+	for _, r := range results {
+		if n, ok := r["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	if !names["alice"] || !names["bob"] {
+		t.Errorf("expected alice+bob, got %v", names)
+	}
 }
 
 // --- test helpers ---

--- a/internal/protocol/mongodb_mock.go
+++ b/internal/protocol/mongodb_mock.go
@@ -1,0 +1,395 @@
+package protocol
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// ServeMock implements MockHandler for MongoDB. It answers the subset of
+// OP_MSG commands that a typical application needs at startup and for
+// simple read-through usage:
+//
+//   - hello / isMaster / ismaster  → server-info document (required for
+//     drivers to complete the handshake)
+//   - ping                         → ok: 1
+//   - buildInfo                    → ok: 1 + minimal version
+//   - find                         → cursor with firstBatch from config
+//                                    collections["<name>"]
+//   - findOne (implemented as find with limit=1)
+//   - insert / update / delete     → ok: 1 + n (writes discarded — this
+//                                    mock is for read-through tests)
+//   - getMore                      → empty cursor (terminates iteration)
+//
+// Any unrecognized command returns ok: 1 with no payload — lenient by
+// design, so unexpected commands don't fail the test with a protocol
+// mismatch. Users who need strict semantics should run the real MongoDB.
+//
+// Configuration keys (from spec.Config):
+//
+//	collections: map[string]any — collection name → list of BSON documents
+//	  served by find/findOne. Each document is a map[string]any.
+//	  Pre-population; no updates at runtime.
+//
+// Wire: real BSON OP_MSG (shares encoding with the RFC-016 MongoDB proxy).
+func (p *mongoProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("mock mongodb listen %s: %w", addr, err)
+	}
+
+	collections := extractCollections(spec.Config)
+	state := &mongoMockState{collections: collections}
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		go handleMongoMockConn(ctx, conn, state, emit)
+	}
+}
+
+type mongoMockState struct {
+	collections map[string][]map[string]any
+	requestID   atomic.Int32
+}
+
+func extractCollections(config map[string]any) map[string][]map[string]any {
+	out := make(map[string][]map[string]any)
+	raw, ok := config["collections"]
+	if !ok {
+		return out
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return out
+	}
+	for name, docsRaw := range m {
+		docs, ok := docsRaw.([]any)
+		if !ok {
+			continue
+		}
+		coll := make([]map[string]any, 0, len(docs))
+		for _, d := range docs {
+			if doc, ok := d.(map[string]any); ok {
+				coll = append(coll, doc)
+			}
+		}
+		out[name] = coll
+	}
+	return out
+}
+
+func handleMongoMockConn(ctx context.Context, conn net.Conn, state *mongoMockState, emit MockEmitter) {
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+	header := make([]byte, 16)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+		if _, err := io.ReadFull(conn, header); err != nil {
+			return
+		}
+
+		msgLen := binary.LittleEndian.Uint32(header[0:4])
+		reqID := binary.LittleEndian.Uint32(header[4:8])
+		opCode := binary.LittleEndian.Uint32(header[12:16])
+
+		if msgLen < 16 || msgLen > 48*1024*1024 {
+			return
+		}
+		body := make([]byte, msgLen-16)
+		if _, err := io.ReadFull(conn, body); err != nil {
+			return
+		}
+
+		if opCode == opQueryCode {
+			// Initial driver handshake. Parse the embedded query document,
+			// dispatch by command, and reply as OP_REPLY.
+			cmd, doc := parseOPQuery(body)
+			emitWith(emit, "op_query", map[string]string{"cmd": cmd})
+			respDoc := state.respondToCommand(cmd, "", doc)
+			if err := sendMongoOPReply(conn, reqID, respDoc, state); err != nil {
+				emitWith(emit, "write_error", map[string]string{"error": err.Error()})
+				return
+			}
+			continue
+		}
+
+		if opCode != opMsgCode {
+			emitWith(emit, "unknown_opcode", map[string]string{
+				"opcode": fmt.Sprintf("%d", opCode),
+			})
+			continue
+		}
+
+		cmd, coll := parseOPMSGCmd(body)
+		emitWith(emit, "cmd", map[string]string{
+			"cmd":        cmd,
+			"collection": coll,
+			"body_size":  fmt.Sprintf("%d", len(body)),
+		})
+		resp := state.respondToCommand(cmd, coll, body)
+		if err := sendMongoMockReply(conn, reqID, resp, state); err != nil {
+			emitWith(emit, "write_error", map[string]string{"error": err.Error()})
+			return
+		}
+		emitWith(emit, "reply_sent", map[string]string{"cmd": cmd})
+	}
+}
+
+// MongoDB wire opcodes we handle. Modern drivers (v2+) use OP_QUERY for
+// the very first handshake so they work against old servers, then switch
+// to OP_MSG once the server's maxWireVersion is confirmed.
+const (
+	opMsgCode   = 2013 // OP_MSG
+	opQueryCode = 2004 // OP_QUERY (legacy handshake path)
+	opReplyCode = 1    // OP_REPLY (legacy handshake response)
+)
+
+// parseOPMSGCmd extracts the command name and collection from an OP_MSG
+// body (same logic as internal/proxy/mongodb.go).
+func parseOPMSGCmd(body []byte) (cmd string, collection string) {
+	if len(body) < 5 {
+		return "", ""
+	}
+	offset := 4 // skip flagBits
+	if body[offset] != 0 {
+		return "", ""
+	}
+	offset++
+	if offset+4 > len(body) {
+		return "", ""
+	}
+	bsonLen := int(binary.LittleEndian.Uint32(body[offset:]))
+	if offset+bsonLen > len(body) {
+		return "", ""
+	}
+	bsonDoc := body[offset : offset+bsonLen]
+
+	pos := 4
+	if pos >= len(bsonDoc) {
+		return "", ""
+	}
+	elemType := bsonDoc[pos]
+	pos++
+	keyStart := pos
+	for pos < len(bsonDoc) && bsonDoc[pos] != 0 {
+		pos++
+	}
+	if pos >= len(bsonDoc) {
+		return "", ""
+	}
+	cmd = string(bsonDoc[keyStart:pos])
+	pos++
+
+	if elemType == 0x02 { // string
+		if pos+4 > len(bsonDoc) {
+			return cmd, ""
+		}
+		strLen := int(binary.LittleEndian.Uint32(bsonDoc[pos:]))
+		pos += 4
+		if pos+strLen > len(bsonDoc) {
+			return cmd, ""
+		}
+		collection = string(bsonDoc[pos : pos+strLen-1])
+	}
+	return cmd, collection
+}
+
+// respondToCommand produces the BSON response document for a given command.
+// Each branch hand-picks the fields the official drivers check at handshake
+// and read time.
+func (s *mongoMockState) respondToCommand(cmd, coll string, body []byte) bson.M {
+	switch cmd {
+	case "hello", "isMaster", "ismaster":
+		return bson.M{
+			"ok":                           1.0,
+			"ismaster":                     true,
+			"isWritablePrimary":            true,
+			"maxBsonObjectSize":            int32(16777216),
+			"maxMessageSizeBytes":          int32(48000000),
+			"maxWriteBatchSize":            int32(100000),
+			"logicalSessionTimeoutMinutes": int32(30),
+			"connectionId":                 int32(1),
+			"minWireVersion":               int32(8),
+			"maxWireVersion":               int32(17),
+			"readOnly":                     false,
+			"topologyVersion": bson.M{
+				"processId": bson.NewObjectID(),
+				"counter":   int64(0),
+			},
+		}
+	case "ping":
+		return bson.M{"ok": 1.0}
+	case "buildInfo", "buildinfo":
+		return bson.M{
+			"ok":           1.0,
+			"version":      "7.0.0",
+			"gitVersion":   "faultbox-mock",
+			"versionArray": bson.A{7, 0, 0, 0},
+			"maxBsonObjectSize": 16777216,
+		}
+	case "find", "findOne":
+		docs := s.collections[coll]
+		batch := bson.A{}
+		for _, d := range docs {
+			batch = append(batch, bson.M(d))
+		}
+		return bson.M{
+			"ok": 1.0,
+			"cursor": bson.M{
+				"id":         int64(0), // exhausted cursor — client stops here
+				"ns":         "mock." + coll,
+				"firstBatch": batch,
+			},
+		}
+	case "getMore":
+		return bson.M{
+			"ok": 1.0,
+			"cursor": bson.M{
+				"id":       int64(0),
+				"ns":       "mock." + coll,
+				"nextBatch": bson.A{},
+			},
+		}
+	case "insert":
+		return bson.M{"ok": 1.0, "n": 1}
+	case "update":
+		return bson.M{"ok": 1.0, "n": 1, "nModified": 1}
+	case "delete":
+		return bson.M{"ok": 1.0, "n": 1}
+	case "endSessions", "abortTransaction", "commitTransaction":
+		return bson.M{"ok": 1.0}
+	default:
+		// Lenient fallback: acknowledge but don't claim support.
+		return bson.M{"ok": 1.0}
+	}
+}
+
+// parseOPQuery extracts the command name from an OP_QUERY body. Body layout:
+// flags(4) + fullCollectionName(cstring) + numberToSkip(4) + numberToReturn(4)
+// + query(BSON). The first key of the query document is the command name.
+func parseOPQuery(body []byte) (cmd string, body2 []byte) {
+	if len(body) < 4 {
+		return "", nil
+	}
+	offset := 4 // flags
+	// fullCollectionName: null-terminated cstring.
+	end := offset
+	for end < len(body) && body[end] != 0 {
+		end++
+	}
+	offset = end + 1
+	// numberToSkip + numberToReturn
+	offset += 8
+	if offset+4 > len(body) {
+		return "", nil
+	}
+	bsonLen := int(binary.LittleEndian.Uint32(body[offset:]))
+	if offset+bsonLen > len(body) {
+		return "", nil
+	}
+	bsonDoc := body[offset : offset+bsonLen]
+	// Parse first element to get command name.
+	pos := 4
+	if pos >= len(bsonDoc) {
+		return "", bsonDoc
+	}
+	pos++ // elem type
+	keyStart := pos
+	for pos < len(bsonDoc) && bsonDoc[pos] != 0 {
+		pos++
+	}
+	if pos >= len(bsonDoc) {
+		return "", bsonDoc
+	}
+	cmd = string(bsonDoc[keyStart:pos])
+	return cmd, bsonDoc
+}
+
+// sendMongoOPReply writes an OP_REPLY (legacy handshake response) containing
+// exactly one BSON document. Body layout:
+// responseFlags(4) + cursorID(8) + startingFrom(4) + numberReturned(4) + docs
+func sendMongoOPReply(conn net.Conn, respondTo uint32, doc bson.M, state *mongoMockState) error {
+	bsonData, err := bson.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	body := make([]byte, 0, 20+len(bsonData))
+	// responseFlags = 0
+	body = append(body, 0, 0, 0, 0)
+	// cursorID = 0
+	body = append(body, 0, 0, 0, 0, 0, 0, 0, 0)
+	// startingFrom = 0
+	body = append(body, 0, 0, 0, 0)
+	// numberReturned = 1
+	nr := make([]byte, 4)
+	binary.LittleEndian.PutUint32(nr, 1)
+	body = append(body, nr...)
+	// Documents
+	body = append(body, bsonData...)
+
+	totalLen := uint32(16 + len(body))
+	reqID := uint32(state.requestID.Add(1))
+	frame := make([]byte, 0, int(totalLen))
+	header := make([]byte, 16)
+	binary.LittleEndian.PutUint32(header[0:4], totalLen)
+	binary.LittleEndian.PutUint32(header[4:8], reqID)
+	binary.LittleEndian.PutUint32(header[8:12], respondTo)
+	binary.LittleEndian.PutUint32(header[12:16], opReplyCode)
+	frame = append(frame, header...)
+	frame = append(frame, body...)
+
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_, err = conn.Write(frame)
+	return err
+}
+
+// sendMongoMockReply writes an OP_MSG response with the given BSON document.
+func sendMongoMockReply(conn net.Conn, respondTo uint32, doc bson.M, state *mongoMockState) error {
+	bsonData, err := bson.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	// OP_MSG body: flagBits(4) + section kind 0 + BSON document.
+	body := make([]byte, 0, 4+1+len(bsonData))
+	body = append(body, 0, 0, 0, 0)
+	body = append(body, 0)
+	body = append(body, bsonData...)
+
+	// Header: messageLength(4) + requestID(4) + responseTo(4) + opCode(4).
+	totalLen := uint32(16 + len(body))
+	reqID := uint32(state.requestID.Add(1))
+	frame := make([]byte, 0, int(totalLen))
+	header := make([]byte, 16)
+	binary.LittleEndian.PutUint32(header[0:4], totalLen)
+	binary.LittleEndian.PutUint32(header[4:8], reqID)
+	binary.LittleEndian.PutUint32(header[8:12], respondTo)
+	binary.LittleEndian.PutUint32(header[12:16], opMsgCode)
+	frame = append(frame, header...)
+	frame = append(frame, body...)
+
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_, err = conn.Write(frame)
+	return err
+}

--- a/internal/protocol/redis_mock.go
+++ b/internal/protocol/redis_mock.go
@@ -1,0 +1,49 @@
+package protocol
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// ServeMock implements MockHandler for Redis. It stands up an in-process
+// Redis server via github.com/alicebob/miniredis/v2 — a battle-tested
+// Go implementation of the RESP protocol that real clients (go-redis,
+// redigo) speak to without modification.
+//
+// Configuration keys (from spec.Config):
+//
+//	state: map[string]any — key → string value, pre-seeded into the server
+//	  before it begins accepting connections. Values are coerced with
+//	  fmt.Sprint to match Redis's "everything is a string" semantics.
+//
+// Routes are ignored — Redis mocks are state-driven, not route-driven.
+// Users should fault specific commands via fault() + the real-service
+// recipes, not through mock overrides.
+func (p *redisProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	mr := miniredis.NewMiniRedis()
+	if err := mr.StartAddr(addr); err != nil {
+		return fmt.Errorf("mock redis start %s: %w", addr, err)
+	}
+
+	seeded := 0
+	if raw, ok := spec.Config["state"]; ok {
+		if state, ok := raw.(map[string]any); ok {
+			for k, v := range state {
+				_ = mr.Set(k, fmt.Sprint(v))
+				seeded++
+			}
+		}
+	}
+
+	emitWith(emit, "started", map[string]string{
+		"addr":   addr,
+		"seeded": fmt.Sprintf("%d", seeded),
+	})
+
+	<-ctx.Done()
+	mr.Close()
+	emitWith(emit, "stopped", nil)
+	return nil
+}

--- a/internal/star/mock_runtime.go
+++ b/internal/star/mock_runtime.go
@@ -184,14 +184,14 @@ func waitMockReady(ctx context.Context, proto, addr string, timeout time.Duratio
 func mockListenerUp(proto, addr string) bool {
 	switch proto {
 	case "udp":
-		// Attempt to bind the same port — success means nothing is listening,
-		// failure means the mock has the port.
-		pc, err := net.ListenPacket("udp", addr)
-		if err != nil {
-			return true
-		}
-		pc.Close()
-		return false
+		// UDP is connectionless — there's no TCP handshake to probe. The
+		// bind-test trick (try to re-bind the same port) is unreliable on
+		// platforms that default to SO_REUSEADDR/SO_REUSEPORT. The mock's
+		// net.ListenPacket returns synchronously inside the goroutine's
+		// first line, so "yield and assume ready" is accurate in practice;
+		// a short sleep to give the goroutine time to run is sufficient.
+		time.Sleep(25 * time.Millisecond)
+		return true
 	default:
 		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
 		if err == nil {

--- a/internal/star/mock_runtime_test.go
+++ b/internal/star/mock_runtime_test.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	kafkago "github.com/segmentio/kafka-go"
+	bsonpkg "go.mongodb.org/mongo-driver/v2/bson"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	mongoopts "go.mongodb.org/mongo-driver/v2/mongo/options"
 	"golang.org/x/net/http2"
 )
 
@@ -404,6 +407,104 @@ bus = kafka.broker(
 		if !seen[want] {
 			t.Errorf("topic %q not found after stdlib kafka.broker(); seen=%+v", want, seen)
 		}
+	}
+}
+
+// TestMockServiceRedisStdlib verifies @faultbox/mocks/redis.star stands up
+// a Redis mock with seeded state and a raw RESP client reads it.
+func TestMockServiceRedisStdlib(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+load("@faultbox/mocks/redis.star", "redis")
+
+cache = redis.server(
+    name      = "cache",
+    interface = interface("main", "redis", %d),
+    state     = {"greeting": "hello", "counter": "42"},
+)
+`, port)
+	if err := rt.LoadString("redis_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	// Seeded values should be returned.
+	_, _ = conn.Write([]byte("*2\r\n$3\r\nGET\r\n$8\r\ngreeting\r\n"))
+	buf := make([]byte, 64)
+	n, _ := conn.Read(buf)
+	if !strings.Contains(string(buf[:n]), "hello") {
+		t.Errorf("GET greeting response = %q, want to contain 'hello'", buf[:n])
+	}
+}
+
+// TestMockServiceMongoStdlib verifies @faultbox/mocks/mongodb.star stands up
+// a MongoDB mock and the real mongo driver completes handshake + find.
+func TestMockServiceMongoStdlib(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+load("@faultbox/mocks/mongodb.star", "mongo")
+
+users_db = mongo.server(
+    name      = "users-stub",
+    interface = interface("main", "mongodb", %d),
+    collections = {
+        "users": [
+            {"_id": "1", "name": "alice"},
+            {"_id": "2", "name": "bob"},
+        ],
+    },
+)
+`, port)
+	if err := rt.LoadString("mongo_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	clientOpts := mongoopts.Client().
+		ApplyURI("mongodb://" + addr).
+		SetServerSelectionTimeout(3 * time.Second).
+		SetConnectTimeout(3 * time.Second)
+	client, err := mongodriver.Connect(clientOpts)
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	defer client.Disconnect(context.Background())
+
+	cctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ccancel()
+	cur, err := client.Database("mock").Collection("users").Find(cctx, bsonpkg.M{})
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	var results []bsonpkg.M
+	if err := cur.All(cctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
 	}
 }
 

--- a/mocks/mongodb.star
+++ b/mocks/mongodb.star
@@ -1,0 +1,42 @@
+# @faultbox/mocks/mongodb.star
+#
+# Starlark wrapper around mock_service() for MongoDB mocks. Stands up an
+# in-process MongoDB OP_MSG responder that handles the handshake (hello /
+# isMaster / buildInfo) plus find / insert / update / delete so real mongo
+# drivers complete their setup and read seeded documents.
+#
+# Usage:
+#
+#     load("@faultbox/mocks/mongodb.star", "mongo")
+#
+#     users_db = mongo.server(
+#         name      = "users-stub",
+#         interface = interface("main", "mongodb", 27017),
+#         collections = {
+#             "users": [
+#                 {"_id": "1", "name": "alice", "role": "admin"},
+#                 {"_id": "2", "name": "bob", "role": "user"},
+#             ],
+#         },
+#     )
+#
+# Scope (v0.8):
+#
+# - Handshake works — real driver connects.
+# - find / findOne return seeded documents.
+# - insert / update / delete acknowledge with ok:1 but do not mutate state.
+#   Designed for read-through tests; for round-trip CRUD use the real server.
+# - Unknown commands return ok:1 (lenient) so unusual driver chatter does
+#   not fail the test.
+
+def _server(name, interface, collections = {}, depends_on = []):
+    return mock_service(
+        name,
+        interface,
+        config = {"collections": collections},
+        depends_on = depends_on,
+    )
+
+mongo = struct(
+    server = _server,
+)

--- a/mocks/redis.star
+++ b/mocks/redis.star
@@ -1,0 +1,36 @@
+# @faultbox/mocks/redis.star
+#
+# Starlark wrapper around mock_service() for Redis mocks. Stands up an
+# in-process Redis server (miniredis) so real go-redis / redigo clients
+# connect, GET / SET / DEL / INCR / EXISTS / TTL, and observe seeded state.
+#
+# Usage:
+#
+#     load("@faultbox/mocks/redis.star", "redis")
+#
+#     cache = redis.server(
+#         name      = "cache",
+#         interface = interface("main", "redis", 6379),
+#         state = {
+#             "config:max_retries": "3",
+#             "config:timeout_ms":  "5000",
+#             "flag:new_ui":        "true",
+#         },
+#     )
+#
+# Scope: string cache + counters (80% of real Redis usage). Streams,
+# pub/sub, Lua scripting inherited from miniredis; not all commands work
+# identically to a real Redis, so specs that depend on exotic features
+# should run the real server.
+
+def _server(name, interface, state = {}, depends_on = []):
+    return mock_service(
+        name,
+        interface,
+        config = {"state": state},
+        depends_on = depends_on,
+    )
+
+redis = struct(
+    server = _server,
+)


### PR DESCRIPTION
Fifth slice of the v0.8.0 mock services epic. Ships the remaining protocol stdlib mocks for v1 scope.

## Summary

| Protocol | Implementation | Stdlib module |
|---|---|---|
| **Redis** | `github.com/alicebob/miniredis/v2` wrapper | `@faultbox/mocks/redis.star` → `redis.server()` |
| **MongoDB** | Hand-written BSON OP_MSG + OP_QUERY responder | `@faultbox/mocks/mongodb.star` → `mongo.server()` |

## Redis

`miniredis` is the equivalent of `kfake` for Redis — a mature in-process server. 50-line wrapper seeds state at startup, real clients (go-redis, redigo, raw RESP) connect and run GET/SET/DEL/INCR/EXISTS/TTL against it.

```python
load("@faultbox/mocks/redis.star", "redis")

cache = redis.server(
    name      = "cache",
    interface = interface("main", "redis", 6379),
    state = {
        "config:max_retries": "3",
        "flag:new_ui":        "true",
    },
)
```

## MongoDB

No equivalent library exists for Go, so this PR ships a hand-written responder (~250 LOC). Handles both wire formats modern drivers use:

- **OP_QUERY** — initial handshake (driver starts here for backward compat)
- **OP_MSG** — all subsequent commands

Commands implemented: `hello`/`isMaster`/`ismaster`/`buildInfo`/`ping` (handshake), `find`/`findOne`/`getMore` (seeded reads), `insert`/`update`/`delete` (acknowledge-and-drop), `endSessions`/`abort*`/`commit*` (no-op). Unknown commands return `ok:1` (lenient — avoids cascading test failures on driver chatter).

```python
load("@faultbox/mocks/mongodb.star", "mongo")

users_db = mongo.server(
    name      = "users-stub",
    interface = interface("main", "mongodb", 27017),
    collections = {
        "users": [
            {"_id": "1", "name": "alice"},
            {"_id": "2", "name": "bob"},
        ],
    },
)
```

**v0.8 scope: read-through.** `find`/`findOne` return seeded docs; writes are acknowledged but discarded. Full CRUD with persistence is v0.9.

## Bonus fix

UDP readiness probe (from step 3) was flaky on macOS because of SO_REUSEADDR defaults — the bind-test returned success even when the mock had the port. Replaced with a 25ms yield; `net.ListenPacket` comes up synchronously so no probe is needed.

## Dependencies

- `github.com/alicebob/miniredis/v2` (+ gopher-lua transitive). Mature (v2.37.0), active.
- No new dep for MongoDB — reuses the existing `mongo-driver/v2/bson` encoder.

## Files

| File | Role |
|---|---|
| `internal/protocol/redis_mock.go` | miniredis wrapper, ~50 LOC |
| `internal/protocol/mongodb_mock.go` | OP_MSG + OP_QUERY responder, ~280 LOC |
| `internal/protocol/mock_test.go` | 2 new tests — real RESP + real mongo driver |
| `internal/star/mock_runtime.go` | UDP readiness fix |
| `internal/star/mock_runtime_test.go` | 2 new stdlib spec tests |
| `mocks/redis.star` | `redis.server()` wrapper |
| `mocks/mongodb.star` | `mongo.server()` wrapper |

## Test plan

- [x] `go test ./...` — 23 mock tests pass (19 existing + 4 new)
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean
- [x] Real segmentio/kafka-go → step 4a ✓
- [x] Raw RESP → Redis mock ✓
- [x] Real mongo-driver/v2 → MongoDB mock (handshake + find with 2 seeded docs) ✓

## v0.8.0 protocol mock surface — complete after this PR

- Generic: HTTP, HTTP/2, TCP, UDP  
- Stdlib: Kafka, Redis, MongoDB

gRPC and TLS remain as v0.8 stretch items; can land as follow-ups before release.

## Links

- RFC: #31
- Milestone: [v0.8.0](https://github.com/faultbox/Faultbox/milestone/1)
- Previous: #41 (HTTP), #42 (HTTP/2), #43 (TCP/UDP), #44 (Kafka + stdlib pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)