### PR TITLE
feat(rfc-017): gRPC mock handler + response constructors (step 5a/N)

### DIFF
--- a/internal/protocol/grpc_mock.go
+++ b/internal/protocol/grpc_mock.go
@@ -1,0 +1,211 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ServeMock implements MockHandler for gRPC. Built on google.golang.org/grpc
+// with an UnknownServiceHandler — every incoming RPC is routed through the
+// mock's route table, keyed by the full method path "/pkg.Service/Method".
+//
+// Without a .proto file, responses are encoded as google.protobuf.Struct
+// (JSON-shaped). Typed clients using reflection or loose decoding (most
+// Go and Node clients) accept this; clients with compiled stubs for a
+// specific message type will need the real backend.
+//
+// Dynamic handlers receive a MockRequest with Path populated; Body is the
+// raw wire bytes of the unary request message (protobuf-encoded).
+//
+// Error responses: grpc_error() producers set Status to a gRPC code; the
+// handler translates Status to the gRPC status code with the Body as the
+// human-readable message.
+func (p *grpcProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec, emit MockEmitter) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("mock grpc listen %s: %w", addr, err)
+	}
+
+	handler := &grpcMockHandler{routes: spec.Routes, def: spec.Default, emit: emit}
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(handler.serve))
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ln) }()
+
+	select {
+	case <-ctx.Done():
+		srv.GracefulStop()
+		return nil
+	case err := <-done:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			return err
+		}
+		return nil
+	}
+}
+
+// grpcMockHandler dispatches unary-style RPCs against the route table.
+type grpcMockHandler struct {
+	routes []MockRoute
+	def    *MockResponse
+	emit   MockEmitter
+}
+
+// serve matches grpc.StreamHandler signature. Receives one request
+// message, dispatches, sends one response (or an error).
+func (h *grpcMockHandler) serve(srv any, stream grpc.ServerStream) error {
+	method, _ := grpc.MethodFromServerStream(stream)
+	var reqFrame anyProto
+	if err := stream.RecvMsg(&reqFrame); err != nil {
+		return err
+	}
+
+	route, matched := matchGRPCRoute(h.routes, method)
+
+	var resp *MockResponse
+	switch {
+	case matched && route.Dynamic != nil:
+		dyn, err := route.Dynamic(MockRequest{Path: method, Body: reqFrame.data})
+		if err != nil {
+			emitWith(h.emit, "dynamic_error", map[string]string{"method": method, "error": err.Error()})
+			return status.Error(codes.Internal, err.Error())
+		}
+		resp = dyn
+	case matched:
+		resp = route.Response
+	case h.def != nil:
+		resp = h.def
+	default:
+		emitWith(h.emit, "unmatched", map[string]string{"method": method})
+		return status.Error(codes.Unimplemented, fmt.Sprintf("mock: no route for %s", method))
+	}
+
+	if resp == nil {
+		return status.Error(codes.Unimplemented, "mock: nil response")
+	}
+
+	// Status != 0 is treated as a gRPC error code (see grpc_error()).
+	if resp.Status != 0 {
+		emitWith(h.emit, "error", map[string]string{
+			"method": method,
+			"code":   fmt.Sprintf("%d", resp.Status),
+		})
+		return status.Error(codes.Code(resp.Status), string(resp.Body))
+	}
+
+	out := anyProto{data: resp.Body}
+	if err := stream.SendMsg(&out); err != nil {
+		return err
+	}
+
+	emitWith(h.emit, "ok", map[string]string{
+		"method":    method,
+		"resp_size": fmt.Sprintf("%d", len(resp.Body)),
+	})
+	return nil
+}
+
+// matchGRPCRoute matches by exact method path with optional tail glob:
+//
+//	"/flags.v1.Flags/Get"    — exact
+//	"/flags.v1.Flags/*"      — any method on the service
+//	"/**"                    — catch-all
+func matchGRPCRoute(routes []MockRoute, method string) (MockRoute, bool) {
+	for _, r := range routes {
+		if grpcMethodMatch(r.Pattern, method) {
+			return r, true
+		}
+	}
+	return MockRoute{}, false
+}
+
+func grpcMethodMatch(pattern, method string) bool {
+	if pattern == method {
+		return true
+	}
+	if pattern == "/**" {
+		return true
+	}
+	// Trailing /* — wildcard method on a specific service.
+	if len(pattern) > 2 && pattern[len(pattern)-2:] == "/*" {
+		prefix := pattern[:len(pattern)-1] // keep the slash
+		return len(method) > len(prefix) && method[:len(prefix)] == prefix
+	}
+	return false
+}
+
+// anyProto is a codec-neutral message type that carries raw protobuf-
+// encoded bytes through grpc.ServerStream.RecvMsg/SendMsg without
+// requiring a registered message type. It satisfies the proto.Message
+// contract that grpc-go's default codec checks for.
+type anyProto struct {
+	data []byte
+}
+
+// Reset / String / ProtoMessage satisfy the proto.Message interface so
+// grpc-go's "proto" codec accepts our value in SendMsg/RecvMsg.
+func (a *anyProto) Reset()        { a.data = nil }
+func (a *anyProto) String() string { return fmt.Sprintf("anyProto(%d bytes)", len(a.data)) }
+func (a *anyProto) ProtoMessage() {}
+
+// Marshal / Unmarshal satisfy grpc-go's special-case path for raw bytes
+// messages. grpc-go checks for (Marshal() ([]byte, error)) before falling
+// back to the proto codec, so carrying bytes through as-is works.
+func (a *anyProto) Marshal() ([]byte, error) { return a.data, nil }
+func (a *anyProto) Unmarshal(b []byte) error {
+	a.data = append(a.data[:0], b...)
+	return nil
+}
+
+// JSONToGRPCStruct converts JSON bytes into a protobuf-encoded
+// google.protobuf.Struct. Used by the grpc_response() builtin so specs
+// can return gRPC messages as ordinary Starlark dicts — the wire-level
+// encoding is the well-known Struct type that reflection-based clients
+// decode naturally.
+func JSONToGRPCStruct(jsonBytes []byte) ([]byte, error) {
+	var tmp map[string]any
+	if err := json.Unmarshal(jsonBytes, &tmp); err != nil {
+		return nil, fmt.Errorf("parse json: %w", err)
+	}
+	s, err := structpb.NewStruct(tmp)
+	if err != nil {
+		return nil, fmt.Errorf("build struct: %w", err)
+	}
+	return proto.Marshal(s)
+}
+
+// GRPCCodeByName returns the numeric gRPC status code for the given
+// canonical name (UPPERCASE with underscores, e.g. "UNAVAILABLE").
+// Returns (0, false) if the name is not recognized.
+func GRPCCodeByName(name string) (int, bool) {
+	codes := map[string]int{
+		"OK":                  0,
+		"CANCELLED":           1,
+		"UNKNOWN":             2,
+		"INVALID_ARGUMENT":    3,
+		"DEADLINE_EXCEEDED":   4,
+		"NOT_FOUND":           5,
+		"ALREADY_EXISTS":      6,
+		"PERMISSION_DENIED":   7,
+		"RESOURCE_EXHAUSTED":  8,
+		"FAILED_PRECONDITION": 9,
+		"ABORTED":             10,
+		"OUT_OF_RANGE":        11,
+		"UNIMPLEMENTED":       12,
+		"INTERNAL":            13,
+		"UNAVAILABLE":         14,
+		"DATA_LOSS":           15,
+		"UNAUTHENTICATED":     16,
+	}
+	c, ok := codes[name]
+	return c, ok
+}

--- a/internal/protocol/mock_test.go
+++ b/internal/protocol/mock_test.go
@@ -17,6 +17,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	mongoopts "go.mongodb.org/mongo-driver/v2/mongo/options"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // TestHTTPMockStaticRoutes verifies that the HTTP MockHandler matches
@@ -753,6 +758,90 @@ func TestMongoMockHandshakeAndFind(t *testing.T) {
 		t.Errorf("expected alice+bob, got %v", names)
 	}
 }
+
+// TestGRPCMockUnaryCall verifies that a gRPC mock routes /pkg.Svc/Method
+// correctly, returns a typeless struct response, and maps grpc_error() to
+// a status code the client sees.
+func TestGRPCMockUnaryCall(t *testing.T) {
+	p := &grpcProtocol{}
+	addr := freeLoopbackAddr(t)
+
+	okBytes, err := JSONToGRPCStruct([]byte(`{"enabled":true,"variant":"B"}`))
+	if err != nil {
+		t.Fatalf("encode struct: %v", err)
+	}
+
+	spec := MockSpec{
+		Routes: []MockRoute{
+			{
+				Pattern:  "/flags.v1.Flags/Get",
+				Response: &MockResponse{Status: 0, Body: okBytes},
+			},
+			{
+				Pattern: "/flags.v1.Flags/Fail",
+				Response: &MockResponse{
+					Status: 14, // UNAVAILABLE
+					Body:   []byte("backend down"),
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- p.ServeMock(ctx, addr, spec, nil) }()
+	if err := waitListening(addr, 3*time.Second); err != nil {
+		t.Fatalf("grpc mock not listening: %v", err)
+	}
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Happy path: /flags.v1.Flags/Get — decode Struct.
+	var gotStruct structpb.Struct
+	err = conn.Invoke(context.Background(), "/flags.v1.Flags/Get", &emptyMsg{}, &gotStruct)
+	if err != nil {
+		t.Fatalf("Invoke Get: %v", err)
+	}
+	if got := gotStruct.Fields["variant"].GetStringValue(); got != "B" {
+		t.Errorf("variant = %q, want B; got struct=%+v", got, gotStruct.Fields)
+	}
+
+	// Error path: /flags.v1.Flags/Fail — expect status UNAVAILABLE.
+	err = conn.Invoke(context.Background(), "/flags.v1.Flags/Fail", &emptyMsg{}, &gotStruct)
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected grpc status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("error code = %s, want Unavailable", st.Code())
+	}
+	if st.Message() != "backend down" {
+		t.Errorf("error msg = %q", st.Message())
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("grpc mock did not shut down in time")
+	}
+}
+
+// emptyMsg is a zero-byte proto message used to satisfy grpc-go's codec
+// when we don't care about the request body. Send as Invoke's req arg.
+type emptyMsg struct{}
+
+func (*emptyMsg) Reset()                   {}
+func (*emptyMsg) String() string           { return "empty" }
+func (*emptyMsg) ProtoMessage()            {}
+func (*emptyMsg) Marshal() ([]byte, error) { return nil, nil }
+func (*emptyMsg) Unmarshal([]byte) error   { return nil }
 
 // --- test helpers ---
 

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -76,6 +76,8 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		"status_only":    starlark.NewBuiltin("status_only", builtinStatusOnly),
 		"redirect":       starlark.NewBuiltin("redirect", builtinRedirect),
 		"dynamic":        starlark.NewBuiltin("dynamic", builtinDynamic),
+		"grpc_response":  starlark.NewBuiltin("grpc_response", builtinGRPCResponse),
+		"grpc_error":     starlark.NewBuiltin("grpc_error", builtinGRPCError),
 	}
 }
 

--- a/internal/star/mock_builtins.go
+++ b/internal/star/mock_builtins.go
@@ -275,6 +275,66 @@ func builtinDynamic(thread *starlark.Thread, fn *starlark.Builtin, args starlark
 	return newDynamicResponse(callable), nil
 }
 
+// grpc_response(body) — returns a gRPC response message. Body is a dict
+// (or list) that gets encoded as google.protobuf.Struct — the common
+// wire format for typeless gRPC mocks. Typed clients using reflection or
+// loose decoding (most Go / Node clients) accept this shape.
+func builtinGRPCResponse(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var body starlark.Value = starlark.None
+	if err := starlark.UnpackArgs("grpc_response", args, kwargs, "body?", &body); err != nil {
+		return nil, err
+	}
+	jsonBytes, err := marshalJSONBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("grpc_response body: %w", err)
+	}
+	structBytes, err := protocol.JSONToGRPCStruct(jsonBytes)
+	if err != nil {
+		return nil, fmt.Errorf("grpc_response encode: %w", err)
+	}
+	return newStaticResponse(&protocol.MockResponse{
+		Status: 0, // OK
+		Body:   structBytes,
+	}), nil
+}
+
+// grpc_error(code, message) — returns a gRPC error response. code is a
+// gRPC canonical status code name (UPPERCASE, e.g. "UNAVAILABLE") or
+// the numeric value. message is the human-readable error string.
+func builtinGRPCError(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		codeVal starlark.Value
+		message string
+	)
+	if err := starlark.UnpackArgs("grpc_error", args, kwargs, "code", &codeVal, "message?", &message); err != nil {
+		return nil, err
+	}
+	var code int
+	switch v := codeVal.(type) {
+	case starlark.Int:
+		n, ok := v.Int64()
+		if !ok {
+			return nil, fmt.Errorf("grpc_error code out of range")
+		}
+		code = int(n)
+	case starlark.String:
+		n, ok := protocol.GRPCCodeByName(string(v))
+		if !ok {
+			return nil, fmt.Errorf("grpc_error: unknown code name %q (use one of OK, CANCELLED, UNKNOWN, INVALID_ARGUMENT, DEADLINE_EXCEEDED, NOT_FOUND, ALREADY_EXISTS, PERMISSION_DENIED, RESOURCE_EXHAUSTED, FAILED_PRECONDITION, ABORTED, OUT_OF_RANGE, UNIMPLEMENTED, INTERNAL, UNAVAILABLE, DATA_LOSS, UNAUTHENTICATED)", v)
+		}
+		code = n
+	default:
+		return nil, fmt.Errorf("grpc_error code must be int or string (got %s)", codeVal.Type())
+	}
+	if code == 0 {
+		return nil, fmt.Errorf("grpc_error code must be non-zero (0 = OK is not an error)")
+	}
+	return newStaticResponse(&protocol.MockResponse{
+		Status: code,
+		Body:   []byte(message),
+	}), nil
+}
+
 // headerDictToMap is a small helper that converts a Starlark dict (or nil)
 // into a Go string->string map, skipping entries that aren't string-typed.
 func headerDictToMap(d *starlark.Dict) map[string]string {

--- a/internal/star/mock_runtime_test.go
+++ b/internal/star/mock_runtime_test.go
@@ -16,6 +16,11 @@ import (
 	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
 	mongoopts "go.mongodb.org/mongo-driver/v2/mongo/options"
 	"golang.org/x/net/http2"
+	grpcdial "google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	insecurecreds "google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
+	grpcstructpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 // TestMockServiceSpecLoad verifies mock_service() parses and registers a
@@ -507,6 +512,68 @@ users_db = mongo.server(
 		t.Fatalf("results = %d, want 2", len(results))
 	}
 }
+
+// TestMockServiceGRPC verifies a mock_service declared with protocol grpc
+// stands up a grpc-go server and routes unary calls via routes={} +
+// grpc_response()/grpc_error(). Exercises the full runtime path.
+func TestMockServiceGRPC(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+flags = mock_service("flags",
+    interface("main", "grpc", %d),
+    routes = {
+        "/flags.v1.Flags/Get":  grpc_response(body = {"enabled": True, "variant": "B"}),
+        "/flags.v1.Flags/Fail": grpc_error(code = "UNAVAILABLE", message = "backend down"),
+    },
+)
+`, port)
+	if err := rt.LoadString("grpc_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	conn, err := grpcdial.NewClient(addr, grpcdial.WithTransportCredentials(insecurecreds.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	var got grpcstructpb.Struct
+	if err := conn.Invoke(context.Background(), "/flags.v1.Flags/Get", &emptyGRPC{}, &got); err != nil {
+		t.Fatalf("Invoke Get: %v", err)
+	}
+	if v := got.Fields["variant"].GetStringValue(); v != "B" {
+		t.Errorf("variant = %q, want B", v)
+	}
+
+	err = conn.Invoke(context.Background(), "/flags.v1.Flags/Fail", &emptyGRPC{}, &got)
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		t.Fatalf("expected grpc status error, got %v", err)
+	}
+	if st.Code() != grpccodes.Unavailable {
+		t.Errorf("code = %s, want Unavailable", st.Code())
+	}
+}
+
+// emptyGRPC is a zero-byte proto used as the request message for Invoke
+// in TestMockServiceGRPC. Local to this file — the grpc mock doesn't
+// inspect request bodies in this test.
+type emptyGRPC struct{}
+
+func (*emptyGRPC) Reset()                   {}
+func (*emptyGRPC) String() string           { return "empty" }
+func (*emptyGRPC) ProtoMessage()            {}
+func (*emptyGRPC) Marshal() ([]byte, error) { return nil, nil }
+func (*emptyGRPC) Unmarshal([]byte) error   { return nil }
 
 // newTestH2CClient returns an HTTP client that speaks h2c. Local to this
 // file to avoid reaching into the protocol package's unexported helpers.


### PR DESCRIPTION
Sixth slice of the v0.8.0 mock services epic. Adds gRPC to the generic `mock_service()` surface.

## Summary

- `grpc` protocol gets `ServeMock()` built on `grpc.NewServer(grpc.UnknownServiceHandler(...))`
- Routes match full method path `/pkg.Service/Method` with `/pkg.Svc/*` and `/**` globs
- Typeless encoding — responses are `google.protobuf.Struct` bytes that reflective gRPC clients decode naturally
- `grpc_response(body={...})` + `grpc_error(code=\"UNAVAILABLE\", message=\"...\")` builtins
- Canonical gRPC status code names accepted as strings: `OK`, `CANCELLED`, `UNKNOWN`, `INVALID_ARGUMENT`, `DEADLINE_EXCEEDED`, `NOT_FOUND`, `ALREADY_EXISTS`, `PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, `FAILED_PRECONDITION`, `ABORTED`, `OUT_OF_RANGE`, `UNIMPLEMENTED`, `INTERNAL`, `UNAVAILABLE`, `DATA_LOSS`, `UNAUTHENTICATED`

## Example (tested end-to-end)

```python
flags = mock_service(\"flags\",
    interface(\"main\", \"grpc\", 50051),
    routes = {
        \"/flags.v1.Flags/Get\":  grpc_response(body = {\"enabled\": True, \"variant\": \"B\"}),
        \"/flags.v1.Flags/Fail\": grpc_error(code = \"UNAVAILABLE\", message = \"backend down\"),
    },
)
```

Real grpc-go client calls `/flags.v1.Flags/Get` and decodes a Struct with `variant=\"B\"`. Calls to `/flags.v1.Flags/Fail` return `status.Error(codes.Unavailable, \"backend down\")`.

## Scope

**v0.8 ships:** unary RPCs + typeless reflection + glob matching + dynamic handlers.

**v0.9 scope:** typed messages via `proto=` kwarg, bidirectional streaming, gRPC reflection service on the mock.

## Files

| File | Role |
|---|---|
| `internal/protocol/grpc_mock.go` | `ServeMock()` + route matcher + `JSONToGRPCStruct` + `GRPCCodeByName` helpers |
| `internal/protocol/mock_test.go` | `TestGRPCMockUnaryCall` |
| `internal/star/builtins.go` | Register `grpc_response`, `grpc_error` |
| `internal/star/mock_builtins.go` | Builtin impls |
| `internal/star/mock_runtime_test.go` | `TestMockServiceGRPC` |

## Test plan

- [x] `go test ./...` — 25 mock tests (23 existing + 2 new)
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean
- [x] Real grpc-go client sees OK + typed Struct response
- [x] Real grpc-go client receives `status.Error(codes.Unavailable, \"...\")` on error route

## Links

- RFC: #31
- Milestone: [v0.8.0](https://github.com/faultbox/Faultbox/milestone/1)
- Previous: #41, #42, #43, #44, #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)