### PR TITLE
feat(rfc-017): TLS support for HTTP/HTTP2/gRPC mocks (step 5b/N)

### DIFF
--- a/internal/protocol/grpc_mock.go
+++ b/internal/protocol/grpc_mock.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -36,7 +38,13 @@ func (p *grpcProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec
 	}
 
 	handler := &grpcMockHandler{routes: spec.Routes, def: spec.Default, emit: emit}
-	srv := grpc.NewServer(grpc.UnknownServiceHandler(handler.serve))
+	opts := []grpc.ServerOption{grpc.UnknownServiceHandler(handler.serve)}
+	if spec.TLSCert != nil {
+		opts = append(opts, grpc.Creds(credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{*spec.TLSCert},
+		})))
+	}
+	srv := grpc.NewServer(opts...)
 
 	done := make(chan error, 1)
 	go func() { done <- srv.Serve(ln) }()

--- a/internal/protocol/http.go
+++ b/internal/protocol/http.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -119,6 +120,9 @@ func (p *httpProtocol) ServeMock(ctx context.Context, addr string, spec MockSpec
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("mock listen %s: %w", addr, err)
+	}
+	if spec.TLSCert != nil {
+		ln = tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{*spec.TLSCert}})
 	}
 
 	mux := &mockHTTPMux{routes: spec.Routes, def: spec.Default, emit: emit}

--- a/internal/protocol/http2.go
+++ b/internal/protocol/http2.go
@@ -120,6 +120,18 @@ func (p *http2Protocol) ServeMock(ctx context.Context, addr string, spec MockSpe
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
+	// With TLS, serve plain HTTP/2 with ALPN "h2" over the TLS listener.
+	// Without TLS, the h2c handler above negotiates HTTP/2 over cleartext.
+	if spec.TLSCert != nil {
+		srv.Handler = mux
+		srv.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{*spec.TLSCert},
+			NextProtos:   []string{"h2", "http/1.1"},
+		}
+		ln = tls.NewListener(ln, srv.TLSConfig)
+		_ = http2.ConfigureServer(srv, h2s)
+	}
+
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- srv.Serve(ln) }()
 

--- a/internal/protocol/mock.go
+++ b/internal/protocol/mock.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "context"
+import (
+	"context"
+	"crypto/tls"
+)
 
 // MockHandler is an optional capability on a Protocol plugin. Protocols that
 // support mock_service() implement it; others do not and mock_service()
@@ -22,10 +25,16 @@ type MockHandler interface {
 // seed state, MongoDB collections) that doesn't fit the route-table shape.
 // Opaque to the generic mock_service() builtin; interpreted by protocol
 // plugins. Keys are documented per protocol in the @faultbox/mocks/ stdlib.
+//
+// TLSCert, when non-nil, instructs the handler to wrap its listener with
+// TLS using this certificate. Applies to HTTP, HTTP/2, and gRPC mocks.
+// Other protocols MAY ignore it (or return an error if the caller asked
+// for TLS on a non-TLS-capable protocol).
 type MockSpec struct {
 	Routes  []MockRoute
 	Default *MockResponse
 	Config  map[string]any
+	TLSCert *tls.Certificate
 }
 
 // MockRoute pairs a pattern with a handler. Pattern matching is

--- a/internal/star/mock_runtime.go
+++ b/internal/star/mock_runtime.go
@@ -44,6 +44,26 @@ func (rt *Runtime) startMockService(ctx context.Context, svcName string, svc *Se
 			return fmt.Errorf("mock %q interface %q: %w", svcName, ifaceName, err)
 		}
 
+		// If tls=True was requested on this interface, generate a leaf
+		// cert signed by the runtime's shared mock CA and attach it to
+		// the spec. The protocol handler wraps its listener with TLS.
+		if svc.Mock.TLS[ifaceName] {
+			mt, err := rt.getMockTLS()
+			if err != nil {
+				svcCancel()
+				return fmt.Errorf("mock %q interface %q: tls init: %w", svcName, ifaceName, err)
+			}
+			cert, err := mt.serverCert(
+				[]string{"localhost", svcName},
+				[]net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+			)
+			if err != nil {
+				svcCancel()
+				return fmt.Errorf("mock %q interface %q: tls cert: %w", svcName, ifaceName, err)
+			}
+			spec.TLSCert = cert
+		}
+
 		addr := fmt.Sprintf("127.0.0.1:%d", iface.Port)
 		emit := rt.mockEmitter(svcName, ifaceName)
 

--- a/internal/star/mock_runtime_test.go
+++ b/internal/star/mock_runtime_test.go
@@ -3,10 +3,12 @@ package star
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +20,7 @@ import (
 	"golang.org/x/net/http2"
 	grpcdial "google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
+	grpccreds "google.golang.org/grpc/credentials"
 	insecurecreds "google.golang.org/grpc/credentials/insecure"
 	grpcstatus "google.golang.org/grpc/status"
 	grpcstructpb "google.golang.org/protobuf/types/known/structpb"
@@ -574,6 +577,124 @@ func (*emptyGRPC) String() string           { return "empty" }
 func (*emptyGRPC) ProtoMessage()            {}
 func (*emptyGRPC) Marshal() ([]byte, error) { return nil, nil }
 func (*emptyGRPC) Unmarshal([]byte) error   { return nil }
+
+// TestMockServiceHTTPWithTLS verifies that tls=True on an HTTP mock results
+// in a real TLS listener, and that a client configured to trust the
+// runtime's mock CA can reach it over HTTPS.
+func TestMockServiceHTTPWithTLS(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+auth = mock_service("auth",
+    interface("http", "http", %d),
+    tls = True,
+    routes = {
+        "GET /.well-known/jwks": json_response(status = 200, body = {"keys": [{"kid": "test-1"}]}),
+    },
+)
+`, port)
+	if err := rt.LoadString("tls_e2e.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	caPath := rt.MockCAPath()
+	if caPath == "" {
+		t.Fatal("MockCAPath() is empty after starting a tls=True mock")
+	}
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Fatalf("read ca: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("AppendCertsFromPEM: parse failed")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+		Timeout: 3 * time.Second,
+	}
+	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/.well-known/jwks", port))
+	if err != nil {
+		t.Fatalf("GET https: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `"kid":"test-1"`) {
+		t.Fatalf("body = %q", string(body))
+	}
+
+	// A client that doesn't trust the CA should fail handshake.
+	strict := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{}},
+		Timeout:   3 * time.Second,
+	}
+	_, err = strict.Get(fmt.Sprintf("https://127.0.0.1:%d/.well-known/jwks", port))
+	if err == nil {
+		t.Fatal("expected strict client to fail TLS verification; got nil")
+	}
+}
+
+// TestMockServiceGRPCWithTLS verifies that tls=True on a gRPC mock
+// terminates TLS before the gRPC handshake and a CA-trusting client
+// completes the Invoke round-trip.
+func TestMockServiceGRPCWithTLS(t *testing.T) {
+	port := freePort(t)
+	rt := New(testLogger())
+	src := fmt.Sprintf(`
+flags = mock_service("flags",
+    interface("main", "grpc", %d),
+    tls = True,
+    routes = {
+        "/flags.v1.Flags/Get": grpc_response(body = {"enabled": True}),
+    },
+)
+`, port)
+	if err := rt.LoadString("grpc_tls.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	caPEM, err := os.ReadFile(rt.MockCAPath())
+	if err != nil {
+		t.Fatalf("read ca: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caPEM)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	conn, err := grpcdial.NewClient(addr, grpcdial.WithTransportCredentials(
+		grpccreds.NewTLS(&tls.Config{RootCAs: pool, ServerName: "localhost"}),
+	))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	var got grpcstructpb.Struct
+	if err := conn.Invoke(ctx, "/flags.v1.Flags/Get", &emptyGRPC{}, &got); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !got.Fields["enabled"].GetBoolValue() {
+		t.Errorf("enabled field missing/false: %+v", got.Fields)
+	}
+}
 
 // newTestH2CClient returns an HTTP client that speaks h2c. Local to this
 // file to avoid reaching into the protocol package's unexported helpers.

--- a/internal/star/mock_tls.go
+++ b/internal/star/mock_tls.go
@@ -1,0 +1,136 @@
+package star
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// mockTLS holds the per-runtime TLS state — one CA signs all mock server
+// certs so a single Faultbox CA bundle can be trusted by every client.
+type mockTLS struct {
+	mu       sync.Mutex
+	ca       *x509.Certificate
+	caDER    []byte
+	caKey    *ecdsa.PrivateKey
+	caPath   string // PEM-encoded CA cert on disk
+}
+
+// newMockTLS generates a fresh CA + writes the PEM bundle to a known path
+// inside the OS temp dir. The CA is ECDSA P-256 with a 24-hour validity —
+// the runtime lifecycle is typically seconds to minutes, but a generous
+// window avoids clock-skew surprises.
+func newMockTLS() (*mockTLS, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("ca key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("ca serial: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "Faultbox Mock CA"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("ca cert: %w", err)
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse ca: %w", err)
+	}
+
+	// Write CA PEM to a well-known path so SUTs can mount it (docker) or
+	// read it (binary mode) without guessing.
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("faultbox-ca-%d.pem", time.Now().UnixNano()))
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		return nil, fmt.Errorf("write ca: %w", err)
+	}
+
+	return &mockTLS{
+		ca:     parsed,
+		caDER:  der,
+		caKey:  key,
+		caPath: path,
+	}, nil
+}
+
+// serverCert signs a leaf cert for the given hostnames/IPs and returns a
+// tls.Certificate suitable for handing to a net/http or grpc server.
+// Every TLS-enabled mock gets its own leaf cert signed by the shared CA,
+// so clients trusting the CA accept all mocks without extra config.
+func (m *mockTLS) serverCert(hostnames []string, ips []net.IP) (*tls.Certificate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("leaf key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("leaf serial: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "Faultbox Mock Server"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     hostnames,
+		IPAddresses:  ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, m.ca, &leafKey.PublicKey, m.caKey)
+	if err != nil {
+		return nil, fmt.Errorf("leaf cert: %w", err)
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{der, m.caDER},
+		PrivateKey:  leafKey,
+		Leaf:        nil,
+	}, nil
+}
+
+// CAPath returns the on-disk PEM bundle path of the runtime's mock CA.
+// SUTs can trust Faultbox-issued mock certs by loading this file.
+func (m *mockTLS) CAPath() string { return m.caPath }
+
+// getMockTLS returns the runtime's shared mock CA, creating it on first
+// use. Thread-safe via sync.Once; subsequent callers see the same CA.
+func (rt *Runtime) getMockTLS() (*mockTLS, error) {
+	rt.mockTLSOnce.Do(func() {
+		rt.mockTLSImpl, rt.mockTLSErr = newMockTLS()
+	})
+	return rt.mockTLSImpl, rt.mockTLSErr
+}
+
+// MockCAPath returns the path to the runtime's mock CA bundle, or ""
+// if no TLS mocks have been started. Tests and CLI can surface this to
+// the user so SUTs know which file to trust.
+func (rt *Runtime) MockCAPath() string {
+	if rt.mockTLSImpl == nil {
+		return ""
+	}
+	return rt.mockTLSImpl.CAPath()
+}

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -116,6 +116,13 @@ type Runtime struct {
 	// currentFaultScenario is set by makeFaultScenarioRunner during execution
 	// so RunTest can copy MatrixInfo to the TestResult.
 	currentFaultScenario *FaultScenarioDef
+
+	// mockTLSImpl is lazy-initialized the first time a tls=True mock service
+	// starts. The whole runtime shares one CA so clients can trust every
+	// mock by trusting a single bundle.
+	mockTLSOnce sync.Once
+	mockTLSImpl *mockTLS
+	mockTLSErr  error
 }
 
 type runningSession struct {


### PR DESCRIPTION
Seventh slice of the v0.8.0 mock services epic. Adds `tls=True` to `mock_service()` — finally closes the motivating JWKS/OIDC use case (real OIDC issuers are `https://`).

## Summary

- One ECDSA P-256 **mock CA per Runtime**, lazy-initialized on first `tls=True` mock
- Each TLS mock gets a **leaf cert signed by that CA** with SANs `["localhost", <service-name>, 127.0.0.1, ::1]`
- CA PEM written to `${TMPDIR}/faultbox-ca-<timestamp>.pem` and exposed via `Runtime.MockCAPath()`
- HTTP mocks: wrap listener with `tls.NewListener`
- HTTP/2 mocks: drop h2c, use ALPN `h2` over TLS listener
- gRPC mocks: pass `credentials.NewTLS(...)` as a `ServerOption`

## Example

```python
auth = mock_service("auth",
    interface("http", "http", 8443),
    tls = True,
    routes = {
        "GET /.well-known/jwks": json_response(status = 200, body = {...}),
    },
)
```

SUTs point at `https://auth:8443/...` and trust the CA bundle from `${TMPDIR}/faultbox-ca-*.pem` (surfaced via `Runtime.MockCAPath()` — integration into service env vars lands with the docs PR).

## Non-TLS protocols

v0.8 ships TLS for HTTP, HTTP/2, gRPC. Kafka/Redis/MongoDB/TCP/UDP silently ignore `tls=True` — adding TLS to those is v0.9 scope. Users who need TLS on those protocols should run the real service.

## Files

| File | Role |
|---|---|
| `internal/protocol/mock.go` | `MockSpec.TLSCert` field |
| `internal/protocol/http.go` | `tls.NewListener` wrap |
| `internal/protocol/http2.go` | ALPN h2 over TLS (drop h2c when TLS set) |
| `internal/protocol/grpc_mock.go` | `grpc.Creds(credentials.NewTLS(...))` |
| `internal/star/mock_tls.go` | `newMockTLS()` + `serverCert()` |
| `internal/star/runtime.go` | Lazy-init singleton CA |
| `internal/star/mock_runtime.go` | Populate `spec.TLSCert` in `startMockService` |
| `internal/star/mock_runtime_test.go` | 2 new tests |

## Test plan

- [x] `go test ./...` — 27 mock tests pass (25 existing + 2 TLS)
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean
- [x] Strict client (no CA in RootCAs pool) fails TLS handshake — negative test confirms cert validation is actually happening

## Links

- RFC: #31
- Milestone: [v0.8.0](https://github.com/faultbox/Faultbox/milestone/1)
- Previous: #41, #42, #43, #44, #45, #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)