### PR TITLE
feat(v0.8.1): MySQL + Kafka + Redis recipes + mock services tutorial

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -83,7 +83,10 @@ Available stdlib recipes (load via @faultbox/recipes/<name>.star):
   cassandra
   clickhouse
   http2
+  kafka
   mongodb
+  mysql
+  redis
   udp
 
 $ faultbox recipes show mongodb
@@ -158,6 +161,46 @@ the recipe injects at the proxy level.
 | `clickhouse.slow_ingest(duration="3s")` | Delays INSERTs — producer back-pressure tests |
 | `clickhouse.connection_drop(query="*")` | HTTP connection reset mid-query |
 | `clickhouse.replica_stale(query="SELECT*")` | Replica too far behind leader |
+
+### `@faultbox/recipes/mysql.star`
+
+| Recipe | What it simulates |
+|---|---|
+| `mysql.deadlock(query="*")` | ER_LOCK_DEADLOCK (1213) — circular row-lock wait. Triggers retry or crash in no-retry paths. |
+| `mysql.lock_wait_timeout(query="*")` | ER_LOCK_WAIT_TIMEOUT (1205) — `innodb_lock_wait_timeout` exceeded |
+| `mysql.too_many_connections()` | ER_CON_COUNT_ERROR (1040) — surfaces nil-pointer bugs in pool init paths that don't check for connect errors |
+| `mysql.read_only_replica(query="INSERT*")` | ER_OPTION_PREVENTS_STATEMENT (1290) — writes routed to a replica |
+| `mysql.disk_full(query="INSERT*")` | ER_RECORD_FILE_FULL (1114) — "The table is full" |
+| `mysql.gone_away(query="*")` | Drop connection mid-query — driver sees classic "MySQL server has gone away" |
+| `mysql.slow_query(duration="3s", query="*")` | Delays any statement — tests client query timeouts |
+| `mysql.slow_writes(duration="3s", query="INSERT*")` | Delays writes only |
+
+### `@faultbox/recipes/kafka.star`
+
+| Recipe | What it simulates |
+|---|---|
+| `kafka.not_leader_for_partition(topic="*")` | Error 6 — produced to a broker no longer the partition leader |
+| `kafka.rebalancing(topic="*")` | Error 27 (REBALANCE_IN_PROGRESS) — simplified trigger for consumer rebalance handlers |
+| `kafka.offset_out_of_range(topic="*")` | Error 1 — consumer offset past log head / before retention cutoff |
+| `kafka.message_too_large(topic="*")` | Error 10 — produce payload exceeds `message.max.bytes` |
+| `kafka.coordinator_not_available(topic="*")` | Error 15 — consumer-group coordinator unavailable; exposes shutdown-order bugs |
+| `kafka.broker_overloaded(topic="*")` | Request quota exceeded — tests client back-pressure |
+| `kafka.slow_produce(duration="3s", topic="*")` | Delays produce requests — tests linger.ms + batching |
+| `kafka.connection_drop(topic="*")` | TCP drop mid-request — forces driver reconnect |
+
+### `@faultbox/recipes/redis.star`
+
+| Recipe | What it simulates |
+|---|---|
+| `redis.oom(key="*")` | "OOM command not allowed..." — maxmemory reached on writes |
+| `redis.cluster_down(key="*")` | "CLUSTERDOWN The cluster is down" — quorum lost |
+| `redis.loading(key="*")` | "LOADING Redis is loading..." — server replaying RDB/AOF after restart |
+| `redis.readonly_replica(key="*")` | "READONLY You can't write against a read only replica." |
+| `redis.busy(key="*")` | "BUSY Redis is busy running a script." — Lua script blocking |
+| `redis.noauth(key="*")` | "NOAUTH Authentication required." — server restarted into authenticated mode |
+| `redis.wrongtype(key="*")` | "WRONGTYPE Operation against a key holding the wrong kind of value" |
+| `redis.slow_command(duration="3s", key="*")` | Delays every command — tests pool timeout cascade |
+| `redis.connection_drop(key="*")` | Connection close mid-command — pool reconnect path |
 
 ## User-authored recipes
 

--- a/docs/tutorial/05-advanced/17-mock-services.md
+++ b/docs/tutorial/05-advanced/17-mock-services.md
@@ -1,0 +1,370 @@
+# Chapter 17: Mock Services — Stubs Without Containers
+
+**Duration:** 25 minutes
+**Prerequisites:** [Chapter 0 (Setup)](../00-prelude/00-setup.md), some familiarity with [Chapter 9 (Containers)](09-containers.md)
+
+## Goals & Purpose
+
+Your system under test (SUT) probably has a handful of dependencies
+that aren't really the thing you're testing — they just need to be
+*there* for the app to boot. An OIDC JWKS endpoint. A feature-flag
+service. A metadata server that returns four lines of JSON. A Redis
+that caches configuration values.
+
+Running each one as a real container is overkill:
+
+- **Slow** — pulling and booting real Kafka/MongoDB/Postgres takes 5-30
+  seconds before your first test runs.
+- **Heavy** — Docker images are 100s of MB each, and you probably only
+  exercise 1% of their functionality.
+- **Wrong abstraction** — the dependency's *behavior* is declarative
+  data ("this endpoint returns this JSON") but you're modelling its
+  *deployment* (Dockerfile, volume mounts, env vars).
+
+Faultbox **mock services** (shipped in v0.8.0) let you stand up these
+dependencies entirely in Starlark — no Dockerfile, no sidecar process.
+This chapter teaches you to:
+
+- **Use `mock_service()`** for HTTP, HTTP/2, TCP, UDP, and gRPC stubs.
+- **Use `@faultbox/mocks/` stdlib** for Kafka, Redis, and MongoDB.
+- **Compose mocks with real services** in the same topology.
+- **Fault your mocks** — `fault_assumption()` works on mocks exactly as
+  on real services.
+- **Know what mocks are for and what they aren't** — when to reach for
+  a real container instead.
+
+After this chapter, you can test a microservice that talks to five
+dependencies with zero containers and first-test latency under a
+second.
+
+## The JWKS problem
+
+Your service validates JWTs at startup. The JWT library fetches
+`/.well-known/openid-configuration/jwks` from the issuer URL in the
+token. Without a reachable JWKS endpoint, the library panics and the
+app crashes before it serves one request.
+
+You don't care about OIDC discovery for the functional test — you care
+about what happens *after* auth succeeds. But every test run has to
+stand up something at that URL.
+
+Before v0.8, options were all bad:
+
+1. **Custom Docker image** with a tiny HTTP server — another Dockerfile
+   to maintain, image to pull, container to wait for.
+2. **`python:3-alpine` + `http.server` + volume mount** — works but
+   imports Python into the dep graph, fights volume-mount semantics
+   on macOS, still boots a container.
+3. **Disable the code path in the SUT** — add a `--skip-auth` flag or
+   similar conditional — changes production code to make tests pass.
+
+With `mock_service()`:
+
+```python
+auth = mock_service("auth",
+    interface("http", "http", 8090),
+    routes = {
+        "GET /.well-known/openid-configuration": json_response(200, {
+            "issuer":   "http://auth:8090",
+            "jwks_uri": "http://auth:8090/.well-known/openid-configuration/jwks",
+        }),
+        "GET /.well-known/openid-configuration/jwks": json_response(200, {
+            "keys": [{
+                "kty": "OKP", "crv": "Ed25519", "kid": "test-1",
+                "x":   "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+            }],
+        }),
+    },
+)
+```
+
+Eleven lines of spec, no container, no image, first test runs in
+<100ms cold.
+
+## Walk-through: auth stub + SUT + test
+
+### 1. Declare the mock
+
+```python
+# faultbox.star
+
+auth = mock_service("auth",
+    interface("http", "http", 8090),
+    routes = {
+        "GET /.well-known/openid-configuration": json_response(200, {
+            "issuer":   "http://auth:8090",
+            "jwks_uri": "http://auth:8090/.well-known/openid-configuration/jwks",
+        }),
+        "GET /.well-known/openid-configuration/jwks": json_response(200, {
+            "keys": [{
+                "kty": "OKP", "crv": "Ed25519", "kid": "test-1",
+                "x":   "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+            }],
+        }),
+    },
+)
+```
+
+### 2. Point the SUT at it
+
+```python
+api = service("api",
+    interface("public", "http", 8080),
+    image = "myapp:latest",
+    depends_on = [auth],
+    env = {
+        "OIDC_ISSUER": "http://auth:8090",
+    },
+)
+```
+
+`depends_on = [auth]` ensures the mock is listening before `api`
+starts. Inside the container network, `api` reaches `auth` by its
+service name — same as for real services.
+
+### 3. Test the authenticated path
+
+```python
+def test_authenticated_request_succeeds():
+    resp = api.public.get(path = "/me", headers = {
+        "Authorization": "Bearer " + stub_jwt(kid = "test-1"),
+    })
+    assert_eq(resp.status, 200)
+
+    assert_eventually(events()
+        .where(service = "auth", op = "GET /.well-known/openid-configuration/jwks")
+        .count() >= 1)
+```
+
+The `events()` assertion verifies the SUT actually fetched JWKS — not
+just succeeded by luck or cached state. Mock services emit events into
+the same event log as real services, so every existing assertion works
+unchanged.
+
+## Dynamic responses
+
+The JWKS doc is static. The `/token` endpoint isn't — it has to mint a
+JWT whose subject matches the `user=` query param so tests can vary
+the logged-in identity.
+
+```python
+def mint_token(req):
+    user = req["query"].get("user", "anonymous")
+    return json_response(200, {
+        "access_token": sign_jwt({"sub": user, "exp": now() + 3600}),
+        "token_type":   "Bearer",
+        "expires_in":   3600,
+    })
+
+auth = mock_service("auth",
+    interface("http", "http", 8090),
+    routes = {
+        "POST /token": dynamic(mint_token),
+        # ... static routes from before
+    },
+)
+```
+
+`dynamic(fn)` wraps a Starlark callable invoked per request. It
+receives a dict with `method`, `path`, `headers`, `query`, and `body`
+and returns a response.
+
+### When to use `dynamic()` vs static
+
+| Use case | Approach |
+|---|---|
+| JWKS, health, config — same response every call | Static (`json_response`) |
+| JWT minting with variable subject | Dynamic |
+| Flag evaluation based on request headers | Dynamic |
+| Echo endpoints for integration-testing request shape | Dynamic |
+| Dozens of operations on the same shape | Static (generate the dict in spec once) |
+
+Dynamic handlers run Starlark on the hot path — fine for mock services
+(designed for low RPS), but don't use them for throughput testing.
+
+## Stdlib mocks: Kafka, Redis, MongoDB
+
+Some protocols don't fit the route-table shape — Kafka has topics
+(not paths), Redis has a key/value model, MongoDB has collections.
+For these, Faultbox ships protocol-specific stdlib constructors at
+`@faultbox/mocks/<name>.star`:
+
+```python
+load("@faultbox/mocks/kafka.star",   "kafka")
+load("@faultbox/mocks/redis.star",   "redis")
+load("@faultbox/mocks/mongodb.star", "mongo")
+
+bus = kafka.broker(
+    name      = "bus",
+    interface = interface("main", "kafka", 9092),
+    topics    = {"orders": [], "payments": []},
+)
+
+cache = redis.server(
+    name      = "cache",
+    interface = interface("main", "redis", 6379),
+    state     = {"config:max_retries": "3", "flag:new_ui": "true"},
+)
+
+users_db = mongo.server(
+    name      = "users-stub",
+    interface = interface("main", "mongodb", 27017),
+    collections = {
+        "users": [
+            {"_id": "1", "name": "alice", "role": "admin"},
+            {"_id": "2", "name": "bob",   "role": "user"},
+        ],
+    },
+)
+```
+
+Under the hood, each stdlib constructor is a thin Starlark wrapper
+that calls the generic `mock_service()` with a protocol-specific
+`config=` map. The Go machinery is the same; the split exists only so
+call sites stay readable.
+
+**Real clients work without modification.** Your `kafka-go`,
+`go-redis`, `mongo-driver/v2` in the SUT container connect and speak
+wire protocol just like they would against the real servers.
+
+### What the stdlib mocks cover (and don't)
+
+| Mock | Good for | Not good for |
+|---|---|---|
+| `kafka.broker` | Producer/consumer tests, consumer-group handshake, topic enumeration | High-throughput benchmarks; exotic broker configs |
+| `redis.server` | String cache, counters, hashes, sorted sets, TTL | Streams, pub/sub, Lua scripting (miniredis has partial support but behavior drifts) |
+| `mongo.server` | Handshake, `find`/`findOne` against seeded docs, write acknowledgement | Round-trip CRUD (writes are acknowledged but dropped), aggregation pipelines, transactions |
+
+For anything in the right column, use a real container (Chapter 9).
+
+## Composing mocks with real services
+
+Mocks sit next to real services in the same topology:
+
+```python
+load("@faultbox/mocks/redis.star", "redis")
+
+auth  = mock_service("auth",  interface("http", "http", 8090), routes = {...})
+cache = redis.server("cache", interface = interface("main", "redis", 6379),
+                              state = {"feature:new": "true"})
+
+# Real containerized Postgres — the interesting dependency
+db = service("db",
+    interface("sql", "postgres", 5432),
+    image = "postgres:16",
+    env = {"POSTGRES_PASSWORD": "test"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api",
+    interface("public", "http", 8080),
+    image      = "myapp:latest",
+    depends_on = [auth, cache, db],
+    env = {
+        "JWKS_URL":     "http://auth:8090/.well-known/openid-configuration/jwks",
+        "REDIS_URL":    "redis://cache:6379",
+        "DATABASE_URL": "postgres://postgres:test@db:5432/postgres",
+    },
+)
+```
+
+Auth and cache are mocks — trivial dependencies, don't matter to the
+test. Postgres is real — transactions, isolation, error codes are
+exactly what you're testing. Best of both worlds: fast mocks for the
+boring bits, real infrastructure where it matters.
+
+## Faulting a mock
+
+`fault_assumption()` works on mocks exactly as on real services:
+
+```python
+jwks_unavailable = fault_assumption("jwks_unavailable",
+    target = auth.http,
+    rules  = [error(path = "/.well-known/**", status = 503)],
+)
+
+fault_scenario("auth_fails_open",
+    target  = jwks_unavailable,
+    monitor = monitor(lambda e: e.service != "api" or e.status != 500),
+)
+```
+
+The mock answers normally, then the proxy layer rewrites the response
+to 503 — same machinery used for real services in Chapter 9. You can
+combine mocks with recipes the same way:
+
+```python
+load("@faultbox/recipes/redis.star", "redis_recipes")
+
+redis_oom = fault_assumption("cache_oom",
+    target = cache.main,
+    rules  = [redis_recipes.oom()],
+)
+```
+
+## TLS
+
+Real OIDC issuers serve HTTPS. Adding `tls = True` generates an
+ECDSA cert signed by a per-runtime mock CA:
+
+```python
+auth = mock_service("auth",
+    interface("https", "http", 8443),
+    tls    = True,
+    routes = {...},
+)
+```
+
+The CA bundle is written to `${TMPDIR}/faultbox-ca-<timestamp>.pem`.
+Your SUT (real service, real client) reads the CA from that path and
+adds it to its `RootCAs` pool. No `InsecureSkipVerify=true` smell
+leaking into production code.
+
+TLS is supported on HTTP, HTTP/2, and gRPC mocks in v0.8. Other
+protocols (Kafka, Redis, MongoDB) silently ignore `tls=True` — if you
+need TLS on those, run the real service.
+
+## What mocks deliberately don't do
+
+- **Stateful CRUD with persistence.** MongoDB writes are dropped;
+  Kafka topic messages aren't pre-populated. If your test cares about
+  "I wrote X, then I read X back" for anything other than the simplest
+  key-value case, use a real container.
+- **Production-shaped throughput.** Mocks optimize for correctness,
+  not performance. Benchmarks belong in real services.
+- **Schema validation.** Routes match by pattern, not by request
+  shape. Use `dynamic()` if you need to reject malformed requests.
+- **Replace WireMock / Prism / mountebank.** Faultbox mocks stand up
+  dependencies *of the system under test*, not act as general-purpose
+  stub servers.
+
+If you find yourself working around these limits, you want a real
+service. Reach for Chapter 9.
+
+## Exercises
+
+1. **Write a minimal JWKS stub** for an SUT you actually work with. A
+   single route, real Ed25519 keys, sign one token, verify the SUT's
+   `Authorization: Bearer ...` path works.
+
+2. **Add a feature-flag endpoint** that returns different flag
+   values based on a header — `X-User-Bucket: canary` returns
+   `{"new_ui": true}`, everyone else gets `false`. Use `dynamic()`.
+
+3. **Compose** the auth stub with a real Postgres container and
+   `mongo.server` seeded with 10 user records. Write a test that hits
+   the SUT, triggers a DB query, and asserts both the mock events
+   (auth call count) and the real DB (row count after write).
+
+4. **Fault the mock.** Wrap your auth stub in a
+   `fault_assumption()` that returns 503 for 50% of JWKS fetches.
+   Assert the SUT gracefully falls back (cached keys, error page, retry
+   — whatever your app does) rather than crashing.
+
+## Reference
+
+- [Mock Services reference](../../mock-services.md) — full API
+- [Spec Language § Mock Services](../../spec-language.md#mock-services)
+- [RFC-017](../../rfcs/0017-mock-services.md) — design rationale
+- [`poc/mock-demo/`](https://github.com/faultbox/faultbox/tree/main/poc/mock-demo)
+  — end-to-end example with every v0.8 mock type

--- a/docs/tutorial/05-advanced/index.md
+++ b/docs/tutorial/05-advanced/index.md
@@ -10,3 +10,4 @@ define high-level operations, and integrate with LLM agents.
 | [Event Sources](11-event-sources.md) | 25 min | observe=, stdout/WAL/Kafka events, decoders, .data |
 | [Named Operations](12-named-ops.md) | 15 min | ops=, op(), operation-level faults, trace output |
 | [LLM Agents & MCP](13-llm-mcp.md) | 15 min | Claude Code setup, MCP server, --format json, CI integration |
+| [Mock Services](17-mock-services.md) | 25 min | mock_service(), @faultbox/mocks/ stdlib, TLS, faulting mocks, when to use vs real services |

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -71,6 +71,7 @@ make lima-create && make lima-build                 # macOS (one-time)
 | 11 | [Event Sources & Observability](05-advanced/11-event-sources.md) | 25 min |
 | 12 | [Named Operations](05-advanced/12-named-ops.md) | 15 min |
 | 13 | [LLM Agents & MCP](05-advanced/13-llm-mcp.md) | 15 min |
+| 17 | [Mock Services](05-advanced/17-mock-services.md) | 25 min |
 
 ---
 

--- a/internal/star/runtime_test.go
+++ b/internal/star/runtime_test.go
@@ -1015,6 +1015,9 @@ func TestRecipesInRepo(t *testing.T) {
 		{"../../recipes/udp.star", "udp", "packet_loss"},
 		{"../../recipes/cassandra.star", "cassandra", "write_timeout"},
 		{"../../recipes/clickhouse.star", "clickhouse", "too_many_parts"},
+		{"../../recipes/mysql.star", "mysql", "deadlock"},
+		{"../../recipes/kafka.star", "kafka", "rebalancing"},
+		{"../../recipes/redis.star", "redis", "oom"},
 	}
 	for _, rf := range recipeFiles {
 		t.Run(rf.namespace, func(t *testing.T) {
@@ -1097,6 +1100,9 @@ func TestStdlibLoad_AllProtocols(t *testing.T) {
 		{"udp", "packet_loss"},
 		{"cassandra", "write_timeout"},
 		{"clickhouse", "too_many_parts"},
+		{"mysql", "deadlock"},
+		{"kafka", "rebalancing"},
+		{"redis", "oom"},
 	}
 	for _, c := range cases {
 		t.Run(c.protocol, func(t *testing.T) {

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -32,13 +32,15 @@ One import per protocol, clean call sites, zero collisions.
 | UDP | [udp.star](udp.star) | ✅ Shipped |
 | Cassandra | [cassandra.star](cassandra.star) | ✅ Shipped |
 | ClickHouse | [clickhouse.star](clickhouse.star) | ✅ Shipped |
+| MySQL | [mysql.star](mysql.star) | ✅ Shipped (v0.8.1) |
+| Kafka | [kafka.star](kafka.star) | ✅ Shipped (v0.8.1) |
+| Redis | [redis.star](redis.star) | ✅ Shipped (v0.8.1) |
 | Postgres | — | To be added |
-| Redis | — | To be added |
-| Kafka | — | To be added |
 | HTTP | — | To be added |
 | gRPC | — | To be added |
-| MySQL | — | To be added |
 | NATS | — | To be added |
+| Memcached | — | To be added |
+| AMQP | — | To be added |
 
 ## Coverage matrix
 
@@ -49,6 +51,9 @@ One import per protocol, clean call sites, zero collisions.
 | UDP | — | `metrics_slow`, `jitter` | — | — | — | `packet_loss`, `dns_flap`, `blackhole` |
 | Cassandra | `overloaded` | `write_timeout`, `read_timeout`, `slow_reads`, `slow_writes`, `connection_drop` | `unavailable`, `schema_mismatch` | — | — | — |
 | ClickHouse | `too_many_parts`, `memory_limit` | `slow_analytics`, `slow_ingest`, `connection_drop`, `replica_stale` | — | `table_not_exists` | — | `readonly_mode` |
+| MySQL | `too_many_connections`, `disk_full` | `lock_wait_timeout`, `gone_away`, `slow_query`, `slow_writes` | `read_only_replica` | `deadlock` | — | — |
+| Kafka | `broker_overloaded`, `message_too_large` | `rebalancing`, `slow_produce`, `connection_drop`, `coordinator_not_available` | `not_leader_for_partition`, `offset_out_of_range` | — | — | — |
+| Redis | `oom` | `loading`, `busy`, `slow_command`, `connection_drop` | `cluster_down`, `readonly_replica` | `wrongtype` | `noauth` | — |
 
 ## Contributing
 

--- a/recipes/kafka.star
+++ b/recipes/kafka.star
@@ -1,0 +1,83 @@
+# Faultbox recipes: Kafka
+#
+# Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib ships embedded in the faultbox binary; load via the
+# @faultbox/ prefix.
+#
+# Usage:
+#     load("@faultbox/recipes/kafka.star", "kafka")
+#
+#     rebalance = fault_assumption("rebalance_during_consume",
+#         target = bus.main,
+#         rules  = [kafka.rebalancing()],
+#     )
+#
+# Scope: Kafka broker error codes that surface to clients as exceptions.
+# The Kafka plugin matches rules by topic name (+ eventually operation,
+# see notes on kafka.not_leader_for_partition below). Error messages
+# embed the canonical Kafka error code number so driver error handlers
+# recognize them (UnknownTopicOrPartitionException, etc.).
+
+kafka = struct(
+    # not_leader_for_partition — error code 6 (NOT_LEADER_FOR_PARTITION).
+    # Produce request hit a broker that is no longer the partition leader
+    # — happens during leadership election or broker rolls. Drivers
+    # refresh metadata and retry; infinite-retry bugs live here.
+    not_leader_for_partition = lambda topic = "*": error(
+        topic = topic,
+        message = "NotLeaderForPartitionException (error code 6): This server is not the leader for that topic-partition",
+    ),
+
+    # rebalancing — simplified REBALANCE_IN_PROGRESS (code 27). Forces
+    # consumers into their rebalance-handler path. Real rebalances are a
+    # multi-step group-coordinator dance; this recipe triggers the same
+    # driver-side code path without simulating the full state machine.
+    rebalancing = lambda topic = "*": error(
+        topic = topic,
+        message = "RebalanceInProgressException (error code 27): The group is rebalancing",
+    ),
+
+    # offset_out_of_range — error code 1 (OFFSET_OUT_OF_RANGE). Consumer
+    # asks for an offset that's past the log head (or before retention
+    # cutoff). Drivers with auto.offset.reset=none die here; silent
+    # consumer deaths hide in this error path.
+    offset_out_of_range = lambda topic = "*": error(
+        topic = topic,
+        message = "OffsetOutOfRangeException (error code 1): The requested offset is not within the range of offsets maintained by the server",
+    ),
+
+    # message_too_large — error code 10 (MESSAGE_TOO_LARGE). Produce
+    # rejected because payload exceeds message.max.bytes. No DLQ in most
+    # apps = event lost forever.
+    message_too_large = lambda topic = "*": error(
+        topic = topic,
+        message = "RecordTooLargeException (error code 10): The request included a message larger than the max message size the server will accept",
+    ),
+
+    # coordinator_not_available — error code 15 (COORDINATOR_NOT_AVAILABLE).
+    # Consumer-group coordinator is down or in the middle of election.
+    # Drivers retry FindCoordinator; shutdown paths that don't wait for
+    # coordinator re-election hang on stop.
+    coordinator_not_available = lambda topic = "*": error(
+        topic = topic,
+        message = "CoordinatorNotAvailableException (error code 15): The coordinator is not available",
+    ),
+
+    # broker_overloaded — simulates request throttling / load shedding.
+    # Useful for testing client back-pressure.
+    broker_overloaded = lambda topic = "*": error(
+        topic = topic,
+        message = "KafkaException: broker overloaded — request quota exceeded",
+    ),
+
+    # slow_produce — delays produce requests. Tests producer batching
+    # and linger.ms behavior under latency.
+    slow_produce = lambda duration = "3s", topic = "*": delay(
+        topic = topic,
+        delay = duration,
+    ),
+
+    # connection_drop closes the TCP connection mid-request. Forces
+    # driver reconnect through its metadata + coordinator discovery path.
+    connection_drop = lambda topic = "*": drop(topic = topic),
+)

--- a/recipes/mysql.star
+++ b/recipes/mysql.star
@@ -1,0 +1,78 @@
+# Faultbox recipes: MySQL
+#
+# Per RFC-018: one namespace struct per recipe file — mysql.deadlock()
+# never collides with postgres.deadlock() when both recipes are loaded.
+# Per RFC-019: stdlib ships embedded in the faultbox binary; load via the
+# @faultbox/ prefix.
+#
+# Usage:
+#     load("@faultbox/recipes/mysql.star", "mysql")
+#
+#     deadlock_retry = fault_assumption("deadlock_retry",
+#         target = db.main,
+#         rules  = [mysql.deadlock()],
+#     )
+#
+# Scope: MySQL 5.7 / 8.0 error packets. The proxy's MySQL plugin matches
+# rules by SQL query pattern; the error message below is what drivers
+# surface up to application code.
+
+mysql = struct(
+    # deadlock — error 1213, Two transactions circular-wait on row locks.
+    # Drivers surface ER_LOCK_DEADLOCK; apps with retry logic loop, apps
+    # without retry crash or leak the transaction.
+    deadlock = lambda query = "*": error(
+        query = query,
+        message = "Deadlock found when trying to get lock; try restarting transaction",
+    ),
+
+    # lock_wait_timeout — error 1205. Statement waited past
+    # innodb_lock_wait_timeout (default 50s). Driver error surfaces the
+    # exact message below; connection stays alive.
+    lock_wait_timeout = lambda query = "*": error(
+        query = query,
+        message = "Lock wait timeout exceeded; try restarting transaction",
+    ),
+
+    # too_many_connections — error 1040. Server rejects new connections
+    # because max_connections is saturated. Exposes nil-pointer bugs in
+    # connection-pool init paths that don't surface the error.
+    too_many_connections = lambda: error(
+        query = "*",
+        message = "Too many connections",
+    ),
+
+    # read_only_replica — error 1290, --read-only. Writes accidentally
+    # routed to a replica fail here; reads succeed. Default targets
+    # INSERT statements; override query= for UPDATE/DELETE.
+    read_only_replica = lambda query = "INSERT*": error(
+        query = query,
+        message = "The MySQL server is running with the --read-only option so it cannot execute this statement",
+    ),
+
+    # disk_full — error 1114. INSERTs against a full tablespace reject.
+    # Drivers surface ER_RECORD_FILE_FULL; app-side retries do not help.
+    disk_full = lambda query = "INSERT*": error(
+        query = query,
+        message = "The table is full",
+    ),
+
+    # gone_away — client-side error 2006. Simulated by dropping the
+    # connection mid-query; drivers see the classic
+    # "MySQL server has gone away" and must reconnect.
+    gone_away = lambda query = "*": drop(query = query),
+
+    # slow_query — delays every statement by duration. Tests client
+    # query-timeout handling and transaction deadline behavior.
+    slow_query = lambda duration = "3s", query = "*": delay(
+        query = query,
+        delay = duration,
+    ),
+
+    # slow_writes — delays write statements only. Useful for testing how
+    # read-heavy paths degrade when the write tier is slow.
+    slow_writes = lambda duration = "3s", query = "INSERT*": delay(
+        query = query,
+        delay = duration,
+    ),
+)

--- a/recipes/redis.star
+++ b/recipes/redis.star
@@ -1,0 +1,88 @@
+# Faultbox recipes: Redis
+#
+# Per RFC-018: one namespace struct per recipe file.
+# Per RFC-019: stdlib ships embedded in the faultbox binary; load via the
+# @faultbox/ prefix.
+#
+# Usage:
+#     load("@faultbox/recipes/redis.star", "redis")
+#
+#     cache_oom = fault_assumption("cache_oom_fallback",
+#         target = cache.main,
+#         rules  = [redis.oom()],
+#     )
+#
+# Scope: RESP error strings Redis emits under operational failure. The
+# Redis plugin matches rules by key pattern (or wildcards); the message
+# is what go-redis / redigo / raw RESP clients see verbatim as an
+# "ERR ..." reply. All recipes prefix with the canonical Redis error
+# tag so client-side error-type detection ("strings.HasPrefix(err, ...)"
+# or error-type checks) works.
+
+redis = struct(
+    # oom — "OOM command not allowed when used memory > 'maxmemory'".
+    # Writes rejected once maxmemory is reached; reads still succeed.
+    # Silent-skip bugs in cache-cleaning logic live in this error path.
+    oom = lambda key = "*": error(
+        key = key,
+        message = "OOM command not allowed when used memory > 'maxmemory'",
+    ),
+
+    # cluster_down — "CLUSTERDOWN The cluster is down". Cluster lost
+    # quorum; most commands fail until a majority of masters are back.
+    cluster_down = lambda key = "*": error(
+        key = key,
+        message = "CLUSTERDOWN The cluster is down",
+    ),
+
+    # loading — "LOADING Redis is loading the dataset in memory". Server
+    # just restarted and is replaying its RDB/AOF; every command fails
+    # until loading completes. Apps without retry see reads-always-fail.
+    loading = lambda key = "*": error(
+        key = key,
+        message = "LOADING Redis is loading the dataset in memory",
+    ),
+
+    # readonly_replica — "READONLY You can't write against a read only
+    # replica." Writes accidentally routed to a replica after failover
+    # fail silently in some client libraries, leaving stale state.
+    readonly_replica = lambda key = "*": error(
+        key = key,
+        message = "READONLY You can't write against a read only replica.",
+    ),
+
+    # busy — "BUSY Redis is busy running a script. You can only call
+    # SCRIPT KILL or SHUTDOWN NOSAVE." A Lua script monopolized the
+    # single-threaded server; all other commands block until it ends.
+    busy = lambda key = "*": error(
+        key = key,
+        message = "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.",
+    ),
+
+    # noauth — "NOAUTH Authentication required". Server restarted into
+    # an authenticated mode the client didn't handshake with; all
+    # commands fail until the client re-AUTHs.
+    noauth = lambda key = "*": error(
+        key = key,
+        message = "NOAUTH Authentication required.",
+    ),
+
+    # wrongtype — "WRONGTYPE Operation against a key holding the wrong
+    # kind of value". Tests client-side type-mismatch handling when a
+    # key's semantics drift (e.g., migration reshaped a string to hash).
+    wrongtype = lambda key = "*": error(
+        key = key,
+        message = "WRONGTYPE Operation against a key holding the wrong kind of value",
+    ),
+
+    # slow_command — delays every command. Tests pool timeout and
+    # client-side deadline propagation.
+    slow_command = lambda duration = "3s", key = "*": delay(
+        key = key,
+        delay = duration,
+    ),
+
+    # connection_drop closes the client connection mid-command. Forces
+    # pool to evict and reconnect.
+    connection_drop = lambda key = "*": drop(key = key),
+)


### PR DESCRIPTION
Closes #49 (customer request for MySQL/Kafka/Redis recipe namespaces) and ships the mock services tutorial chapter deferred from v0.8.0.

## Summary

**Three new recipe namespaces** (#49 customer priority: MySQL > Kafka > Redis):

| File | Recipes |
|---|---|
| `recipes/mysql.star` | deadlock, lock_wait_timeout, too_many_connections, read_only_replica, disk_full, gone_away, slow_query, slow_writes |
| `recipes/kafka.star` | not_leader_for_partition, rebalancing, offset_out_of_range, message_too_large, coordinator_not_available, broker_overloaded, slow_produce, connection_drop |
| `recipes/redis.star` | oom, cluster_down, loading, readonly_replica, busy, noauth, wrongtype, slow_command, connection_drop |

**Tutorial chapter 17: Mock Services** (`docs/tutorial/05-advanced/17-mock-services.md`) — 25-minute walkthrough of `mock_service()`, `dynamic()`, `@faultbox/mocks/` stdlib, composition with real services, faulting mocks, TLS.

## Docs

- `docs/recipes.md` — three new per-recipe tables
- `recipes/README.md` — status matrix + coverage matrix updated
- Tutorial README + Part 5 index — Chapter 17 registered

## Test plan

- [x] `go test ./...` — 6 new recipe subtests, all pass
- [x] `go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — clean
- [x] `faultbox recipes list` — shows mysql, kafka, redis

## Site sync

Will land in a companion `faultbox-site` commit: recipes.md, spec-language.md, Chapter 17, public/docs/recipes/{mysql,kafka,redis}.star, sidebar entry for Chapter 17, version badge bump when this merges.

## Links

- Issue: #49
- Milestone: [v0.8.1](https://github.com/faultbox/Faultbox/milestone/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)