### PR TITLE
fix(poc/demo): observe openat via trace_start for WAL assertions

### DIFF
--- a/poc/demo/faultbox.star
+++ b/poc/demo/faultbox.star
@@ -27,6 +27,11 @@ orders = service("orders",
 
 def test_happy_path():
     """Place an order — stock reserved, WAL written."""
+    # openat isn't targeted by any fault() here, so install a passive
+    # filter that observes it without faulting. Without this, the
+    # assert_eventually below has nothing to match against.
+    trace_start(inventory, syscalls = ["openat"])
+
     # Check stock is available.
     resp = orders.get(path="/inventory/widget")
     assert_eq(resp.status, 200)
@@ -48,9 +53,11 @@ def test_happy_path():
         syscall = "openat",
         path = "/tmp/inventory.wal",
     )
+    trace_stop(inventory)
 
 def test_inventory_slow():
     """Inventory writes delayed 500ms — order still succeeds but slow."""
+    trace_start(inventory, syscalls = ["openat"])
     def scenario():
         resp = orders.post(path="/orders", body='{"sku":"gadget","qty":1}')
         assert_eq(resp.status, 200)
@@ -64,9 +71,14 @@ def test_inventory_slow():
             path = "/tmp/inventory.wal",
         )
     fault(inventory, write=delay("500ms"), run=scenario)
+    trace_stop(inventory)
 
 def test_inventory_unreachable():
     """Order service can't connect to inventory — returns 503."""
+    # assert_never is only meaningful when the syscall is being observed;
+    # without trace_start the filter would ignore openat and the negative
+    # assertion would pass vacuously.
+    trace_start(inventory, syscalls = ["openat"])
     def scenario():
         resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
         assert_eq(resp.status, 503)
@@ -79,6 +91,7 @@ def test_inventory_unreachable():
             path = "/tmp/inventory.wal",
         )
     fault(orders, connect=deny("ECONNREFUSED"), run=scenario)
+    trace_stop(inventory)
 
 def test_wal_fsync_failure():
     """WAL fsync fails — reservation should fail, data integrity preserved."""


### PR DESCRIPTION
Closes #56.

## Summary

The [poc/demo spec](poc/demo/faultbox.star) asserted on openat events (both \`assert_eventually\` for happy paths and \`assert_never\` for unreachability proofs) without any \`fault()\` or \`trace()\` call installing openat in the service's seccomp filter. Faultbox only intercepts syscalls declared explicitly; assertions don't implicitly extend the filter. The assertions therefore queried a trace that never saw openat, failing with "no matching event found" or passing vacuously.

Fix: wrap the three affected tests with \`trace_start(inventory, syscalls=["openat"])\` and \`trace_stop(inventory)\`. This installs a passive allow-only filter that records openat without faulting it — exactly what \`trace_start\` was designed for.

## Verified in Lima (linux/arm64), seed=1

All 5 tests pass individually:

| Test | Before | After |
|---|---|---|
| \`test_happy_path\` | FAIL (no openat event) | PASS (222ms) |
| \`test_inventory_slow\` | FAIL (no openat event) | PASS (1720ms) |
| \`test_inventory_unreachable\` | vacuously passed | PASS (meaningful) |
| \`test_wal_fsync_failure\` | PASS (unchanged) | PASS (211ms) |
| \`test_disk_full\` | PASS (unchanged) | PASS |

Host Go test suite: \`go test ./...\` green.

## Out of scope

A separate test-isolation bug surfaced while verifying this fix: running all 6 tests in one \`faultbox test\` invocation fails 5 of them with \`status=0\` / unreachable-proxy patterns, even though each test passes in isolation. Tracked as #61 — not addressed here.

## Unblocks

Partial un-skip of \`poc_demo\` in the testops regression corpus ([PR #55](https://github.com/faultbox/Faultbox/pull/55)). Full un-skip also requires #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)