### PR TITLE
experiment: relax AppArmor userns restriction for #57

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Build poc binaries for testops
         run: make testops-prep
 
+      # Experiment for issue #57 — Ubuntu 24.04's AppArmor default
+      # restricts processes inside unprivileged user namespaces, which
+      # breaks faultbox's service sandbox on GitHub-hosted runners.
+      # If this makes poc_example pass, the hypothesis is confirmed
+      # and this becomes a documented CI prerequisite (pending a
+      # proper per-service `namespaces=` kwarg).
+      - name: Relax AppArmor userns restriction (experiment for #57)
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Testops goldens
         run: go test ./testops/... -race -count=1 -v
 

--- a/testops/harness.go
+++ b/testops/harness.go
@@ -96,7 +96,6 @@ var Cases = []Case{
 		Seed:      1,
 		Timeout:   60 * time.Second,
 		LinuxOnly: true,
-		Skip:      "passes in Lima but test_db_slow + test_happy_path fail on GitHub-hosted ubuntu-latest — see FINDINGS #3",
 	},
 	{
 		Name:      "poc_demo",


### PR DESCRIPTION
Experiment to confirm or refute the hypothesis in #57.

## What this does

- Un-skips \`poc_example\` in the testops corpus.
- Adds one CI step: \`sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\` before the testops goldens step.

## Hypothesis under test

Ubuntu 24.04's default \`kernel.apparmor_restrict_unprivileged_userns=1\` applies an AppArmor profile to processes inside unprivileged user namespaces, restricting some network operations. GitHub-hosted \`ubuntu-latest\` runners are Ubuntu 24.04 and inherit this default. Faultbox creates per-service unprivileged USER + PID + MNT namespaces, so this policy applies to the services under test — breaking loopback TCP between them.

## Outcomes

- **Green CI** → hypothesis confirmed. The sysctl becomes a documented CI prerequisite. Keep #57 open for the proper fix: a per-service \`namespaces=\` kwarg that lets specs opt out of USER namespace, making this sysctl unnecessary.
- **Red CI** → hypothesis refuted. Re-skip \`poc_example\`, reopen #57 investigation.

## Not a long-term fix

The sysctl is a system-wide escape hatch. On shared CI, it's acceptable (the runner is ephemeral). On a customer's laptop or security-sensitive CI it isn't — hence the follow-up \`namespaces=\` kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)