### PR TITLE
fix(proxy): tear down proxies in stopServices for test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,6 @@ jobs:
       - name: Build poc binaries for testops
         run: make testops-prep
 
-      # Experiment for issue #57 — Ubuntu 24.04's AppArmor default
-      # restricts processes inside unprivileged user namespaces, which
-      # breaks faultbox's service sandbox on GitHub-hosted runners.
-      # If this makes poc_example pass, the hypothesis is confirmed
-      # and this becomes a documented CI prerequisite (pending a
-      # proper per-service `namespaces=` kwarg).
-      - name: Relax AppArmor userns restriction (experiment for #57)
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
       - name: Testops goldens
         run: go test ./testops/... -race -count=1 -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Build poc binaries for testops
         run: make testops-prep
 
+      # Experiment for issue #57 — Ubuntu 24.04's AppArmor default
+      # restricts processes inside unprivileged user namespaces, which
+      # breaks faultbox's service sandbox on GitHub-hosted runners.
+      # If this makes poc_example pass, the hypothesis is confirmed
+      # and this becomes a documented CI prerequisite (pending a
+      # proper per-service `namespaces=` kwarg).
+      - name: Relax AppArmor userns restriction (experiment for #57)
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Testops goldens
         run: go test ./testops/... -race -count=1 -v
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -247,6 +247,28 @@ func (m *Manager) StopAll() {
 	}
 }
 
+// StopService tears down every proxy belonging to a single service,
+// across all of its interfaces. Used during per-test teardown so that
+// a following test's EnsureProxy call allocates a fresh listener bound
+// to the new backend target, rather than returning a stale one whose
+// upstream points at a dead PID from the previous test.
+func (m *Manager) StopService(svcName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	prefix := svcName + ":"
+	for key, rp := range m.proxies {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rp.cancel()
+		if rp.proxy != nil {
+			rp.proxy.Stop()
+		}
+		delete(m.proxies, key)
+	}
+}
+
 // SupportsProxy reports whether a protocol has a proxy implementation that
 // can be started in pass-through mode (no rules installed). Callers that
 // want to pre-start proxies for every interface (RFC-024 data-path mode)

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1149,7 +1149,11 @@ func (rt *Runtime) stopServices() {
 		}
 	}
 
-	// Cancel non-reused sessions.
+	// Cancel non-reused sessions and tear down their proxies. Leaving
+	// the proxy alive across tests would cause the next test's
+	// EnsureProxy call to reuse a listener whose target points at the
+	// now-dead PID, so real traffic stalls until the proxy read
+	// timeout fires (see #61).
 	for name, rs := range rt.sessions {
 		if reused[name] {
 			// Keep session alive; just clear dynamic fault rules.
@@ -1157,6 +1161,9 @@ func (rt *Runtime) stopServices() {
 			continue
 		}
 		rs.cancel()
+		if rt.proxyMgr != nil {
+			rt.proxyMgr.StopService(name)
+		}
 	}
 	// Wait for non-reused sessions to finish.
 	kept := make(map[string]*runningSession)

--- a/testops/harness.go
+++ b/testops/harness.go
@@ -96,7 +96,6 @@ var Cases = []Case{
 		Seed:      1,
 		Timeout:   60 * time.Second,
 		LinuxOnly: true,
-		Skip:      "passes in Lima but test_db_slow + test_happy_path fail on GitHub-hosted ubuntu-latest — see FINDINGS #3",
 	},
 	{
 		Name:      "poc_demo",


### PR DESCRIPTION
Closes #61. Closes #57.

## Root cause (applies to both issues)

\`stopServices()\` cancels non-reused service sessions between tests but did **not** tear down the corresponding proxies in \`proxyMgr\`. On the next test, \`EnsureProxy\` finds the existing \`svc:iface\` entry and returns the old listen address without updating the target — so traffic from the new test's client flows into a proxy whose upstream points at the previous test's now-dead PID. Reads hang until proxy read timeout fires, producing the \`status=0\` / \`i/o timeout\` pattern that:

- broke 5 of 6 \`poc_demo\` tests when run in one invocation while each passed in isolation (#61)
- broke \`poc_example\` tests 2 and 3 alphabetically after \`test_api_cannot_reach_db\` leaked its proxy (#57)

The two bugs' differing surface-level symptoms came from different alphabetical test orderings in the two specs; the underlying failure mode is identical.

## Fix

- New: \`proxy.Manager.StopService(name)\` — closes every listener belonging to a single service (all interfaces).
- \`stopServices\` calls it per non-reused service, immediately after \`rs.cancel()\`.
- Reused services (\`reuse=True\`) keep their proxies by design.

## Verification

**Lima (linux/arm64), seed=1**: \`poc_demo\` full suite

| | Before this PR | After this PR |
|---|---|---|
| \`poc_demo\` full suite (#61) | 1 passed, 5 failed | 4 passed, 2 failed |
| + spec fix from #62 | — | **6 passed, 0 failed** |

**GitHub-hosted ubuntu-latest amd64** (diagnostic PR #65): \`poc_example\`

\`\`\`
--- PASS: TestGoldens/poc_example (1.65s)
\`\`\`

All 3 tests in the spec pass on amd64 CI with this PR. No AppArmor workaround, no arch-specific code change.

## Also included

- Un-skip of \`poc_example\` in \`testops/harness.go\` — so CI verifies the fix on every push going forward. Added because #65's CI run confirmed the suite passes clean.

## History note

An earlier experimental sysctl step (\`kernel.apparmor_restrict_unprivileged_userns=0\`) was tried to isolate the cause; PR #65's diagnostic proved the proxy teardown alone is sufficient, and the sysctl was removed in the final commit so the CI config doesn't imply a false dependency.

## Unblocks

- ~8 Critical-tier rows in [docs/feature-manifest.md](docs/feature-manifest.md) (binary-mode \`service()\`, \`fault(deny/delay/hold)\`, \`assert_eventually/never\` on real syscall traces) flip from 🔴 to 🟢 once this lands and real-fault-injection CI coverage turns on.
- \`poc_demo\` still depends on PR #62 (openat matching) to reach full 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)