### PR TITLE
diagnostic: amd64 trace capture for #57 investigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,29 @@ jobs:
       - name: Testops goldens
         run: go test ./testops/... -race -count=1 -v
 
+      # Diagnostic run for #57 — captures full amd64 trace from a
+      # real faultbox invocation so we can compare against the
+      # known-good Lima (arm64) output. Runs always=true so we see
+      # the diagnostic even when the test step above also fails.
+      - name: Diagnostic — poc_example on amd64 with --debug (for #57)
+        if: always()
+        run: |
+          set +e
+          go build -o bin/faultbox ./cmd/faultbox/
+          echo "=== kernel ==="
+          uname -a
+          echo "=== AppArmor userns sysctl ==="
+          cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || echo "not present"
+          echo "=== unprivileged_userns_clone ==="
+          cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null || echo "not present"
+          echo "=== lsb_release ==="
+          lsb_release -a 2>/dev/null
+          echo "=== run test_happy_path with --debug ==="
+          rm -f /tmp/inventory.wal
+          timeout 30 ./bin/faultbox test poc/example/faultbox.star \
+            --test happy_path --seed 1 --debug \
+            --log-format=console 2>&1 | head -400
+
       - name: Cross-compile (linux/arm64)
         run: |
           GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o /dev/null ./cmd/faultbox/

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -247,6 +247,28 @@ func (m *Manager) StopAll() {
 	}
 }
 
+// StopService tears down every proxy belonging to a single service,
+// across all of its interfaces. Used during per-test teardown so that
+// a following test's EnsureProxy call allocates a fresh listener bound
+// to the new backend target, rather than returning a stale one whose
+// upstream points at a dead PID from the previous test.
+func (m *Manager) StopService(svcName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	prefix := svcName + ":"
+	for key, rp := range m.proxies {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rp.cancel()
+		if rp.proxy != nil {
+			rp.proxy.Stop()
+		}
+		delete(m.proxies, key)
+	}
+}
+
 // SupportsProxy reports whether a protocol has a proxy implementation that
 // can be started in pass-through mode (no rules installed). Callers that
 // want to pre-start proxies for every interface (RFC-024 data-path mode)

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1209,7 +1209,11 @@ func (rt *Runtime) stopServices() {
 		}
 	}
 
-	// Cancel non-reused sessions.
+	// Cancel non-reused sessions and tear down their proxies. Leaving
+	// the proxy alive across tests would cause the next test's
+	// EnsureProxy call to reuse a listener whose target points at the
+	// now-dead PID, so real traffic stalls until the proxy read
+	// timeout fires (see #61).
 	for name, rs := range rt.sessions {
 		if reused[name] {
 			// Keep session alive; just clear dynamic fault rules.
@@ -1217,6 +1221,9 @@ func (rt *Runtime) stopServices() {
 			continue
 		}
 		rs.cancel()
+		if rt.proxyMgr != nil {
+			rt.proxyMgr.StopService(name)
+		}
 	}
 	// Wait for non-reused sessions to finish.
 	kept := make(map[string]*runningSession)

--- a/testops/harness.go
+++ b/testops/harness.go
@@ -96,7 +96,6 @@ var Cases = []Case{
 		Seed:      1,
 		Timeout:   60 * time.Second,
 		LinuxOnly: true,
-		Skip:      "passes in Lima but test_db_slow + test_happy_path fail on GitHub-hosted ubuntu-latest — see FINDINGS #3",
 	},
 	{
 		Name:      "poc_demo",


### PR DESCRIPTION
Diagnostic run to gather concrete evidence for #57. Adds an always-run CI step that prints kernel/AppArmor state and runs poc_example test_happy_path with --debug + console logging. Will close this PR after inspecting the CI logs.

Includes the #61 fix (cherry-picked from #64) so test isolation doesn't muddy the signal. Not intended to merge.