### PR TITLE
feat(testops): redis_fault_basic + flip HTTP/Redis proxy faults to green

### DIFF
--- a/docs/feature-manifest.md
+++ b/docs/feature-manifest.md
@@ -51,9 +51,9 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 
 | Feature | Tier | Mechanism | Status | Notes |
 |---|---|---|---|---|
-| HTTP proxy faults | 1 | `internal/proxy/http_test.go` + corpus | 🟡 | Unit tests exist, no integration corpus |
-| Postgres proxy faults | 1 | `internal/proxy/postgres_test.go` + corpus | 🟡 | Unit tests exist, no integration corpus |
-| Redis proxy faults | 1 | corpus | 🔴 | Unit tests only |
+| HTTP proxy faults | 1 | `internal/proxy/http_test.go` + corpus (fault_matrix_basic) | 🟢 | Path-matched error rules via `error(path=, status=, message=)` |
+| Postgres proxy faults | 1 | `internal/proxy/postgres_test.go` + corpus | 🟡 | No Postgres mock; real container needed — gated on CI Docker |
+| Redis proxy faults | 1 | `internal/proxy/redis_test.go` + corpus (redis_fault_basic) | 🟢 | Key-pattern matched error rules via stdlib recipes (oom/loading/readonly) |
 | MySQL proxy faults | 2 | unit + `sqlmatch` canonicalizer | 🟢 | Strong unit coverage |
 | Other protocols (HTTP2, UDP, Mongo, Cassandra, ClickHouse, Kafka, NATS, gRPC) | 2 | unit tests | 🟢 | 13 protocols, all have parse/proxy unit tests |
 
@@ -109,7 +109,7 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 
 ## Summary counts
 
-- Critical (Tier 1): 17 rows, **~53% green**.
+- Critical (Tier 1): 17 rows, **~65% green**.
 - Supported (Tier 2): 22 rows, **~55% green**.
 - Experimental (Tier 3): 8 rows, **~0% green** — expected; these are checklist-gated.
 

--- a/testops/corpus/redis_fault_basic.star
+++ b/testops/corpus/redis_fault_basic.star
@@ -1,0 +1,60 @@
+# testops/corpus/redis_fault_basic.star
+#
+# Mock-only corpus spec exercising Redis proxy-level fault injection.
+# Uses the redis mock (miniredis-backed) + the stdlib Redis recipes that
+# emit canonical RESP error strings (OOM, LOADING, READONLY).
+#
+# Verifies:
+#   - GET on a seeded key succeeds baseline (resp.ok == True).
+#   - Recipe-driven faults surface as RESP errors on the client
+#     (resp.ok == False, error message visible).
+#   - Key-pattern matching: fault only fires on matching keys.
+
+load("@faultbox/mocks/redis.star", "redis")
+load("@faultbox/recipes/redis.star", redis_recipe = "redis")
+
+cache = redis.server(
+    name      = "cache",
+    interface = interface("main", "redis", 16381),
+    state = {
+        "user:1":          "alice",
+        "counter:hits":    "0",
+        "config:readonly": "false",
+    },
+)
+
+def test_baseline_get():
+    """Without faults, GET returns the seeded value via the mock."""
+    resp = cache.main.get(key = "user:1")
+    assert_true(resp.ok, "expected ok=True on baseline GET")
+    assert_true("alice" in resp.body, "expected seeded value for user:1")
+
+def test_oom_on_all_keys():
+    """redis.oom() with default key='*' faults every GET."""
+    def scenario():
+        resp = cache.main.get(key = "user:1")
+        assert_true(not resp.ok, "expected ok=False under OOM fault")
+        assert_true("OOM" in resp.error, "expected OOM in error message")
+    fault(cache.main, redis_recipe.oom(), run = scenario)
+
+def test_loading_selective():
+    """redis.loading() scoped to counter:* keys only faults matching keys."""
+    def scenario():
+        # counter:* key — should see LOADING error.
+        resp = cache.main.get(key = "counter:hits")
+        assert_true(not resp.ok, "expected ok=False on matching key")
+        assert_true("LOADING" in resp.error, "expected LOADING in error")
+
+        # Non-matching key — should succeed.
+        resp2 = cache.main.get(key = "user:1")
+        assert_true(resp2.ok, "expected ok=True on non-matching key")
+        assert_true("alice" in resp2.body)
+    fault(cache.main, redis_recipe.loading(key = "counter:*"), run = scenario)
+
+def test_readonly_on_config_keys():
+    """READONLY error scoped to config:* keys."""
+    def scenario():
+        resp = cache.main.get(key = "config:readonly")
+        assert_true(not resp.ok, "expected ok=False on config:* key")
+        assert_true("READONLY" in resp.error, "expected READONLY in error")
+    fault(cache.main, redis_recipe.readonly_replica(key = "config:*"), run = scenario)

--- a/testops/goldens/redis_fault_basic.norm
+++ b/testops/goldens/redis_fault_basic.norm
@@ -1,0 +1,30 @@
+=== test_baseline_get ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_recv cache
+=== test_loading_selective ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_recv cache
+step_send cache
+step_recv cache
+=== test_oom_on_all_keys ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_recv cache
+=== test_readonly_on_config_keys ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_recv cache

--- a/testops/harness.go
+++ b/testops/harness.go
@@ -86,6 +86,12 @@ var Cases = []Case{
 		Seed:    1,
 		Timeout: 30 * time.Second,
 	},
+	{
+		Name:    "redis_fault_basic",
+		Spec:    "testops/corpus/redis_fault_basic.star",
+		Seed:    1,
+		Timeout: 30 * time.Second,
+	},
 
 	// --- LinuxOnly, currently skipped. ---
 	//


### PR DESCRIPTION
## Summary

Adds Redis-focused integration corpus entry that exercises protocol-level fault injection via the stdlib Redis recipes. Flips two Critical-tier manifest rows 🟡/🔴 → 🟢.

## Changes

- **testops/corpus/redis_fault_basic.star** (new) — 4 tests:
  - Baseline GET returns seeded value.
  - \`redis.oom()\` faults every GET — client sees \`OOM ...\` on \`resp.error\`.
  - \`redis.loading(key=\"counter:*\")\` — matching keys fault, non-matching keys succeed (verifies key-pattern matching).
  - \`redis.readonly_replica(key=\"config:*\")\` — scoped fault.

- **testops/goldens/redis_fault_basic.norm** (new) — seeded, deterministic across 3 consecutive runs.

- **testops/harness.go** — register the case.

- **docs/feature-manifest.md**:
  - **HTTP proxy faults** 🟡 → 🟢 — fault_matrix_basic (merged via #70) already exercises path-matched \`error()\` rules on an HTTP mock.
  - **Redis proxy faults** 🔴 → 🟢 — redis_fault_basic added here.
  - Critical coverage: ~53% → ~65%.

## Note on Postgres

Postgres proxy faults stay 🟡 — we have \`internal/proxy/postgres_test.go\` unit tests, but no in-process Postgres mock exists. Real integration coverage requires CI Docker provisioning (a separate follow-up).

## Test plan

- [ ] \`go test ./testops/... -run redis_fault_basic -v\` passes locally (verified).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)