### PR TITLE
feat(testops): parallel_basic corpus + rename fault(hold) manifest row

### DIFF
--- a/docs/feature-manifest.md
+++ b/docs/feature-manifest.md
@@ -37,7 +37,7 @@ Status legend: **🟢 green** (CI signal proves it), **🟡 partial** (some mech
 | `service()` container mode (Docker) | 1 | testops corpus with pinned image digest | 🔴 | CI Docker provisioning not yet added |
 | `fault(deny)` on syscalls | 1 | testops corpus (poc_example test_api_cannot_reach_db; poc_demo test_wal_fsync_failure, test_disk_full) | 🟢 | |
 | `fault(delay)` on syscalls | 1 | testops corpus (poc_example test_db_slow; poc_demo test_inventory_slow) | 🟢 | |
-| `fault(hold)` on syscalls | 1 | testops corpus | 🔴 | No corpus entry exercises hold |
+| `parallel()` concurrent scenarios + hold/release scheduler | 1 | testops corpus (parallel_basic) | 🟢 | Hold is an internal scheduler primitive exercised by `parallel()` setup/teardown; `--explore=all/sample` adds interleaving enumeration on top |
 | `assert_eventually` temporal | 1 | testops corpus (poc_demo test_happy_path on openat) | 🟢 | |
 | `assert_never` temporal | 1 | testops corpus (poc_demo test_inventory_unreachable) | 🟢 | |
 | `--seed` deterministic replay | 1 | testops harness itself asserts identical traces across 5 runs | 🟢 | Already proven by corpus entries |
@@ -109,7 +109,7 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 
 ## Summary counts
 
-- Critical (Tier 1): 17 rows, **~65% green**.
+- Critical (Tier 1): 15 rows, **~87% green**.
 - Supported (Tier 2): 22 rows, **~55% green**.
 - Experimental (Tier 3): 8 rows, **~0% green** — expected; these are checklist-gated.
 

--- a/testops/corpus/parallel_basic.star
+++ b/testops/corpus/parallel_basic.star
@@ -1,0 +1,44 @@
+# testops/corpus/parallel_basic.star
+#
+# Mock-only spec exercising the parallel() builtin. Runs two concurrent
+# step calls against a redis mock; both must observe the same seeded
+# state. Under the hood this exercises the runtime's hold-and-release
+# scheduler setup/teardown (see builtinParallel). With
+# --explore=all/sample the scheduler additionally enumerates
+# interleavings; we don't use --explore here so the run is
+# deterministic under --seed 1.
+
+load("@faultbox/mocks/redis.star", "redis")
+
+cache = redis.server(
+    name      = "cache",
+    interface = interface("main", "redis", 16384),
+    state = {
+        "a": "alpha",
+        "b": "beta",
+    },
+)
+
+def test_parallel_reads_both_succeed():
+    """Two concurrent reads return their seeded values."""
+    results = parallel(
+        lambda: cache.main.get(key = "a"),
+        lambda: cache.main.get(key = "b"),
+    )
+    assert_eq(len(results), 2)
+    for r in results:
+        assert_true(r.ok, "concurrent read succeeded")
+    # Results are in argument order (parallel() contract).
+    assert_true("alpha" in results[0].body, "first result is a=alpha")
+    assert_true("beta" in results[1].body, "second result is b=beta")
+
+def test_parallel_same_key_idempotent():
+    """Two concurrent reads of the same key agree."""
+    results = parallel(
+        lambda: cache.main.get(key = "a"),
+        lambda: cache.main.get(key = "a"),
+    )
+    assert_eq(len(results), 2)
+    assert_true(results[0].ok)
+    assert_true(results[1].ok)
+    assert_eq(results[0].body, results[1].body)

--- a/testops/goldens/parallel_basic.norm
+++ b/testops/goldens/parallel_basic.norm
@@ -1,0 +1,18 @@
+=== test_parallel_reads_both_succeed ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_send cache
+step_recv cache
+step_recv cache
+=== test_parallel_same_key_idempotent ===
+--- cache ---
+service_started
+service_ready
+--- test ---
+step_send cache
+step_send cache
+step_recv cache
+step_recv cache

--- a/testops/harness.go
+++ b/testops/harness.go
@@ -92,6 +92,12 @@ var Cases = []Case{
 		Seed:    1,
 		Timeout: 30 * time.Second,
 	},
+	{
+		Name:    "parallel_basic",
+		Spec:    "testops/corpus/parallel_basic.star",
+		Seed:    1,
+		Timeout: 30 * time.Second,
+	},
 
 	// --- LinuxOnly, currently skipped. ---
 	//


### PR DESCRIPTION
## Summary

The manifest's **\"fault(hold) on syscalls\"** row was misleading. Hold is a *scheduler primitive* used internally by \`parallel()\` + \`--explore\`, not a user-facing fault action. \`fault(svc, write=hold(...))\` doesn't parse — there's no \`builtinHold\`. Discovered while trying to write a corpus entry for the row.

## Changes

- **testops/corpus/parallel_basic.star** (new) — 2 tests:
  - Two concurrent reads against a redis mock, results preserve argument order.
  - Two concurrent reads of the same key agree (idempotent).
- **testops/goldens/parallel_basic.norm** — seeded, deterministic across 3 consecutive runs.
- **testops/harness.go** — register the case.
- **docs/feature-manifest.md** — rename the row to reflect reality:
  - \`fault(hold)\` → \`parallel() concurrent scenarios + hold/release scheduler\`
  - 🔴 → 🟢
  - Row-count correction: 17 → 15 (earlier draft miscounted).
  - Critical coverage: ~65% → **~87% green** (13 of 15).

## Remaining Critical gaps (out of scope here)

| Row | Status | Gate |
|---|---|---|
| \`service()\` container mode (Docker) | 🔴 | Docker CI provisioning + pinned image digests |
| Postgres proxy faults | 🟡 | In-process Postgres mock or Docker CI |

Both collapse into a single follow-up: wire Docker into CI.

## Test plan

- [ ] \`go test ./testops/... -run parallel_basic -v\` passes locally (verified).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)