### PR TITLE
RFC-035: container-consumer fault paths on Linux Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,68 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.17] - 2026-05-01
+
+RFC-035: container-consumer fault paths on Linux Docker. Closes the
+silent breakage that has been hiding in `poc/demo-container` since
+v0.9.6 — when a container SUT dials an upstream through the
+fault-injection proxy on Lima/Linux Docker, `host.docker.internal`
+resolves to the docker0 bridge gateway (`172.17.0.1`), but every
+proxy plugin bound on `127.0.0.1` only — so the connection RST'd
+before the SUT's first byte. Two independent fixes; together they
+close the design hole.
+
+### Changed
+
+- **Proxy listeners now bind on `0.0.0.0` on Linux** (or
+  `FAULTBOX_PROXY_BIND` if set). New `proxy.Listen()` /
+  `proxy.ListenUDP()` helpers in [internal/proxy/listen.go](https://github.com/faultbox/Faultbox/blob/main/internal/proxy/listen.go)
+  centralise the bind decision and normalise the dial address to
+  `127.0.0.1:<port>` regardless of bind interface, so host-binary
+  consumers keep their loopback dial unchanged. All 13 protocol
+  plugins (amqp, cassandra, clickhouse, grpc, http, http2, kafka,
+  memcached, mongodb, mysql, nats, postgres, redis, tcp, udp)
+  migrated to the helper. Defaults: `0.0.0.0` on Linux,
+  `127.0.0.1` everywhere else (Mac/Windows Docker Desktop already
+  tunnels `host.docker.internal` to host loopback). Override with
+  `FAULTBOX_PROXY_BIND=127.0.0.1` for shared CI runners on public
+  NICs where LAN exposure is unwanted.
+
+- **Container-consumer address substitution gated on registered
+  proxy faults.** `proxyAddrSubstitutionsFor` now only emits
+  rewrites for `containerConsumer` mode when at least one
+  `fault_scenario` in the suite registers a proxy-level rule
+  against the interface. Without a fault, container SUTs use
+  Docker's container DNS directly — no proxy round-trip, no
+  reachability dependency on the bridge bind. New
+  `Runtime.faultedInterfaces()` helper does static-analysis at
+  spec-load over `rt.faultScenarios`. Binary consumers are not
+  gated: substitution doubles as DNS translation for them
+  (`postgres:5432` is unresolvable on the host), so they always
+  rewrite to the proxy listener — same as pre-RFC-035 behavior.
+
+### Fixed
+
+- **`poc/demo-container` no longer silently broken on Lima.**
+  Was hidden because `TestGoldens` doesn't run container-to-container
+  faults, the demo passed on Mac Docker Desktop (loopback tunneling),
+  and a pre-RFC-035 hotfix had already reverted the `api` service
+  to a host binary. With RFC-035 the underlying bug is gone, so
+  future container SUTs reaching containerised upstreams via
+  `host.docker.internal` work on Linux Docker.
+
+### Internal
+
+- New `internal/proxy/listen.go` + `listen_test.go` (covers
+  default platform behavior, FAULTBOX_PROXY_BIND override, UDP,
+  byte-identity passthrough) — satisfies the #84 proxy-coverage
+  gate.
+
+- `cmd/faultbox/replay_test.go::TestEnforceReplayVersionPolicySame`
+  now reads the binary's compiled-in version dynamically rather
+  than hard-coding `"dev"` — was a latent test-brittleness that
+  fired on the v0.12.16 → v0.12.17 bump.
+
 ## [0.12.16] - 2026-04-30
 
 Report UX overhaul. The HTML report (`faultbox report <bundle.fb>`)
@@ -1141,7 +1203,8 @@ artifact.
   refuses (forward-compat safety); `faultbox_version` drift warns and
   proceeds; `faultbox replay` refuses major-version drift.
 
-[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.16...HEAD
+[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.17...HEAD
+[0.12.17]: https://github.com/faultbox/Faultbox/compare/release-0.12.16...release-0.12.17
 [0.12.16]: https://github.com/faultbox/Faultbox/compare/release-0.12.15.2...release-0.12.16
 [0.12.0]: https://github.com/faultbox/Faultbox/compare/release-0.11.3...release-0.12.0
 [0.11.3]: https://github.com/faultbox/Faultbox/compare/release-0.11.2...release-0.11.3

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.16"
+var version = "0.12.17"
 
 func run() int {
 	args := os.Args[1:]

--- a/cmd/faultbox/replay_test.go
+++ b/cmd/faultbox/replay_test.go
@@ -77,7 +77,9 @@ func TestExtractSpecOnlyPreservesTree(t *testing.T) {
 }
 
 func TestEnforceReplayVersionPolicySame(t *testing.T) {
-	r, _ := bundle.Open(writeReplayBundle(t, "dev"))
+	// Use the binary's compiled-in version so the test stays correct
+	// across release bumps (was hard-coded to "dev" before v0.12.16).
+	r, _ := bundle.Open(writeReplayBundle(t, faultboxVersion()))
 	// Capture stderr.
 	old := os.Stderr
 	r2, w, _ := os.Pipe()

--- a/internal/proxy/amqp.go
+++ b/internal/proxy/amqp.go
@@ -47,7 +47,7 @@ func (p *amqpProxy) Protocol() string { return "amqp" }
 func (p *amqpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -73,7 +73,7 @@ func (p *amqpProxy) Start(ctx context.Context, target string) (string, error) {
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *amqpProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/cassandra.go
+++ b/internal/proxy/cassandra.go
@@ -57,7 +57,7 @@ func (p *cassandraProxy) Protocol() string { return "cassandra" }
 func (p *cassandraProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -83,7 +83,7 @@ func (p *cassandraProxy) Start(ctx context.Context, target string) (string, erro
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *cassandraProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/clickhouse.go
+++ b/internal/proxy/clickhouse.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -35,7 +34,7 @@ func (p *clickhouseProxy) Protocol() string { return "clickhouse" }
 
 func (p *clickhouseProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -57,7 +56,7 @@ func (p *clickhouseProxy) Start(ctx context.Context, target string) (string, err
 		<-ctx.Done()
 		p.server.Close()
 	}()
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *clickhouseProxy) handle(w http.ResponseWriter, r *http.Request, rp *httputil.ReverseProxy) {

--- a/internal/proxy/grpc.go
+++ b/internal/proxy/grpc.go
@@ -84,7 +84,7 @@ func (p *grpcProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 	ctx, p.cancel = context.WithCancel(ctx)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -122,7 +122,7 @@ func (p *grpcProxy) Start(ctx context.Context, target string) (string, error) {
 		p.server.GracefulStop()
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 // handleStream is the catch-all handler for all gRPC methods.

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -35,7 +34,7 @@ func (p *httpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
 	// Listen on random port.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -62,7 +61,7 @@ func (p *httpProxy) Start(ctx context.Context, target string) (string, error) {
 		p.server.Close()
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *httpProxy) handleRequest(w http.ResponseWriter, r *http.Request, rp *httputil.ReverseProxy) {

--- a/internal/proxy/http2.go
+++ b/internal/proxy/http2.go
@@ -38,7 +38,7 @@ func (p *http2Proxy) Protocol() string { return "http2" }
 func (p *http2Proxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -82,7 +82,7 @@ func (p *http2Proxy) Start(ctx context.Context, target string) (string, error) {
 		p.server.Close()
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *http2Proxy) handleRequest(w http.ResponseWriter, r *http.Request, rp *httputil.ReverseProxy) {

--- a/internal/proxy/kafka.go
+++ b/internal/proxy/kafka.go
@@ -40,7 +40,7 @@ func (p *kafkaProxy) Protocol() string { return "kafka" }
 func (p *kafkaProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -66,7 +66,7 @@ func (p *kafkaProxy) Start(ctx context.Context, target string) (string, error) {
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *kafkaProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/listen.go
+++ b/internal/proxy/listen.go
@@ -1,0 +1,95 @@
+// Package proxy — bind helpers for transparent fault-injection proxies.
+//
+// RFC-035: protocol plugins call Listen() instead of net.Listen("tcp",
+// "127.0.0.1:0") so the bind side honours the platform default plus
+// FAULTBOX_PROXY_BIND override. On Linux the default is "0.0.0.0",
+// which is required for container consumers reaching the proxy via
+// host.docker.internal (= the docker0 bridge gateway, e.g.
+// 172.17.0.1) — loopback isn't reachable from the bridge. On
+// macOS/Windows Docker Desktop, host.docker.internal already
+// tunnels to host loopback, so the legacy 127.0.0.1 default keeps
+// working.
+//
+// The returned listenAddr is always 127.0.0.1:<port> regardless of
+// the bind interface, so host-binary consumers dial loopback
+// without translation. Container consumers get
+// host.docker.internal:<port> via the Starlark runtime's
+// proxyAddrSubstitutionsFor layer.
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+)
+
+// FaultboxProxyBindEnv overrides the bind interface that Listen and
+// related helpers use. Useful on bare-metal CI runners where the
+// default Linux "0.0.0.0" exposes proxies to the LAN — set to
+// "127.0.0.1" to keep them strictly host-local at the cost of
+// container reachability.
+const FaultboxProxyBindEnv = "FAULTBOX_PROXY_BIND"
+
+// listenHost returns the bind interface for new proxy listeners.
+//
+// Default: 127.0.0.1 (host loopback) — reachable by host-binary
+// consumers and Docker Desktop containers (which tunnel
+// host.docker.internal to loopback).
+//
+// Linux override: 0.0.0.0 — reachable from container consumers on
+// Linux Docker, where host.docker.internal resolves to the docker0
+// bridge gateway (172.17.0.1) and loopback is not reachable from
+// that bridge. This is the default-on-Linux behavior; opt out via
+// FAULTBOX_PROXY_BIND=127.0.0.1 if you need strict host-local
+// binding (e.g. shared CI runner with public NIC).
+func listenHost() string {
+	if v := os.Getenv(FaultboxProxyBindEnv); v != "" {
+		return v
+	}
+	if runtime.GOOS == "linux" {
+		return "0.0.0.0"
+	}
+	return "127.0.0.1"
+}
+
+// Listen returns a TCP listener bound on the platform-appropriate
+// interface (see listenHost) plus a "dialable from this host"
+// address — always 127.0.0.1:<port> regardless of the bind side.
+// Plugins use this instead of calling net.Listen + ln.Addr().String()
+// directly so the bind/dial split is consistent across all 13
+// protocols.
+func Listen() (net.Listener, string, error) {
+	ln, err := net.Listen("tcp", listenHost()+":0")
+	if err != nil {
+		return nil, "", err
+	}
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		ln.Close()
+		return nil, "", fmt.Errorf("listener address is not TCP: %T", ln.Addr())
+	}
+	return ln, fmt.Sprintf("127.0.0.1:%d", addr.Port), nil
+}
+
+// ListenUDP is the UDP counterpart of Listen. The udp proxy is the
+// only plugin that needs it; same semantics — bind side honours
+// listenHost, returned addr is 127.0.0.1:<port> for host-side
+// dialers.
+func ListenUDP() (*net.UDPConn, string, error) {
+	laddr, err := net.ResolveUDPAddr("udp", listenHost()+":0")
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve local: %w", err)
+	}
+	conn, err := net.ListenUDP("udp", laddr)
+	if err != nil {
+		return nil, "", err
+	}
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		conn.Close()
+		return nil, "", fmt.Errorf("listener address is not UDP: %T", conn.LocalAddr())
+	}
+	return conn, fmt.Sprintf("127.0.0.1:%d", addr.Port), nil
+}

--- a/internal/proxy/listen_test.go
+++ b/internal/proxy/listen_test.go
@@ -1,0 +1,153 @@
+package proxy
+
+import (
+	"net"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestListen_ReturnsLoopbackDialAddr — regardless of platform or
+// FAULTBOX_PROXY_BIND override, the address Listen() returns to the
+// caller is always 127.0.0.1:<port>. Container consumers get
+// host.docker.internal:<port> via the runtime substitution layer;
+// this test pins the host-side dial contract.
+func TestListen_ReturnsLoopbackDialAddr(t *testing.T) {
+	t.Setenv(FaultboxProxyBindEnv, "")
+	ln, listenAddr, err := Listen()
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	if !strings.HasPrefix(listenAddr, "127.0.0.1:") {
+		t.Errorf("listenAddr = %q, want 127.0.0.1:<port> prefix", listenAddr)
+	}
+	// The reported port must match the listener's actual port.
+	tcp, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr is not TCP: %T", ln.Addr())
+	}
+	want := "127.0.0.1:" + portString(tcp.Port)
+	if listenAddr != want {
+		t.Errorf("listenAddr = %q, want %q", listenAddr, want)
+	}
+}
+
+// TestListen_BindsBridgeOnLinux — on Linux the default bind interface
+// is 0.0.0.0 so container consumers reaching host.docker.internal
+// (= docker0 bridge gateway) can dial the listener. RFC-035 motivation.
+func TestListen_BindsBridgeOnLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-specific bind default; macOS/Windows keep 127.0.0.1")
+	}
+	t.Setenv(FaultboxProxyBindEnv, "")
+	ln, _, err := Listen()
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	addr := ln.Addr().String()
+	// On Linux, ln.Addr().String() reports the bind interface as
+	// "0.0.0.0:<port>" (or "[::]:<port>" if IPv6 dual-stack).
+	if !strings.HasPrefix(addr, "0.0.0.0:") && !strings.HasPrefix(addr, "[::]:") {
+		t.Errorf("bind addr = %q, want 0.0.0.0:<port> or [::]:<port> on Linux", addr)
+	}
+}
+
+// TestListen_RespectsEnvOverride — FAULTBOX_PROXY_BIND overrides the
+// platform default. Host-binary deployments on shared CI runners can
+// pin to 127.0.0.1 to avoid LAN exposure.
+func TestListen_RespectsEnvOverride(t *testing.T) {
+	t.Setenv(FaultboxProxyBindEnv, "127.0.0.1")
+	ln, _, err := Listen()
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	addr := ln.Addr().String()
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Errorf("bind addr = %q, want 127.0.0.1:<port> with env override", addr)
+	}
+}
+
+// TestListenUDP_ReturnsLoopbackDialAddr — same contract as Listen()
+// for the UDP proxy.
+func TestListenUDP_ReturnsLoopbackDialAddr(t *testing.T) {
+	t.Setenv(FaultboxProxyBindEnv, "")
+	conn, listenAddr, err := ListenUDP()
+	if err != nil {
+		t.Fatalf("ListenUDP failed: %v", err)
+	}
+	defer conn.Close()
+
+	if !strings.HasPrefix(listenAddr, "127.0.0.1:") {
+		t.Errorf("listenAddr = %q, want 127.0.0.1:<port> prefix", listenAddr)
+	}
+}
+
+// TestListen_PassthroughByteIdentity — clients dialing the loopback
+// listenAddr land at the same listener whether bind is 0.0.0.0 or
+// 127.0.0.1, and bytes flow round-trip cleanly. Mirrors the canonical
+// passthrough pattern other proxy plugins use; satisfies #84.
+func TestListen_PassthroughByteIdentity(t *testing.T) {
+	t.Setenv(FaultboxProxyBindEnv, "")
+	ln, listenAddr, err := Listen()
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 5)
+		if _, err := c.Read(buf); err != nil {
+			return
+		}
+		c.Write(buf)
+	}()
+
+	conn, err := net.Dial("tcp", listenAddr)
+	if err != nil {
+		t.Fatalf("dial loopback addr: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 5)
+	if _, err := conn.Read(got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("byte-identity broken: got %q", got)
+	}
+}
+
+func portString(p int) string {
+	// avoid pulling in strconv just for this — small alloc, only test code
+	return netJoinPort(p)
+}
+
+// netJoinPort: minimal int → ASCII without strconv.Itoa import noise.
+// Test-only helper.
+func netJoinPort(p int) string {
+	if p == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	i := len(buf)
+	for p > 0 {
+		i--
+		buf[i] = byte('0' + p%10)
+		p /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/proxy/memcached.go
+++ b/internal/proxy/memcached.go
@@ -36,7 +36,7 @@ func (p *memcachedProxy) Protocol() string { return "memcached" }
 func (p *memcachedProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -62,7 +62,7 @@ func (p *memcachedProxy) Start(ctx context.Context, target string) (string, erro
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/mongodb.go
+++ b/internal/proxy/mongodb.go
@@ -41,7 +41,7 @@ func (p *mongodbProxy) Protocol() string { return "mongodb" }
 func (p *mongodbProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -67,7 +67,7 @@ func (p *mongodbProxy) Start(ctx context.Context, target string) (string, error)
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *mongodbProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/mysql.go
+++ b/internal/proxy/mysql.go
@@ -36,7 +36,7 @@ func (p *mysqlProxy) Protocol() string { return "mysql" }
 func (p *mysqlProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -62,7 +62,7 @@ func (p *mysqlProxy) Start(ctx context.Context, target string) (string, error) {
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *mysqlProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/nats.go
+++ b/internal/proxy/nats.go
@@ -34,7 +34,7 @@ func (p *natsProxy) Protocol() string { return "nats" }
 func (p *natsProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -60,7 +60,7 @@ func (p *natsProxy) Start(ctx context.Context, target string) (string, error) {
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *natsProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/postgres.go
+++ b/internal/proxy/postgres.go
@@ -37,7 +37,7 @@ func (p *postgresProxy) Protocol() string { return "postgres" }
 func (p *postgresProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -63,7 +63,7 @@ func (p *postgresProxy) Start(ctx context.Context, target string) (string, error
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *postgresProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/redis.go
+++ b/internal/proxy/redis.go
@@ -36,7 +36,7 @@ func (p *redisProxy) Protocol() string { return "redis" }
 func (p *redisProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -63,7 +63,7 @@ func (p *redisProxy) Start(ctx context.Context, target string) (string, error) {
 		}
 	}()
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *redisProxy) handleConn(ctx context.Context, clientConn net.Conn) {

--- a/internal/proxy/tcp.go
+++ b/internal/proxy/tcp.go
@@ -46,7 +46,7 @@ func (p *tcpProxy) Protocol() string { return "tcp" }
 
 func (p *tcpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, listenAddr, err := Listen()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -56,7 +56,7 @@ func (p *tcpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.wg.Add(1)
 	go p.acceptLoop(ctx)
 
-	return ln.Addr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *tcpProxy) acceptLoop(ctx context.Context) {

--- a/internal/proxy/udp.go
+++ b/internal/proxy/udp.go
@@ -40,11 +40,7 @@ func (p *udpProxy) Protocol() string { return "udp" }
 func (p *udpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	laddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		return "", fmt.Errorf("resolve local: %w", err)
-	}
-	conn, err := net.ListenUDP("udp", laddr)
+	conn, listenAddr, err := ListenUDP()
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -60,7 +56,7 @@ func (p *udpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.wg.Add(1)
 	go p.relay(ctx, targetAddr)
 
-	return conn.LocalAddr().String(), nil
+	return listenAddr, nil
 }
 
 func (p *udpProxy) relay(ctx context.Context, targetAddr *net.UDPAddr) {

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1695,14 +1695,82 @@ func (rt *Runtime) proxyAddrSubstitutions() map[string]string {
 	return rt.proxyAddrSubstitutionsFor(binaryConsumer)
 }
 
+// faultedInterfaces walks every registered fault_scenario / fault_matrix
+// cell and returns the set of (service, interface) pairs that some test
+// in the suite injects a *proxy-level* fault against. Used by
+// proxyAddrSubstitutionsFor to gate address rewriting: an interface
+// nothing faults gets no env substitution, the SUT dials the upstream
+// directly via its real DNS name (Docker container DNS, host loopback,
+// etc.), and the listener-reachability bug RFC-035 documents simply
+// doesn't apply.
+//
+// Syscall-level faults (FaultAssumptionRule) do *not* contribute here:
+// seccomp intercepts inside the SUT process and needs no proxy address
+// rewrite. Only ProxyRules — which install protocol-level rewrite
+// rules on the transparent proxy — require the substitution to be
+// active.
+//
+// Static analysis at suite scope, not per-test: container reuse means
+// the SUT's env is built once at first launch, so per-test gating
+// would race with cells that fault interfaces a prior cell didn't.
+// Coarser but stable.
+func (rt *Runtime) faultedInterfaces() map[string]map[string]bool {
+	out := make(map[string]map[string]bool)
+	for _, fs := range rt.faultScenarios {
+		for _, fa := range fs.Faults {
+			if fa == nil {
+				continue
+			}
+			for _, pr := range fa.ProxyRules {
+				if pr.Target == nil || pr.Target.Service == nil || pr.Target.Interface == nil {
+					continue
+				}
+				svc := pr.Target.Service.Name
+				ifn := pr.Target.Interface.Name
+				if out[svc] == nil {
+					out[svc] = make(map[string]bool)
+				}
+				out[svc][ifn] = true
+			}
+		}
+	}
+	return out
+}
+
 // proxyAddrSubstitutionsFor builds the rewrite table targeting either
 // binary or container consumers. For container consumers, proxy addrs
 // are re-spelled with host.docker.internal so the SUT, isolated in its
 // network namespace, can still reach the host-side listener.
 func (rt *Runtime) proxyAddrSubstitutionsFor(mode consumerMode) map[string]string {
 	out := make(map[string]string)
+	// RFC-035: gate container-consumer substitutions on a registered
+	// proxy fault.
+	//
+	// Two consumer modes serve different purposes:
+	//
+	//   - binaryConsumer (host-binary SUT): substitution is *also*
+	//     a DNS-translation primitive. The SUT's
+	//     `postgres.main.internal_addr` evaluates to "postgres:5432"
+	//     which is unresolvable on the host. Substitution rewrites
+	//     that to the host-reachable proxy listener (always loopback
+	//     after RFC-035 fix 2). Without substitution, the SUT can't
+	//     reach the upstream at all. So we never gate this branch.
+	//
+	//   - containerConsumer: the SUT is itself in a container, which
+	//     can resolve "postgres:5432" via Docker's container DNS.
+	//     Pre-RFC-035 substitution rewrote that to host.docker.internal,
+	//     which on Linux Docker resolves to the docker0 bridge gateway
+	//     (172.17.0.1) and hits a 127.0.0.1-only proxy listener — RST.
+	//     Now: gate on a registered proxy-level fault. No fault →
+	//     skip rewrite → SUT uses container DNS directly. Fault → rewrite
+	//     to host.docker.internal (reachable thanks to Fix 2's
+	//     bridge-bind).
+	faulted := rt.faultedInterfaces()
 	for name, s := range rt.services {
 		for ifName, iface := range s.Interfaces {
+			if mode == containerConsumer && !faulted[name][ifName] {
+				continue
+			}
 			proxyAddr := rt.proxyMgr.GetProxyAddr(name, ifName)
 			if proxyAddr == "" {
 				continue

--- a/internal/star/runtime_test.go
+++ b/internal/star/runtime_test.go
@@ -2779,6 +2779,13 @@ app = service("app", "/tmp/mock",
 // as host.docker.internal:<port>, not 127.0.0.1:<port>. Without this
 // rewrite the SUT inside its container network namespace has no route
 // to the host-side proxy and the whole data-path story falls apart.
+//
+// RFC-035 update: substitution is now gated on a proxy-level fault
+// being registered against the interface. Without a fault, the SUT
+// dials the upstream directly via container DNS — see
+// TestBuildContainerEnv_NoFault_SkipsSubstitution. This test sets up
+// a fault_scenario that targets db.main so the substitution stays
+// active.
 func TestBuildContainerEnvRewritesViaHostDockerInternal(t *testing.T) {
 	rt := New(testLogger())
 	err := rt.LoadString("test.star", `
@@ -2796,6 +2803,26 @@ api = service("api",
 `)
 	if err != nil {
 		t.Fatalf("LoadString: %v", err)
+	}
+
+	// RFC-035: substitution is gated on a proxy-level fault being
+	// registered against the interface. Inject one here so the test
+	// covers the rewrite path; TestBuildContainerEnv_NoFault_*
+	// covers the gate's other branch.
+	rt.faultScenarios = map[string]*FaultScenarioDef{
+		"test_db_fault": {
+			Name: "test_db_fault",
+			Faults: []*FaultAssumptionDef{{
+				Name: "db_fault",
+				ProxyRules: []FaultAssumptionProxyRule{{
+					Target: &InterfaceRef{
+						Service:   rt.services["db"],
+						Interface: rt.services["db"].Interfaces["main"],
+					},
+					ProxyFault: &ProxyFaultDef{},
+				}},
+			}},
+		},
 	}
 
 	ln, _ := net.Listen("tcp", "127.0.0.1:0")
@@ -2822,6 +2849,55 @@ api = service("api",
 	wantDB := "postgres://u:p@" + wantAddr + "/appdb"
 	if got := envMap["DATABASE_URL"]; got != wantDB {
 		t.Errorf("DATABASE_URL = %q, want %q", got, wantDB)
+	}
+}
+
+// TestBuildContainerEnv_NoFault_SkipsSubstitution — RFC-035 fix 1.
+//
+// When no test in the suite faults an interface, the SUT's env vars
+// must keep referencing the real upstream (container DNS), not the
+// host-side proxy. The pre-RFC-035 behavior unconditionally rewrote
+// every interface's address, which on Linux Docker hard-failed
+// because the proxy bound on 127.0.0.1 (loopback) is unreachable
+// from the docker0 bridge gateway containers use as
+// host.docker.internal.
+func TestBuildContainerEnv_NoFault_SkipsSubstitution(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("test.star", `
+db = service("db",
+    interface("main", "postgres", 5432),
+    image = "postgres:16",
+)
+api = service("api",
+    interface("public", "http", 8080),
+    image = "alpine",
+    env = {
+        "DATABASE_URL": "postgres://u:p@db:5432/appdb",
+    },
+)
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	// Register a proxy listenAddr — pre-RFC-035 this alone was
+	// enough to trigger substitution. With RFC-035 the substitution
+	// also requires a fault rule, so the env should still spell
+	// db:5432 untouched.
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer ln.Close()
+	rt.proxyMgr.RegisterListenAddr("db", "main", ln.Addr().String())
+
+	env := rt.buildContainerEnv(rt.services["api"])
+	envMap := map[string]string{}
+	for _, e := range env {
+		k, v, _ := strings.Cut(e, "=")
+		envMap[k] = v
+	}
+
+	if got := envMap["DATABASE_URL"]; got != "postgres://u:p@db:5432/appdb" {
+		t.Errorf("DATABASE_URL = %q, want unchanged (no proxy fault registered, "+
+			"substitution must skip)", got)
 	}
 }
 

--- a/poc/demo-container/faultbox.star
+++ b/poc/demo-container/faultbox.star
@@ -7,15 +7,17 @@
 #   - Docker running, faultbox-shim built
 #   - api-svc built and staged at /tmp/api-svc (make demo-build does this)
 #
-# Why host-binary api: when the api lived inside a container, its env
-# `DATABASE_URL` substring `postgres:5432` was rewritten by the proxy
-# substitution layer to `host.docker.internal:<host-port>` so faults
-# could be injected. On Linux Docker (Lima) `host.docker.internal`
-# resolves to the docker0 bridge gateway (172.17.0.1), and proxies
-# bind to 127.0.0.1 only — so the api couldn't reach them. Running
-# the api on the host fixes the path: it dials 127.0.0.1:<host-port>
-# directly. Tracked as a follow-up RFC for the conditional-rewrite
-# code fix.
+# Why host-binary api: historical workaround for the bug RFC-035
+# fixed in v0.12.17. Pre-RFC-035 the substitution layer rewrote
+# `postgres:5432` to `host.docker.internal:<host-port>` for
+# container consumers; on Linux Docker (Lima) `host.docker.internal`
+# resolves to the docker0 bridge gateway (172.17.0.1) but proxies
+# bound on `127.0.0.1` only, so the api couldn't reach them.
+# RFC-035 binds proxies on `0.0.0.0` on Linux + gates substitution
+# on a registered proxy-level fault, so container SUTs reaching
+# containerised upstreams now work end-to-end. The host-binary api
+# stays as the simpler topology for this demo, but a fully
+# container-to-container variant also works post-v0.12.17.
 
 postgres = service("postgres",
     interface("main", "tcp", 5432),


### PR DESCRIPTION
Closes #89.

## Summary

- Container SUTs reaching upstreams through the fault-injection proxy on Lima/Linux Docker silently failed since v0.9.6: `host.docker.internal` resolves to `172.17.0.1` (docker0 bridge gateway), but every proxy plugin bound on `127.0.0.1` only, so connections RST'd.
- Two independent fixes; together they close the design hole.

## Fix 1 — semantic: container-consumer substitution gated on registered proxy faults

`proxyAddrSubstitutionsFor` only emits rewrites for `containerConsumer` mode when at least one `fault_scenario` in the suite registers a proxy-level rule against the interface. Without a fault, container SUTs use Docker's container DNS directly — no proxy round-trip, no reachability dependency. New `Runtime.faultedInterfaces()` does static-analysis at spec-load.

**Binary consumers are NOT gated.** Substitution there doubles as DNS translation (`postgres:5432` is unresolvable on the host), so they always rewrite to the proxy listener — preserving the pre-RFC-035 host-binary behaviour exactly. Surfaced poc/demo-container regression in Lima sweep before commit; carve-out fixed it.

## Fix 2 — platform: proxy listeners bind on 0.0.0.0 on Linux

New `proxy.Listen()` / `proxy.ListenUDP()` helpers in [internal/proxy/listen.go](https://github.com/faultbox/Faultbox/blob/epic/rfc-035/internal/proxy/listen.go) centralise the bind decision and normalise the dial address to `127.0.0.1:<port>` regardless of bind interface, so host-binary consumers keep their loopback dial unchanged. All 13 protocol plugins migrated.

Defaults: `0.0.0.0` on Linux, `127.0.0.1` everywhere else (Mac/Windows Docker Desktop already tunnels `host.docker.internal` to host loopback). Override via `FAULTBOX_PROXY_BIND` for shared CI runners on public NICs.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test ./internal/proxy/...` — including new `listen_test.go` covering platform default, env override, UDP, byte-identity passthrough
- [x] `go vet ./...` — clean
- [x] Cross-compile linux/arm64 — builds
- [x] Lima sweep 21/21 PASS across poc/example (3), poc/demo (6), poc/mock-demo (6), poc/demo-container (4), poc/mysql-rfc022-repro (1), poc/kafka-rfc014 (1)
- [x] Version bump to 0.12.17 + CHANGELOG entry
- [x] poc/demo-container comment updated

## Notes

- `cmd/faultbox/replay_test.go::TestEnforceReplayVersionPolicySame` was hard-coded to `"dev"` and broke on every version bump; switched to read `faultboxVersion()` dynamically (not part of RFC-035 proper but caught in the same flow, included in this PR).
- Coverage gate (#84) satisfied — `listen.go` ships with `listen_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)