### PR TITLE
feat(eventsource): stderr() event source — customer ask (Freight)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,49 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.18] - 2026-05-01
+
+`stderr()` event source. Counterpart to the existing `stdout()` source
+— captures the service's stderr stream and emits each line as a
+first-class trace event. Customer-driven (inDrive Freight,
+2026-04-30): every default-configured Go service using zap, slog, or
+logrus writes to fd 2; pre-v0.12.18 the only way to observe those
+logs through Faultbox was to inject an env-gate (e.g.
+`FB_LOG_TO_STDOUT=1`) into the SUT and rebuild it. With `stderr()`
+the SUT stays unchanged.
+
+### Added
+
+- **`stderr(decoder=...)` event source.** Same kwargs surface as
+  `stdout()`; same decoder catalog (`json_decoder`, `logfmt_decoder`,
+  `regex_decoder`). Emits events with type `"stderr"` so the
+  report timeline filters and the event-log table can distinguish
+  the two streams. Use both simultaneously when the SUT splits
+  log streams (e.g. business events on stdout, errors on stderr).
+
+  ```python
+  observe=[
+      stdout(decoder=json_decoder()),
+      stderr(decoder=json_decoder()),
+  ]
+  ```
+
+### Internal
+
+- New `internal/eventsource/stderr.go` + `stderr_test.go` mirror
+  the stdout source byte-for-byte; only the registered name and
+  emission type differ. Decoder interface is source-agnostic so
+  existing decoders apply unchanged.
+
+- `internal/star/runtime.go` binary-mode launch path now branches
+  on `obs.SourceName ∈ {"stdout", "stderr"}` and wires a
+  separate OS pipe per stream. The two flow into the engine
+  session config's `Stdout` / `Stderr` fields independently;
+  console output is preserved via `io.MultiWriter` tee.
+
+- Container-mode launch path is unchanged — neither stdout nor
+  stderr observation is wired there yet, tracked separately.
+
 ## [0.12.17] - 2026-05-01
 
 RFC-035: container-consumer fault paths on Linux Docker. Closes the
@@ -1203,7 +1246,8 @@ artifact.
   refuses (forward-compat safety); `faultbox_version` drift warns and
   proceeds; `faultbox replay` refuses major-version drift.
 
-[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.17...HEAD
+[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.18...HEAD
+[0.12.18]: https://github.com/faultbox/Faultbox/compare/release-0.12.17...release-0.12.18
 [0.12.17]: https://github.com/faultbox/Faultbox/compare/release-0.12.16...release-0.12.17
 [0.12.16]: https://github.com/faultbox/Faultbox/compare/release-0.12.15.2...release-0.12.16
 [0.12.0]: https://github.com/faultbox/Faultbox/compare/release-0.11.3...release-0.12.0

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.17"
+var version = "0.12.18"
 
 func run() int {
 	args := os.Args[1:]

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -876,6 +876,7 @@ Events from sources have a type (`"stdout"`, `"wal"`, `"topic"`, `"tail"`,
 | Source | Constructor | What it captures |
 |--------|------------|-----------------|
 | stdout | `stdout(decoder=)` | Service stdout lines, decoded per line |
+| stderr | `stderr(decoder=)` | Service stderr lines, decoded per line (zap/logrus default) |
 | wal_stream | `wal_stream(slot=)` | Postgres logical replication (INSERT/UPDATE/DELETE) |
 | topic | `topic(broker=, topic=, group=)` | Kafka/NATS topic messages |
 | tail | `tail(path=)` | New lines appended to a file (inotify) |
@@ -919,27 +920,53 @@ monitor(lambda e: fail("unexpected error") if e.type == "stdout" and "ERROR" in 
 msgs = events(where=lambda e: e.type == "topic" and e.data["topic"] == "orders.events")
 ```
 
-### Diagnosing SUT failures via `stdout`
+### Diagnosing SUT failures via `stdout` / `stderr`
 
 When a containerized or binary SUT silently hangs at startup or fails
-behind a proxy, attach `observe=[stdout(decoder=...)]` so the SUT's own
-log lines become **first-class trace events** in the bundle. The bundle
+behind a proxy, attach `observe=[stdout(decoder=...)]` (or `stderr(...)`
+if your service writes logs to fd 2) so the SUT's own log lines
+become **first-class trace events** in the bundle. The bundle
 becomes self-diagnosing — you can see the last function the SUT
 reached without redeploying a debug build.
 
 ```python
+# zap, logrus, slog (default) all write to stderr — capture via stderr().
 api = service("truck-api",
     interface("http", "http", 8080),
     binary="/usr/local/bin/truck-api",
     env={
         "DATABASE_HOST": db.mysql.proxy_host,
         "DATABASE_PORT": db.mysql.proxy_port,
-        "FB_LOG_TO_STDOUT": "1",  # SUT-side env-gate to route logs to stdout
     },
-    observe=[stdout(decoder=json_decoder())],
+    observe=[stderr(decoder=json_decoder())],
     healthcheck=http("localhost:8080/health", timeout="60s"),
 )
+
+# Services that route logs to stdout explicitly (Python defaults,
+# many CLIs) use stdout() — same surface, different fd.
+worker = service("worker",
+    interface("rpc", "tcp", 9000),
+    binary="/usr/local/bin/worker",
+    observe=[stdout(decoder=logfmt_decoder())],
+)
+
+# Capture both — the SUT writes errors to stderr, business events to
+# stdout. Each emits with its own event type so you can filter the
+# timeline and event log independently.
+mixed = service("mixed",
+    interface("api", "http", 8080),
+    binary="/usr/local/bin/mixed",
+    observe=[
+        stdout(decoder=json_decoder()),
+        stderr(decoder=json_decoder()),
+    ],
+)
 ```
+
+Pre-v0.12.17 only `stdout()` existed; capturing zap/logrus output
+required a SUT-side env-gate (e.g. `FB_LOG_TO_STDOUT=1`) to redirect
+logs to fd 1. With `stderr()` you can capture default-configured Go
+services without touching their code.
 
 Combined with structured logging in the SUT (zap, slog, logrus, etc.),
 this turns "the SUT hangs and nobody knows why" into "seq 33: 'done

--- a/internal/eventsource/stderr.go
+++ b/internal/eventsource/stderr.go
@@ -1,0 +1,103 @@
+package eventsource
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"sync"
+)
+
+func init() {
+	RegisterSource("stderr", func(params map[string]string, decoder Decoder) (EventSource, error) {
+		return &stderrSource{decoder: decoder}, nil
+	})
+}
+
+// stderrSource is the stdout-source twin for the service's stderr stream.
+// Customer ask (inDrive Freight, 2026-04-30): every Go service using zap
+// or logrus defaults to stderr; the v0.12.15.x arc worked around that
+// with an FB_LOG_TO_STDOUT env-gate, but a one-line
+// observe=[stderr(decoder=...)] removes the SUT-side change for every
+// future adopter.
+//
+// Same shape as stdoutSource — the decoder, scanner, emit pattern, and
+// shutdown semantics are identical. The only thing that differs is which
+// fd the runtime wires to the pipe (rt.runtime.go's
+// captureServiceObservations branch chooses based on SourceName) and the
+// event type stamped on each emission ("stderr" vs "stdout").
+type stderrSource struct {
+	decoder Decoder
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func (s *stderrSource) Name() string { return "stderr" }
+
+// Start is the placeholder hook required by the EventSource interface.
+// Real entry is StartWithReader; the runtime materialises a pipe whose
+// write end is wired to the service process's Stderr fd, then hands the
+// read end here.
+func (s *stderrSource) Start(ctx context.Context, cfg SourceConfig) error {
+	ctx, s.cancel = context.WithCancel(ctx)
+	reader, ok := cfg.Params["_reader_ptr"]
+	if !ok {
+		return nil
+	}
+	_ = reader
+
+	return nil
+}
+
+// StartWithReader is the actual entry point — the runtime passes an io.Reader.
+func (s *stderrSource) StartWithReader(ctx context.Context, cfg SourceConfig, reader io.Reader) {
+	ctx, s.cancel = context.WithCancel(ctx)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			if s.decoder != nil {
+				fields, err := s.decoder.Decode(line)
+				if err != nil {
+					cfg.Emit("stderr", map[string]string{"raw": string(line)})
+					continue
+				}
+				cfg.Emit("stderr", fields)
+			} else {
+				cfg.Emit("stderr", map[string]string{"raw": string(line)})
+			}
+		}
+	}()
+}
+
+func (s *stderrSource) Stop() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// StderrSource returns a new stderr event source (exported for runtime use).
+func StderrSource(decoder Decoder) *stderrSource {
+	return &stderrSource{decoder: decoder}
+}
+
+// StderrSourceHandle holds a running stderr source and its pipe for
+// cleanup. Mirrors StdoutSourceHandle so the runtime's lifecycle code
+// can treat the two streams uniformly.
+type StderrSourceHandle struct {
+	Source    *stderrSource
+	PipeWrite io.WriteCloser
+}

--- a/internal/eventsource/stderr_test.go
+++ b/internal/eventsource/stderr_test.go
@@ -1,0 +1,97 @@
+package eventsource
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStderrSource(t *testing.T) {
+	src := StderrSource(&mockDecoder{})
+
+	pr, pw := io.Pipe()
+
+	var mu sync.Mutex
+	var events []map[string]string
+	var types []string
+
+	cfg := SourceConfig{
+		ServiceName: "test-svc",
+		Emit: func(typ string, fields map[string]string) {
+			mu.Lock()
+			events = append(events, fields)
+			types = append(types, typ)
+			mu.Unlock()
+		},
+	}
+
+	ctx := context.Background()
+	src.StartWithReader(ctx, cfg, pr)
+
+	pw.Write([]byte("line1\n"))
+	pw.Write([]byte("line2\n"))
+	pw.Write([]byte("\n"))
+	pw.Write([]byte("line3\n"))
+	pw.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	src.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	// Event type discriminates stderr from stdout — the report timeline
+	// renders them on the same lane but the type matters for filtering.
+	for i, ty := range types {
+		if ty != "stderr" {
+			t.Errorf("event %d: type = %q, want stderr", i, ty)
+		}
+	}
+	if events[0]["decoded"] != "true" {
+		t.Error("expected decoded=true")
+	}
+	if events[0]["data"] != "line1" {
+		t.Errorf("expected data=line1, got %q", events[0]["data"])
+	}
+}
+
+func TestStderrSourceNoDecoder(t *testing.T) {
+	src := StderrSource(nil)
+
+	pr, pw := io.Pipe()
+
+	var mu sync.Mutex
+	var events []map[string]string
+
+	cfg := SourceConfig{
+		Emit: func(typ string, fields map[string]string) {
+			mu.Lock()
+			events = append(events, fields)
+			mu.Unlock()
+		},
+	}
+
+	ctx := context.Background()
+	src.StartWithReader(ctx, cfg, pr)
+
+	pw.Write([]byte("raw line\n"))
+	pw.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	src.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0]["raw"] != "raw line" {
+		t.Errorf("expected raw='raw line', got %q", events[0]["raw"])
+	}
+}

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -61,6 +61,7 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		"drop":              starlark.NewBuiltin("drop", builtinProxyDrop),
 		"duplicate":         starlark.NewBuiltin("duplicate", builtinProxyDuplicate),
 		"stdout":            starlark.NewBuiltin("stdout", builtinStdoutSource),
+		"stderr":            starlark.NewBuiltin("stderr", builtinStderrSource),
 		"json_decoder":      starlark.NewBuiltin("json_decoder", builtinJSONDecoder),
 		"logfmt_decoder":    starlark.NewBuiltin("logfmt_decoder", builtinLogfmtDecoder),
 		"regex_decoder":     starlark.NewBuiltin("regex_decoder", builtinRegexDecoder),
@@ -2308,6 +2309,29 @@ func builtinOp(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tupl
 func builtinStdoutSource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	cfg := ObserveConfig{
 		SourceName: "stdout",
+		Params:     make(map[string]string),
+	}
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		if key == "decoder" {
+			if dv, ok := kv[1].(*DecoderVal); ok {
+				cfg.DecoderName = dv.Name
+				for k, v := range dv.Params {
+					cfg.Params["decoder_"+k] = v
+				}
+			}
+		}
+	}
+	return &ObserveSourceVal{Config: cfg}, nil
+}
+
+// builtinStderrSource is the stderr-stream twin of builtinStdoutSource.
+// Customer ask (inDrive Freight, 2026-04-30): zap/logrus default to
+// stderr, so observing stdout alone misses every default-configured Go
+// service. Same kwargs surface as stdout(decoder=...).
+func builtinStderrSource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	cfg := ObserveConfig{
+		SourceName: "stderr",
 		Params:     make(map[string]string),
 	}
 	for _, kv := range kwargs {

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1089,24 +1089,33 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 	ns := engine.NamespaceConfig{PID: true, Mount: true, User: true}
 	onSyscall := rt.makeSyscallCallback(svcName)
 
-	// Set up stdout: if observe includes stdout source, create an OS pipe
-	// so the child process writes directly to it. We tee from the read-end
-	// to both the decoder and the configured output.
+	// Set up stdout / stderr observation: if observe includes the
+	// matching source, create an OS pipe per stream so the child
+	// writes directly to it; tee from the read-end to both the
+	// decoder and the configured console output.
+	//
+	// Customer ask (Freight, 2026-04-30): stderr was added as a
+	// counterpart to stdout because zap/logrus default to fd 2,
+	// and the v0.12.15.x arc had to ship an FB_LOG_TO_STDOUT
+	// env-gate workaround to capture them. The two branches are
+	// near-identical — only the source factory and the underlying
+	// fd they wire to differ.
 	svcStdout := rt.ServiceStdout
-	var stdoutFile *os.File // if set, overrides child's fd 1
+	svcStderr := rt.ServiceStdout
+	var stdoutFile *os.File
+	var stderrFile *os.File
 	var stdoutSources []*eventsource.StdoutSourceHandle
+	var stderrSources []*eventsource.StderrSourceHandle
 
 	for _, obs := range svc.Observe {
-		if obs.SourceName == "stdout" {
-			// Create a real OS pipe — the child writes to pipeW (fd),
-			// we read from pipeR in a goroutine.
+		switch obs.SourceName {
+		case "stdout":
 			pipeR, pipeW, err := os.Pipe()
 			if err != nil {
 				return fmt.Errorf("os.Pipe for stdout observe: %w", err)
 			}
 			stdoutFile = pipeW
 
-			// Create and start the stdout event source.
 			var dec eventsource.Decoder
 			if obs.DecoderName != "" {
 				if factory, ok := eventsource.GetDecoder(obs.DecoderName); ok {
@@ -1120,7 +1129,6 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 				}
 			}
 
-			// Tee: copy pipe output to both the decoder and the console.
 			decoderPR, decoderPW := io.Pipe()
 			go func() {
 				defer decoderPW.Close()
@@ -1139,14 +1147,58 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 				Source:    src,
 				PipeWrite: decoderPW,
 			})
+
+		case "stderr":
+			pipeR, pipeW, err := os.Pipe()
+			if err != nil {
+				return fmt.Errorf("os.Pipe for stderr observe: %w", err)
+			}
+			stderrFile = pipeW
+
+			var dec eventsource.Decoder
+			if obs.DecoderName != "" {
+				if factory, ok := eventsource.GetDecoder(obs.DecoderName); ok {
+					d, err := factory(obs.Params)
+					if err != nil {
+						pipeR.Close()
+						pipeW.Close()
+						return fmt.Errorf("decoder %q: %w", obs.DecoderName, err)
+					}
+					dec = d
+				}
+			}
+
+			decoderPR, decoderPW := io.Pipe()
+			go func() {
+				defer decoderPW.Close()
+				defer pipeR.Close()
+				io.Copy(io.MultiWriter(svcStderr, decoderPW), pipeR)
+			}()
+
+			src := eventsource.StderrSource(dec)
+			src.StartWithReader(ctx, eventsource.SourceConfig{
+				ServiceName: svcName,
+				Emit: func(typ string, fields map[string]string) {
+					rt.events.Emit(typ, svcName, fields)
+				},
+			}, decoderPR)
+			stderrSources = append(stderrSources, &eventsource.StderrSourceHandle{
+				Source:    src,
+				PipeWrite: decoderPW,
+			})
 		}
 	}
 
-	// Build session stdout: use the OS pipe file if observe is active,
-	// otherwise use the configured writer.
+	// Build session stdout/stderr: use the OS pipe file if observe is
+	// active for that stream, otherwise fall back to the configured
+	// console writer.
 	var sessStdout io.Writer = svcStdout
 	if stdoutFile != nil {
 		sessStdout = stdoutFile
+	}
+	var sessStderr io.Writer = svcStderr
+	if stderrFile != nil {
+		sessStderr = stderrFile
 	}
 
 	sessCfg := engine.SessionConfig{
@@ -1154,7 +1206,7 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 		Args:               svc.Args,
 		Env:                envVars,
 		Stdout:             sessStdout,
-		Stderr:             rt.ServiceStdout,
+		Stderr:             sessStderr,
 		Namespaces:         ns,
 		FaultRules:         faultRules,
 		OnSyscall:          onSyscall,
@@ -1164,6 +1216,7 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 	}
 
 	_ = stdoutSources // TODO: store for cleanup in stopServices
+	_ = stderrSources // TODO: store for cleanup in stopServices
 	return rt.launchSession(ctx, svcName, svc, sessCfg)
 }
 


### PR DESCRIPTION
## Summary

Counterpart to the existing `stdout()` source. Captures the service's stderr stream and emits each line as a first-class trace event with type `\"stderr\"`. Same kwargs surface (`decoder=`...) and same decoder catalog as stdout — decoders are source-agnostic by design.

## Motivation

Customer ask (inDrive Freight, 2026-04-30): every default-configured Go service using zap, slog, or logrus writes to fd 2. Pre-v0.12.18 the only way to observe those logs was to inject `FB_LOG_TO_STDOUT=1` into the SUT's env and rebuild. With `stderr()` the SUT stays unchanged.

## What changed

- **`internal/eventsource/stderr.go`** — `stderrSource` struct, `RegisterSource`, `StartWithReader`. Mirrors `stdout.go` byte-for-byte; only the registered name and emission type differ.
- **`internal/star/builtins.go`** — `builtinStderrSource` registers `ObserveSourceVal` with `SourceName=\"stderr\"`, same decoder kwarg threading.
- **`internal/star/runtime.go`** — binary-mode launch path branches on `obs.SourceName ∈ {\"stdout\", \"stderr\"}` and wires a separate OS pipe per stream. Engine session config's `Stdout`/`Stderr` fields receive the matching pipe; console output preserved via `io.MultiWriter` tee.
- **`internal/eventsource/stderr_test.go`** — mirrors `stdout_test.go`; asserts emitted type is `\"stderr\"` so a regression that conflates streams fails loudly.

## Out of scope

Container-mode launch path is not modified — neither stdout nor stderr observation is wired for container services yet (separate gap, not addressed here).

## Test plan

- [x] `go test ./...` — all packages green
- [x] Lima smoke spec: target script writes 2 JSON lines to fd 1 and 2 to fd 2; bundle's trace contains 2× stderr + 2× stdout events with decoded fields (`level`, `msg`, `stream`) promoted to top-level
- [x] Lima poc sweep **21/21 PASS** across `example`, `demo`, `mock-demo`, `demo-container`, `mysql-rfc022-repro`, `kafka-rfc014`
- [x] `go vet` clean, cross-compile linux/arm64 builds

## Docs

- `docs/spec-language.md` — stderr row in event-sources table; Diagnosing-failures section documents `zap/logrus → stderr()` pattern, retains the `stdout()` example for explicit-stdout SUTs, adds a \"capture both\" example for split-stream services
- `CHANGELOG.md` entry, version bump to 0.12.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)