### PR TITLE
feat(container): observe=[stdout/stderr] for container services + regex_decoder fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,57 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.19] - 2026-05-01
+
+Container-mode `observe=` wiring + regex decoder bugfix.
+
+v0.12.18 added `stderr()` but only wired it for binary-mode services.
+This release closes the gap for container services: `observe=[stdout(...),
+stderr(...)]` now works against any Docker image, with logs captured
+via Docker's multiplexed log stream and demuxed inside Faultbox.
+
+### Added
+
+- **Container-mode `observe=` capture.** Service services launched
+  via `image=` / `build=` now stream their stdout and stderr through
+  Faultbox's event log, same as binary services. Implementation
+  reads the Docker multiplexed log channel via
+  `client.ContainerLogs(ctx, id, LogsOptions{ShowStdout, ShowStderr,
+  Follow})` and demultiplexes with `stdcopy.StdCopy`. Console output
+  preserved via `io.MultiWriter` tee — `docker logs` watchers and
+  Faultbox's bundle both see the same lines.
+
+  Lima smoke (`redis:7-alpine` with `observe=[stdout(decoder=regex_decoder(...))]`)
+  produced 14 decoded `stdout` events with `pid` / `role` / `rest`
+  capture-group fields populated end-to-end.
+
+### Fixed
+
+- **`regex_decoder(pattern=...)` was silently failing on every
+  observation site.** The Starlark builtin stored decoder kwargs
+  in `ObserveConfig.Params` with a `decoder_` prefix to avoid
+  collisions with source-level params, but the runtime called
+  decoder factories with that map unstripped — so the regex
+  factory's lookup of `params["pattern"]` always missed and
+  returned the "regex decoder requires 'pattern' parameter"
+  error. Cosmetic for `json_decoder`/`logfmt_decoder` (zero
+  params), load-bearing for `regex_decoder`. New helper
+  `decoderParams()` strips the prefix at all three factory call
+  sites (binary stdout, binary stderr, container stdout/stderr).
+
+### Internal
+
+- New `Client.StreamLogs(ctx, containerID, stdoutW, stderrW)` in
+  `internal/container/docker.go` — thin wrapper around
+  `cli.ContainerLogs` with stdcopy demux. Either writer may be nil
+  to discard that stream.
+- New `Runtime.setupContainerObservation(ctx, svcName, svc, containerID)`
+  in `internal/star/runtime.go`. Mirrors the binary-mode wiring
+  pattern; spawns one goroutine per container that pulls from the
+  log stream until container exit or context cancel.
+- `internal/star/runtime.go` factory call sites at lines 1122,
+  1161, 1523 all routed through `decoderParams()`.
+
 ## [0.12.18] - 2026-05-01
 
 `stderr()` event source. Counterpart to the existing `stdout()` source
@@ -1246,7 +1297,8 @@ artifact.
   refuses (forward-compat safety); `faultbox_version` drift warns and
   proceeds; `faultbox replay` refuses major-version drift.
 
-[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.18...HEAD
+[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.19...HEAD
+[0.12.19]: https://github.com/faultbox/Faultbox/compare/release-0.12.18...release-0.12.19
 [0.12.18]: https://github.com/faultbox/Faultbox/compare/release-0.12.17...release-0.12.18
 [0.12.17]: https://github.com/faultbox/Faultbox/compare/release-0.12.16...release-0.12.17
 [0.12.16]: https://github.com/faultbox/Faultbox/compare/release-0.12.15.2...release-0.12.16

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.18"
+var version = "0.12.19"
 
 func run() int {
 	args := os.Args[1:]

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -968,6 +968,12 @@ required a SUT-side env-gate (e.g. `FB_LOG_TO_STDOUT=1`) to redirect
 logs to fd 1. With `stderr()` you can capture default-configured Go
 services without touching their code.
 
+Pre-v0.12.19 both sources only worked against binary-mode services;
+from v0.12.19 they apply to container services too. Faultbox reads
+Docker's multiplexed log stream (`client.ContainerLogs(...)`) and
+demultiplexes internally, so a containerised SUT becomes self-
+diagnosing without any image change.
+
 Combined with structured logging in the SUT (zap, slog, logrus, etc.),
 this turns "the SUT hangs and nobody knows why" into "seq 33: 'done
 init config' → seq 34: 'FATAL: connect to db: invalid connection'."

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -292,6 +293,54 @@ func (c *Client) ContainerHostPort(ctx context.Context, id string, containerPort
 
 // BuildImage builds a Docker image from a Dockerfile in the given context directory.
 // The image is tagged with the given tag.
+// StreamLogs opens a follow-mode log stream against a running container
+// and demultiplexes it into the supplied stdout / stderr writers. The
+// Docker daemon multiplexes both streams over a single read channel
+// (8-byte frame header tags each frame as fd 1 or fd 2); stdcopy.StdCopy
+// is the canonical demuxer.
+//
+// Either writer may be nil to discard that stream — callers that only
+// observe stdout pass nil for stderr, and vice versa. The function
+// blocks until the stream closes (container exit, context cancel) and
+// returns the underlying error from the demux.
+//
+// Used by the runtime's container-mode observe= wiring (RFC-???? /
+// stderr() follow-up) so SUTs running as Docker containers get the same
+// first-class log-line trace events binary services have had since
+// v0.12.18.
+func (c *Client) StreamLogs(ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	opts := container.LogsOptions{
+		ShowStdout: stdout != nil,
+		ShowStderr: stderr != nil,
+		Follow:     true,
+	}
+	if !opts.ShowStdout && !opts.ShowStderr {
+		return nil
+	}
+	rc, err := c.cli.ContainerLogs(ctx, containerID, opts)
+	if err != nil {
+		return fmt.Errorf("container logs %s: %w", containerID, err)
+	}
+	defer rc.Close()
+
+	// Discard via io.Discard rather than nil so stdcopy doesn't panic
+	// on the half the caller didn't ask for. Docker's log driver still
+	// emits both halves when the TTY is allocated; the multiplex header
+	// distinguishes them and Discard is the cheapest sink.
+	out := stdout
+	if out == nil {
+		out = io.Discard
+	}
+	errW := stderr
+	if errW == nil {
+		errW = io.Discard
+	}
+	if _, err := stdcopy.StdCopy(out, errW, rc); err != nil && ctx.Err() == nil {
+		return fmt.Errorf("stdcopy demux: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) BuildImage(ctx context.Context, contextDir, tag string) error {
 	c.log.Info("building image", slog.String("context", contextDir), slog.String("tag", tag))
 

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1119,7 +1119,7 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 			var dec eventsource.Decoder
 			if obs.DecoderName != "" {
 				if factory, ok := eventsource.GetDecoder(obs.DecoderName); ok {
-					d, err := factory(obs.Params)
+					d, err := factory(decoderParams(obs.Params))
 					if err != nil {
 						pipeR.Close()
 						pipeW.Close()
@@ -1158,7 +1158,7 @@ func (rt *Runtime) startBinaryService(ctx context.Context, svcName string, svc *
 			var dec eventsource.Decoder
 			if obs.DecoderName != "" {
 				if factory, ok := eventsource.GetDecoder(obs.DecoderName); ok {
-					d, err := factory(obs.Params)
+					d, err := factory(decoderParams(obs.Params))
 					if err != nil {
 						pipeR.Close()
 						pipeW.Close()
@@ -1294,6 +1294,16 @@ func (rt *Runtime) startContainerService(ctx context.Context, svcName string, sv
 		return fmt.Errorf("launch container %q: %w", svcName, err)
 	}
 	rt.containerIDs[svcName] = result.ContainerID
+
+	// Set up stdout / stderr observation for container services. Same
+	// surface as the binary path (svc.Observe with stdout()/stderr()
+	// sources) — under the hood it pulls Docker's multiplexed log
+	// stream and demuxes to the configured sources. Pre-this-change,
+	// container services were a black box: zap/logrus output stayed in
+	// `docker logs` and never reached the bundle. With this wiring,
+	// container SUTs get the same self-diagnosing trace-event treatment
+	// as binary SUTs.
+	rt.setupContainerObservation(ctx, svcName, svc, result.ContainerID)
 
 	// Update interface ports to actual host-mapped ports (for healthchecks + steps).
 	for _, iface := range svc.Interfaces {
@@ -1461,6 +1471,123 @@ func (rt *Runtime) resolveHealthcheck(svc *ServiceDef) string {
 		}
 	}
 	return test
+}
+
+// decoderParams strips the `decoder_` prefix from observation
+// parameters so a decoder factory sees the keys it actually expects
+// (`pattern` instead of `decoder_pattern`). The prefix exists in
+// ObserveConfig.Params to avoid collisions with source-level params,
+// but the factory contract is unprefixed.
+//
+// Pre-this-change, regex_decoder(pattern=...) silently failed at
+// runtime: the decoder factory looked for `pattern` and didn't find
+// it because the builtin had stored it as `decoder_pattern`. Affected
+// every observation site (binary stdout, binary stderr, container
+// stdout/stderr); cosmetic for json/logfmt (zero params) but
+// load-bearing for regex.
+func decoderParams(all map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range all {
+		if rest, ok := strings.CutPrefix(k, "decoder_"); ok {
+			out[rest] = v
+		}
+	}
+	return out
+}
+
+// setupContainerObservation wires svc.Observe stdout/stderr sources to
+// the container's log stream. Mirrors the binary-mode wiring in
+// startBinaryService except the byte source is Docker's multiplexed
+// log channel (demuxed via stdcopy) rather than direct fd-1 / fd-2
+// pipes.
+//
+// Lifecycle: a single goroutine pulls from `dc.StreamLogs` for the
+// lifetime of the container; it exits naturally when the container
+// stops (stream EOF) or when the runtime context cancels. We don't
+// retry on container restart — reuse=True keeps the container alive
+// across tests so a single follow stream covers the whole session.
+//
+// No-op when svc.Observe contains no stdout/stderr sources, so this
+// can be called unconditionally for every container service.
+func (rt *Runtime) setupContainerObservation(ctx context.Context, svcName string, svc *ServiceDef, containerID string) {
+	var stdoutPipeW io.WriteCloser
+	var stderrPipeW io.WriteCloser
+
+	for _, obs := range svc.Observe {
+		if obs.SourceName != "stdout" && obs.SourceName != "stderr" {
+			continue
+		}
+		var dec eventsource.Decoder
+		if obs.DecoderName != "" {
+			if factory, ok := eventsource.GetDecoder(obs.DecoderName); ok {
+				if d, err := factory(decoderParams(obs.Params)); err == nil {
+					dec = d
+				} else {
+					rt.log.Warn("decoder factory failed",
+						slog.String("service", svcName),
+						slog.String("source", obs.SourceName),
+						slog.String("decoder", obs.DecoderName),
+						slog.Any("err", err))
+					continue
+				}
+			}
+		}
+
+		decoderPR, decoderPW := io.Pipe()
+		emitter := func(typ string, fields map[string]string) {
+			rt.events.Emit(typ, svcName, fields)
+		}
+
+		switch obs.SourceName {
+		case "stdout":
+			src := eventsource.StdoutSource(dec)
+			src.StartWithReader(ctx, eventsource.SourceConfig{
+				ServiceName: svcName,
+				Emit:        emitter,
+			}, decoderPR)
+			stdoutPipeW = decoderPW
+		case "stderr":
+			src := eventsource.StderrSource(dec)
+			src.StartWithReader(ctx, eventsource.SourceConfig{
+				ServiceName: svcName,
+				Emit:        emitter,
+			}, decoderPR)
+			stderrPipeW = decoderPW
+		}
+	}
+
+	if stdoutPipeW == nil && stderrPipeW == nil {
+		return
+	}
+
+	// Tee to console too so users still see container output in their
+	// terminal — same UX as `docker logs -f` running alongside.
+	consoleW := rt.ServiceStdout
+	var stdoutW io.Writer
+	if stdoutPipeW != nil {
+		stdoutW = io.MultiWriter(consoleW, stdoutPipeW)
+	}
+	var stderrW io.Writer
+	if stderrPipeW != nil {
+		stderrW = io.MultiWriter(consoleW, stderrPipeW)
+	}
+
+	go func() {
+		defer func() {
+			if stdoutPipeW != nil {
+				stdoutPipeW.Close()
+			}
+			if stderrPipeW != nil {
+				stderrPipeW.Close()
+			}
+		}()
+		if err := rt.dockerClient.StreamLogs(ctx, containerID, stdoutW, stderrW); err != nil {
+			rt.log.Warn("container log stream ended with error",
+				slog.String("service", svcName),
+				slog.String("container_id", containerID),
+				slog.Any("err", err))
+		}
+	}()
 }
 
 // buildContainerEnv builds environment variables for a container service.


### PR DESCRIPTION
## Summary

Closes the gap between binary-mode and container-mode services. v0.12.18 added `stderr()` but only wired it for binary services. This PR extends the `observe=` surface to anything launched via `image=` / `build=`.

Plus a pre-existing regex_decoder pattern-threading bug, fixed in passing.

## Container observation

**`internal/container/docker.go`** — new `Client.StreamLogs(ctx, containerID, stdoutW, stderrW)`. Thin wrapper around `cli.ContainerLogs(ctx, id, container.LogsOptions{ShowStdout, ShowStderr, Follow: true})` plus `stdcopy.StdCopy` demux. Either writer may be nil (Docker still emits both halves when the TTY is allocated; nil → discard).

**`internal/star/runtime.go`** — new `setupContainerObservation(ctx, svcName, svc, containerID)` called right after the container starts. Mirrors the binary-mode wiring pattern: iterate `svc.Observe`, create matching `StdoutSource`/`StderrSource`, open pipe per stream, spawn one goroutine to pull from Docker's log stream until container exit or context cancel. Console output preserved via `io.MultiWriter` tee.

## Pre-existing bug fixed: regex_decoder pattern threading

`regex_decoder(pattern=...)` was silently failing on **every** observation site. The Starlark builtin stored decoder kwargs in `ObserveConfig.Params` with a `decoder_` prefix to avoid collisions with source-level params, but the runtime called decoder factories with that map unstripped — so the regex factory's `params[\"pattern\"]` lookup always missed and returned `\"regex decoder requires 'pattern' parameter\"`. Cosmetic for `json_decoder`/`logfmt_decoder` (zero params), load-bearing for `regex_decoder`.

New helper `decoderParams()` strips the prefix at all three factory call sites (lines 1122, 1161, 1523 in `runtime.go`).

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] Cross-compile linux/arm64 — builds
- [x] Lima smoke 1: `redis:7-alpine` with `observe=[stdout()]` (no decoder) — 14 stdout events captured with `raw` field
- [x] Lima smoke 2: same with `regex_decoder(pattern=\"(?P<pid>\\\\d+):(?P<role>[A-Z])\\\\s+(?P<rest>.+)\")` — all 14 events decoded with `pid`, `role`, `rest` capture-group fields
- [x] Lima poc sweep **21/21 PASS** across `example`, `demo`, `mock-demo`, `demo-container`, `mysql-rfc022-repro`, `kafka-rfc014`

## Out of scope

- Container reuse (RFC-015 reuse=True) edge case: log stream attached at first container start; if the container restarts mid-session, the stream EOFs and we don't re-attach. Tested cases all use single-container-per-session, so not exercised. Tracked separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)