### PR TITLE
rfc-034 phase 2: conn lifecycle events for 9 more plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,71 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.21] - 2026-05-01
+
+RFC-034 Phase 2 — proxy traffic observability extended to 9 more
+plugins. v0.12.20 wired conn lifecycle + handshake + stall events
+into 4 plugins (tcp, mysql, postgres, redis). This release covers
+9 of the remaining 11; the customer's bundle now carries
+proxy_conn_open / _close / _handshake_complete events for nearly
+every protocol Faultbox proxies.
+
+### Added
+
+- **6 frame/text-based plugins instrumented** (same pattern as
+  mysql/postgres/redis):
+  - `amqp.go` — protocol-header acts as handshake marker;
+    bidirectional frame forwarders count C2S/S2C bytes per
+    direction.
+  - `cassandra.go` — frame-aware on client→server (count C2S
+    inline), `io.Copy` on server→client (wrapped via
+    `tracker.WrapServerReader` to count S2C). Handshake fires
+    after first request-response round-trip.
+  - `kafka.go` — length-prefix framed; conn_open/close + first
+    request marks handshake.
+  - `memcached.go` — text-line + binary-data hybrid; bytes
+    counted at every `bufio.Reader.ReadString` and
+    `Fprintf`/`Write`. Handshake fires on first round-trip.
+  - `mongodb.go` — LE32 framed; same pattern as kafka.
+  - `nats.go` — text-line via `bufio.Scanner`; first server line
+    (typically `INFO`) marks handshake_complete; byte counts
+    include the trailing newline.
+
+- **3 HTTP-family plugins instrumented via
+  `http.Server.ConnState`** (http, http2, clickhouse):
+  - New `HTTPConnStateTracker` helper in `observability.go`
+    maps `StateNew` → `proxy_conn_open`, `StateClosed` →
+    `proxy_conn_close`, first `StateActive` →
+    `proxy_handshake_complete`. Idempotent on keep-alive
+    (handshakeDone CAS).
+  - HTTP/2 emits per underlying-TCP-conn (one open/close per
+    physical connection regardless of stream count).
+  - **Byte counts not yet wired** for HTTP-family — `http.Server`
+    reads/writes through the listener internally; a Listener
+    wrapper that returns counting Conns is the natural follow-up.
+    `bytes_c2s` / `bytes_s2c` report 0 for these plugins until
+    that ships.
+
+### Out of scope (final follow-up)
+
+- **`udp.go`** — datagram protocol, connectionless. RFC-034's
+  conn_open/conn_close model doesn't fit. Likely needs a new
+  event family (`proxy_datagram_received` / `_sent`) — separate
+  RFC.
+- **`grpc.go`** — gRPC's per-RPC handler is not connection-scoped
+  and the standard library's grpc.Server does not expose a
+  per-connection lifecycle hook compatible with RFC-034. The
+  `grpc.StatsHandler` interface gives per-RPC stats but not
+  per-connection lifecycle. Defer until we can either build a
+  StatsHandler-based variant or wrap the listener pre-gRPC.
+
+### Internal
+
+- `proxy_test.go::TestHTTPProxyErrorRule` updated to count only
+  legacy rule-fired events (`ProxyEvent.Type == ""`); the
+  added connection-lifecycle events would otherwise inflate the
+  per-test count from 1 to 3.
+
 ## [0.12.20] - 2026-05-01
 
 RFC-034: proxy traffic observability. The Faultbox transparent
@@ -1382,7 +1447,8 @@ artifact.
   refuses (forward-compat safety); `faultbox_version` drift warns and
   proceeds; `faultbox replay` refuses major-version drift.
 
-[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.20...HEAD
+[Unreleased]: https://github.com/faultbox/Faultbox/compare/release-0.12.21...HEAD
+[0.12.21]: https://github.com/faultbox/Faultbox/compare/release-0.12.20...release-0.12.21
 [0.12.20]: https://github.com/faultbox/Faultbox/compare/release-0.12.19...release-0.12.20
 [0.12.19]: https://github.com/faultbox/Faultbox/compare/release-0.12.18...release-0.12.19
 [0.12.18]: https://github.com/faultbox/Faultbox/compare/release-0.12.17...release-0.12.18

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.20"
+var version = "0.12.21"
 
 func run() int {
 	args := os.Args[1:]

--- a/internal/proxy/amqp.go
+++ b/internal/proxy/amqp.go
@@ -85,36 +85,59 @@ func (p *amqpProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. AMQP has a protocol
+	// header "AMQP\x00\x00\x09\x01" then bidirectional frame flow;
+	// the header serves as the handshake boundary marker. Byte
+	// counters update inside forwardFrames per direction.
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "amqp",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+
 	// AMQP starts with protocol header: "AMQP\x00\x00\x09\x01"
 	// Forward the handshake bidirectionally until both sides are ready.
 	// Simplified: forward the protocol header from client to server.
 	protoHeader := make([]byte, 8)
 	if _, err := io.ReadFull(clientConn, protoHeader); err != nil {
+		closeReason = classifyCloseReason(err, "client")
 		return
 	}
+	tracker.AddBytesC2S(8)
 	if _, err := serverConn.Write(protoHeader); err != nil {
+		closeReason = classifyCloseReason(err, "server")
 		return
 	}
+	tracker.EmitHandshakeComplete("amqp_proto_header", 1)
 
-	// Bidirectional frame forwarding with interception.
+	// Bidirectional frame forwarding with interception. Wait for
+	// first errCh only — second goroutine drains naturally when
+	// deferred conn closes propagate (same lesson as tcp.go's
+	// single-`<-done` semantic).
 	errCh := make(chan error, 2)
 
 	// Server → client (delivery path).
 	go func() {
-		errCh <- p.forwardFrames(ctx, serverConn, clientConn, "deliver")
+		errCh <- p.forwardFrames(ctx, serverConn, clientConn, "deliver", tracker.AddBytesS2C)
 	}()
 
 	// Client → server (publish path).
 	go func() {
-		errCh <- p.forwardFrames(ctx, clientConn, serverConn, "publish")
+		errCh <- p.forwardFrames(ctx, clientConn, serverConn, "publish", tracker.AddBytesC2S)
 	}()
 
-	<-errCh
+	if err := <-errCh; err != nil {
+		closeReason = classifyCloseReason(err, "client")
+	}
 }
 
 // forwardFrames reads AMQP frames from src and writes to dst.
 // Intercepts Basic.Publish frames for fault injection.
-func (p *amqpProxy) forwardFrames(ctx context.Context, src, dst net.Conn, direction string) error {
+//
+// addBytes records bytes read from `src` so the connection-lifecycle
+// tracker can report bytes_c2s / bytes_s2c on proxy_conn_close. nil
+// is fine — counter call is conditional.
+func (p *amqpProxy) forwardFrames(ctx context.Context, src, dst net.Conn, direction string, addBytes func(int)) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -129,6 +152,9 @@ func (p *amqpProxy) forwardFrames(ctx context.Context, src, dst net.Conn, direct
 		if _, err := io.ReadFull(src, frameHeader); err != nil {
 			return err
 		}
+		if addBytes != nil {
+			addBytes(7)
+		}
 
 		frameType := frameHeader[0]
 		frameSize := int(binary.BigEndian.Uint32(frameHeader[3:7]))
@@ -136,6 +162,9 @@ func (p *amqpProxy) forwardFrames(ctx context.Context, src, dst net.Conn, direct
 		payload := make([]byte, frameSize+1) // +1 for frame-end byte (0xCE)
 		if _, err := io.ReadFull(src, payload); err != nil {
 			return err
+		}
+		if addBytes != nil {
+			addBytes(len(payload))
 		}
 
 		// Check for Basic.Publish method frame.

--- a/internal/proxy/cassandra.go
+++ b/internal/proxy/cassandra.go
@@ -95,14 +95,31 @@ func (p *cassandraProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. Cassandra is
+	// asymmetric — frame-aware on client→server, raw io.Copy on
+	// server→client. Wrap the server reader to count S2C bytes;
+	// count C2S bytes inline at the framed-read sites. CQL has a
+	// STARTUP/READY exchange but it flows through the same loop;
+	// we mark handshake_complete after the first request-response
+	// round-trip (approximation — captures the post-startup state).
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "cassandra",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+
 	// Upstream → client (responses). Forwarded without inspection.
-	go io.Copy(clientConn, serverConn)
+	// Wrap the server reader so byte counts land in the tracker.
+	go io.Copy(clientConn, tracker.WrapServerReader(serverConn))
+
+	requestsSeen := 0
 
 	// Client → upstream (requests). Frame-aware to support fault injection
 	// on QUERY / EXECUTE opcodes.
 	for {
 		select {
 		case <-ctx.Done():
+			closeReason = "context_cancel"
 			return
 		default:
 		}
@@ -111,8 +128,10 @@ func (p *cassandraProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 
 		header := make([]byte, 9)
 		if _, err := io.ReadFull(clientConn, header); err != nil {
+			closeReason = classifyCloseReason(err, "client")
 			return
 		}
+		tracker.AddBytesC2S(9)
 
 		version := header[0]
 		streamID := binary.BigEndian.Uint16(header[2:4])
@@ -120,14 +139,17 @@ func (p *cassandraProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		bodyLen := binary.BigEndian.Uint32(header[5:9])
 
 		if bodyLen > 256*1024*1024 {
+			closeReason = "io_error"
 			return
 		}
 
 		body := make([]byte, bodyLen)
 		if bodyLen > 0 {
 			if _, err := io.ReadFull(clientConn, body); err != nil {
+				closeReason = classifyCloseReason(err, "client")
 				return
 			}
+			tracker.AddBytesC2S(int(bodyLen))
 		}
 
 		if opcode == cqlOpQuery || opcode == cqlOpExecute || opcode == cqlOpBatch {
@@ -139,12 +161,22 @@ func (p *cassandraProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 
 		// Forward to upstream.
 		if _, err := serverConn.Write(header); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
 		if bodyLen > 0 {
 			if _, err := serverConn.Write(body); err != nil {
+				closeReason = classifyCloseReason(err, "server")
 				return
 			}
+		}
+
+		requestsSeen++
+		if requestsSeen == 1 {
+			// First successful request marks the handshake (STARTUP/
+			// READY exchange completed before this point in any
+			// well-behaved Cassandra session).
+			tracker.EmitHandshakeComplete("", 1)
 		}
 	}
 }

--- a/internal/proxy/clickhouse.go
+++ b/internal/proxy/clickhouse.go
@@ -46,10 +46,14 @@ func (p *clickhouseProxy) Start(ctx context.Context, target string) (string, err
 	}
 	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
 
+	// RFC-034: connection-lifecycle events via http.Server.ConnState.
+	connTracker := NewHTTPConnStateTracker(p.onEvent, p.svcName, "main", "clickhouse", target)
+
 	p.server = &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p.handle(w, r, reverseProxy)
 		}),
+		ConnState: connTracker.ConnState,
 	}
 	go p.server.Serve(ln)
 	go func() {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -47,10 +47,16 @@ func (p *httpProxy) Start(ctx context.Context, target string) (string, error) {
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
 
+	// RFC-034: connection-lifecycle events via http.Server.ConnState.
+	// Per-conn open/close + first-request handshake_complete; byte
+	// counts not yet wired (follow-up — needs Listener wrapper).
+	connTracker := NewHTTPConnStateTracker(p.onEvent, p.svcName, "main", "http", target)
+
 	p.server = &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p.handleRequest(w, r, reverseProxy)
 		}),
+		ConnState: connTracker.ConnState,
 	}
 
 	go func() {

--- a/internal/proxy/http2.go
+++ b/internal/proxy/http2.go
@@ -68,10 +68,16 @@ func (p *http2Proxy) Start(ctx context.Context, target string) (string, error) {
 		p.handleRequest(w, r, reverseProxy)
 	})
 
+	// RFC-034: connection-lifecycle events via http.Server.ConnState.
+	// HTTP/2 multiplexes streams over a single TCP conn; we emit per
+	// underlying-TCP-conn (StateNew/StateClosed), not per-stream.
+	connTracker := NewHTTPConnStateTracker(p.onEvent, p.svcName, "main", "http2", target)
+
 	// h2c.NewHandler upgrades prior-knowledge HTTP/2 cleartext connections
 	// in the inbound direction. Clients that send HTTP/1.1 still work.
 	p.server = &http.Server{
-		Handler: h2c.NewHandler(handler, &http2.Server{}),
+		Handler:   h2c.NewHandler(handler, &http2.Server{}),
+		ConnState: connTracker.ConnState,
 	}
 
 	go func() {

--- a/internal/proxy/kafka.go
+++ b/internal/proxy/kafka.go
@@ -78,9 +78,22 @@ func (p *kafkaProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. Kafka has no
+	// explicit handshake — client jumps straight to Produce/Fetch
+	// requests after TCP connect. We mark handshake_complete after
+	// the first request-response round-trip as a stand-in for "this
+	// connection is in steady-state command phase".
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "kafka",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+	requestsSeen := 0
+
 	for {
 		select {
 		case <-ctx.Done():
+			closeReason = "context_cancel"
 			return
 		default:
 		}
@@ -91,17 +104,22 @@ func (p *kafkaProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		// Payload starts with: api_key(2) + api_version(2) + correlation_id(4) + client_id.
 		lenBuf := make([]byte, 4)
 		if _, err := io.ReadFull(clientConn, lenBuf); err != nil {
+			closeReason = classifyCloseReason(err, "client")
 			return
 		}
+		tracker.AddBytesC2S(4)
 		msgLen := int(binary.BigEndian.Uint32(lenBuf))
 		if msgLen <= 0 || msgLen > 10*1024*1024 {
+			closeReason = "io_error"
 			return
 		}
 
 		payload := make([]byte, msgLen)
 		if _, err := io.ReadFull(clientConn, payload); err != nil {
+			closeReason = classifyCloseReason(err, "client")
 			return
 		}
+		tracker.AddBytesC2S(msgLen)
 
 		// Parse API key to identify Produce/Fetch requests.
 		if len(payload) >= 8 {
@@ -120,27 +138,39 @@ func (p *kafkaProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 
 		// Forward to server.
 		if _, err := serverConn.Write(lenBuf); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
 		if _, err := serverConn.Write(payload); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
 
 		// Forward response back.
 		respLenBuf := make([]byte, 4)
 		if _, err := io.ReadFull(serverConn, respLenBuf); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
+		tracker.AddBytesS2C(4)
 		respLen := int(binary.BigEndian.Uint32(respLenBuf))
 		if respLen <= 0 || respLen > 10*1024*1024 {
+			closeReason = "io_error"
 			return
 		}
 		resp := make([]byte, respLen)
 		if _, err := io.ReadFull(serverConn, resp); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
+		tracker.AddBytesS2C(respLen)
 		clientConn.Write(respLenBuf)
 		clientConn.Write(resp)
+
+		requestsSeen++
+		if requestsSeen == 1 {
+			tracker.EmitHandshakeComplete("", 1)
+		}
 	}
 }
 

--- a/internal/proxy/memcached.go
+++ b/internal/proxy/memcached.go
@@ -74,12 +74,24 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. Memcached has no
+	// handshake — commands flow immediately. Mark
+	// handshake_complete after the first successful round-trip as
+	// the "connection ready" beat.
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "memcached",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+
 	clientReader := bufio.NewReader(clientConn)
 	serverReader := bufio.NewReader(serverConn)
+	requestsSeen := 0
 
 	for {
 		select {
 		case <-ctx.Done():
+			closeReason = "context_cancel"
 			return
 		default:
 		}
@@ -89,8 +101,10 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		// Read command line from client.
 		line, err := clientReader.ReadString('\n')
 		if err != nil {
+			closeReason = classifyCloseReason(err, "client")
 			return
 		}
+		tracker.AddBytesC2S(len(line))
 		line = strings.TrimRight(line, "\r\n")
 		parts := strings.Fields(line)
 		if len(parts) == 0 {
@@ -109,8 +123,10 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 			bytes, _ := strconv.Atoi(parts[4])
 			dataBlock = make([]byte, bytes+2) // +2 for \r\n
 			if _, err := io.ReadFull(clientReader, dataBlock); err != nil {
+				closeReason = classifyCloseReason(err, "client")
 				return
 			}
+			tracker.AddBytesC2S(len(dataBlock))
 		}
 
 		// Check rules.
@@ -127,8 +143,10 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		// Forward response back.
 		resp, err := serverReader.ReadString('\n')
 		if err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
+		tracker.AddBytesS2C(len(resp))
 		fmt.Fprint(clientConn, resp)
 
 		// For get commands, forward VALUE lines + END.
@@ -136,8 +154,10 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 			for !strings.HasPrefix(resp, "END") {
 				resp, err = serverReader.ReadString('\n')
 				if err != nil {
+					closeReason = classifyCloseReason(err, "server")
 					return
 				}
+				tracker.AddBytesS2C(len(resp))
 				fmt.Fprint(clientConn, resp)
 				// If VALUE line, also forward the data block.
 				if strings.HasPrefix(resp, "VALUE") {
@@ -146,10 +166,16 @@ func (p *memcachedProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 						bytes, _ := strconv.Atoi(valParts[3])
 						data := make([]byte, bytes+2)
 						io.ReadFull(serverReader, data)
+						tracker.AddBytesS2C(len(data))
 						clientConn.Write(data)
 					}
 				}
 			}
+		}
+
+		requestsSeen++
+		if requestsSeen == 1 {
+			tracker.EmitHandshakeComplete("", 1)
 		}
 	}
 }

--- a/internal/proxy/mongodb.go
+++ b/internal/proxy/mongodb.go
@@ -79,9 +79,22 @@ func (p *mongodbProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. MongoDB has no
+	// distinct handshake at the wire level — the first OP_MSG (often
+	// `hello` or `isMaster`) negotiates connection state but flows
+	// through the same loop. Mark handshake_complete after the first
+	// successful round-trip.
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "mongodb",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+	requestsSeen := 0
+
 	for {
 		select {
 		case <-ctx.Done():
+			closeReason = "context_cancel"
 			return
 		default:
 		}
@@ -91,22 +104,27 @@ func (p *mongodbProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		// MongoDB message header: length(4) + requestID(4) + responseTo(4) + opCode(4)
 		header := make([]byte, 16)
 		if _, err := io.ReadFull(clientConn, header); err != nil {
+			closeReason = classifyCloseReason(err, "client")
 			return
 		}
+		tracker.AddBytesC2S(16)
 
 		msgLen := int(binary.LittleEndian.Uint32(header[0:4]))
 		requestID := binary.LittleEndian.Uint32(header[4:8])
 		opCode := int32(binary.LittleEndian.Uint32(header[12:16]))
 
 		if msgLen < 16 || msgLen > 48*1024*1024 {
+			closeReason = "io_error"
 			return
 		}
 
 		body := make([]byte, msgLen-16)
 		if len(body) > 0 {
 			if _, err := io.ReadFull(clientConn, body); err != nil {
+				closeReason = classifyCloseReason(err, "client")
 				return
 			}
+			tracker.AddBytesC2S(len(body))
 		}
 
 		// Only intercept OP_MSG (modern protocol).
@@ -121,10 +139,12 @@ func (p *mongodbProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 
 		// Forward to server.
 		if _, err := serverConn.Write(header); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
 		if len(body) > 0 {
 			if _, err := serverConn.Write(body); err != nil {
+				closeReason = classifyCloseReason(err, "server")
 				return
 			}
 		}
@@ -132,17 +152,26 @@ func (p *mongodbProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		// Forward response back.
 		respHeader := make([]byte, 16)
 		if _, err := io.ReadFull(serverConn, respHeader); err != nil {
+			closeReason = classifyCloseReason(err, "server")
 			return
 		}
+		tracker.AddBytesS2C(16)
 		respLen := int(binary.LittleEndian.Uint32(respHeader[0:4]))
 		respBody := make([]byte, respLen-16)
 		if len(respBody) > 0 {
 			if _, err := io.ReadFull(serverConn, respBody); err != nil {
+				closeReason = classifyCloseReason(err, "server")
 				return
 			}
+			tracker.AddBytesS2C(len(respBody))
 		}
 		clientConn.Write(respHeader)
 		clientConn.Write(respBody)
+
+		requestsSeen++
+		if requestsSeen == 1 {
+			tracker.EmitHandshakeComplete("", 1)
+		}
 	}
 }
 

--- a/internal/proxy/nats.go
+++ b/internal/proxy/nats.go
@@ -72,14 +72,26 @@ func (p *natsProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	}
 	defer serverConn.Close()
 
+	// RFC-034: per-connection lifecycle tracker. NATS sends an
+	// INFO line immediately after connect (the handshake-equivalent
+	// — server announces itself); we mark handshake_complete after
+	// the first server-line reaches the client.
+	tracker := newConnTracker(p.onEvent, p.svcName, "main", "nats",
+		clientConn.RemoteAddr().String(), p.target)
+	tracker.EmitOpen()
+	closeReason := "client_eof"
+	defer func() { tracker.EmitClose(closeReason) }()
+
 	errCh := make(chan error, 2)
 
 	// Server → client.
 	go func() {
 		scanner := bufio.NewScanner(serverConn)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		linesSeen := 0
 		for scanner.Scan() {
 			line := scanner.Text()
+			tracker.AddBytesS2C(len(line) + 1) // +1 for newline
 			// Intercept MSG lines (delivery).
 			if strings.HasPrefix(line, "MSG ") {
 				subject := extractNATSSubject(line)
@@ -88,6 +100,12 @@ func (p *natsProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 				}
 			}
 			fmt.Fprintln(clientConn, line)
+			linesSeen++
+			if linesSeen == 1 {
+				// First server line (typically `INFO {...}`) marks
+				// the connection-ready state.
+				tracker.EmitHandshakeComplete("info", 1)
+			}
 		}
 		errCh <- scanner.Err()
 	}()
@@ -98,6 +116,7 @@ func (p *natsProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
+			tracker.AddBytesC2S(len(line) + 1)
 			// Intercept PUB lines (publish).
 			if strings.HasPrefix(line, "PUB ") {
 				subject := extractNATSSubject(line)
@@ -110,7 +129,9 @@ func (p *natsProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 		errCh <- scanner.Err()
 	}()
 
-	<-errCh
+	if err := <-errCh; err != nil {
+		closeReason = classifyCloseReason(err, "client")
+	}
 }
 
 func (p *natsProxy) shouldDrop(subject, direction string) bool {

--- a/internal/proxy/observability.go
+++ b/internal/proxy/observability.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -285,4 +287,78 @@ func classifyCloseReason(err error, side string) string {
 		}
 	}
 	return "io_error"
+}
+
+// HTTPConnStateTracker wires RFC-034 connection-lifecycle events into
+// any net/http.Server-based proxy plugin (http, http2, clickhouse).
+// Standard library exposes a ConnState callback firing on
+// StateNew / StateActive / StateIdle / StateClosed transitions; we map
+// StateNew → proxy_conn_open and StateClosed → proxy_conn_close.
+// First StateActive is the connection-ready beat (HTTP has no auth
+// handshake; first byte of first request is the closest analogue).
+//
+// Byte counting at the http.Server layer is not exposed cleanly — the
+// standard library reads/writes through the listener for us. v1 wires
+// lifecycle + handshake only; bytes_c2s / bytes_s2c report 0 for
+// HTTP-family plugins. Follow-up: wrap the underlying net.Conn via a
+// custom Listener that returns counting Conns.
+type HTTPConnStateTracker struct {
+	mu       sync.Mutex
+	trackers map[net.Conn]*connTracker
+	onEvent  OnProxyEvent
+	service  string
+	iface    string
+	protocol string
+	target   string
+}
+
+// NewHTTPConnStateTracker constructs the tracker map. Plugins call
+// `tracker.ConnState` and assign it to `http.Server.ConnState`.
+func NewHTTPConnStateTracker(onEvent OnProxyEvent, service, iface, protocol, target string) *HTTPConnStateTracker {
+	return &HTTPConnStateTracker{
+		trackers: make(map[net.Conn]*connTracker),
+		onEvent:  onEvent,
+		service:  service,
+		iface:    iface,
+		protocol: protocol,
+		target:   target,
+	}
+}
+
+// ConnState is the http.Server.ConnState handler. Hook it on the
+// server before Serve(): `srv.ConnState = tracker.ConnState`.
+func (h *HTTPConnStateTracker) ConnState(c net.Conn, state http.ConnState) {
+	if h == nil || h.onEvent == nil {
+		return
+	}
+	switch state {
+	case http.StateNew:
+		t := newConnTracker(h.onEvent, h.service, h.iface, h.protocol,
+			c.RemoteAddr().String(), h.target)
+		t.EmitOpen()
+		h.mu.Lock()
+		h.trackers[c] = t
+		h.mu.Unlock()
+	case http.StateActive:
+		h.mu.Lock()
+		t := h.trackers[c]
+		h.mu.Unlock()
+		if t != nil {
+			// Idempotent — handshakeDone CAS makes subsequent
+			// StateActive transitions on keep-alive connections no-ops.
+			t.EmitHandshakeComplete("", 1)
+		}
+	case http.StateClosed, http.StateHijacked:
+		h.mu.Lock()
+		t := h.trackers[c]
+		delete(h.trackers, c)
+		h.mu.Unlock()
+		if t != nil {
+			reason := "client_eof"
+			if state == http.StateHijacked {
+				reason = "context_cancel"
+			}
+			t.EmitClose(reason)
+		}
+	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -94,9 +94,17 @@ func TestHTTPProxyErrorRule(t *testing.T) {
 	}
 	resp2.Body.Close()
 
-	// Should have 1 proxy event.
-	if len(events) != 1 {
-		t.Errorf("expected 1 event, got %d", len(events))
+	// Should have 1 rule-fired event (legacy ProxyEvent.Type=="").
+	// RFC-034 added connection-lifecycle events (proxy_conn_open /
+	// _close); count only the legacy events for this assertion.
+	ruleEvents := 0
+	for _, e := range events {
+		if e.Type == "" {
+			ruleEvents++
+		}
+	}
+	if ruleEvents != 1 {
+		t.Errorf("expected 1 rule-fired event, got %d (total events: %d)", ruleEvents, len(events))
 	}
 }
 


### PR DESCRIPTION
Closes the bulk of #88. v0.12.20 (PR #95) wired 4 plugins (tcp, mysql, postgres, redis); this PR covers 9 of the remaining 11, leaving only udp + grpc for follow-up RFCs.

## What's wired

**6 frame/text-based plugins** — same pattern as mysql/postgres/redis (tracker after dial, EmitOpen, deferred EmitClose with closeReason, AddBytesC2S/S2C inline at every read/write, EmitHandshakeComplete at the protocol's natural ready-beat):

- `amqp.go` — protocol header as handshake marker; bidirectional `forwardFrames` accept an `addBytes` callback per direction
- `cassandra.go` — asymmetric (framed C2S, `io.Copy` S2C wrapped via `tracker.WrapServerReader`)
- `kafka.go` — length-prefix framed
- `memcached.go` — text-line + binary-data hybrid
- `mongodb.go` — LE32 framed
- `nats.go` — text-line via `bufio.Scanner`; first server line (INFO) is handshake-complete

**3 HTTP-family plugins** via new `HTTPConnStateTracker` helper:

- New helper in `observability.go` maps `http.Server.ConnState` transitions: `StateNew` → `proxy_conn_open`, `StateClosed` → `proxy_conn_close`, first `StateActive` → `proxy_handshake_complete` (idempotent for keep-alive via handshakeDone CAS).
- Wired in `http.go`, `http2.go`, `clickhouse.go` — single line per plugin: `ConnState: connTracker.ConnState`.
- HTTP/2 emits per underlying-TCP-conn (one open/close per physical connection, regardless of stream count).
- **Byte counts not yet wired for HTTP-family** — `http.Server` reads/writes through the listener internally; a custom Listener that returns counting Conns is the natural follow-up. `bytes_c2s` / `bytes_s2c` report 0 for these plugins until that ships.

## Out of scope (final follow-up)

- **`udp.go`** — datagram protocol, connectionless. RFC-034's open/close model doesn't fit. Likely a new event family (`proxy_datagram_received` / `_sent`) — separate RFC.
- **`grpc.go`** — per-RPC handler is not connection-scoped; `grpc.Server` exposes no per-connection lifecycle hook compatible with RFC-034. `grpc.StatsHandler` is per-RPC. Defer until either a StatsHandler-based variant or pre-gRPC listener wrapping.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet`, cross-compile linux/arm64 — clean
- [x] Lima poc sweep **21/21 PASS** across example, demo, mock-demo, demo-container, mysql-rfc022-repro, kafka-rfc014
- [x] Smoke trace from `poc/demo-container`: 18 `proxy_conn_open` / 18 `proxy_conn_close` pairs + 4 `proxy_handshake_complete` events alongside the existing `proxy_started` events
- [x] Pre-existing `TestHTTPProxyErrorRule` updated to count only legacy rule-fired events (`ProxyEvent.Type == ""`); the new lifecycle events would otherwise inflate the count from 1 to 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)