### PR TITLE
RFC-038 Phase 1: TLS-aware proxy foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,65 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.22] - 2026-05-02
+
+RFC-038 Phase 1 — TLS-aware proxy foundation. Lays the transport-
+layer plumbing every plugin will inherit when the per-plugin migration
+lands in Phase 3. No plugin behavior changes in this release; pure
+infrastructure addition.
+
+### Added
+
+- **`proxy.ListenTLS(cfg)`** — TLS-aware variant of `Listen()` that
+  wraps the bind-side listener via `tls.NewListener`. Returns the
+  same `(net.Listener, listenAddr, error)` triple, so plugins flip
+  one call site to opt into TLS termination at the proxy without
+  touching their handler code (the handler still reads/writes
+  plaintext via the wrapped `*tls.Conn`).
+- **`proxy.Dial(ctx, target, cfg, timeout)`** — upstream-side
+  companion. With a nil cfg it's `net.DialTimeout("tcp", …)`; with
+  a non-nil cfg it negotiates TLS via `tls.Client.HandshakeContext`,
+  honouring both ctx cancellation and the timeout argument so
+  stalled handshakes don't outlive the call.
+  - Auto-fills `cfg.ServerName` from `target`'s host portion when
+    unset, so the customer's `tls=tls_cert(ca=...)` material matches
+    upstream certs without per-plugin SNI plumbing.
+- **`proxy.GenerateSelfSignedCert(hosts)`** — returns a `*tls.Config`
+  with a freshly minted ECDSA P-256 self-signed cert in memory. SAN
+  always includes `localhost` + `127.0.0.1` + `::1` so the host-side
+  dial address from `Listen()` works without per-test config; extra
+  hosts get added on top. 24-hour validity window. New cert per call
+  (intentional — Phase 1 ships sub-option 1a from the RFC; persisted
+  fixture path 1c lands when a customer asks).
+
+### RFC-038 scope notes
+
+- Phase 1 = foundation only. `internal/proxy/{listen.go,tls.go}` are
+  the only files touched on the data path — the 14 existing `Listen()`
+  callsites in plugins are unchanged. Adding the sibling helper
+  rather than extending `Listen()`'s signature kept the diff
+  reviewable and lets per-plugin migration roll in one PR at a time.
+- Spec-language surface (`tls_cert(...)` Starlark builtin) is
+  Phase 2; per-plugin upstream-dial migration is Phase 3.
+- `proxy_tls_handshake_complete` event family (Open Question 6 in
+  the RFC) lands with Phase 4 once at least one plugin actually
+  terminates TLS — no point shipping the event before something
+  fires it.
+
+### Tests
+
+9 new tests cover the foundation:
+- Loopback SAN defaults / custom hosts / fresh-on-each-call for
+  `GenerateSelfSignedCert`.
+- `ListenTLS` rejects nil cfg and round-trips bytes through a real
+  TLS handshake.
+- `Dial` plaintext path, TLS path, handshake-timeout (timeout
+  argument is honoured), and ServerName-defaulting-from-target
+  verification.
+
+Full repo `go test ./...` green; no plugin behavior changes so
+Lima sweep mirrors v0.12.21.
+
 ## [0.12.21] - 2026-05-01
 
 RFC-034 Phase 2 — proxy traffic observability extended to 9 more

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.21"
+var version = "0.12.22"
 
 func run() int {
 	args := os.Args[1:]

--- a/internal/proxy/listen.go
+++ b/internal/proxy/listen.go
@@ -19,10 +19,13 @@
 package proxy
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"os"
 	"runtime"
+	"time"
 )
 
 // FaultboxProxyBindEnv overrides the bind interface that Listen and
@@ -71,6 +74,98 @@ func Listen() (net.Listener, string, error) {
 		return nil, "", fmt.Errorf("listener address is not TCP: %T", ln.Addr())
 	}
 	return ln, fmt.Sprintf("127.0.0.1:%d", addr.Port), nil
+}
+
+// ListenTLS is the TLS-aware variant of Listen. The bind side and
+// returned listenAddr behave exactly like Listen — bind interface
+// honours listenHost(), addr is always 127.0.0.1:<port>. The
+// listener wraps incoming connections in tls.NewListener using the
+// provided cfg, so Accept() returns *tls.Conn whose Read/Write speak
+// plaintext to the proxy plugin while transmitting ciphertext on
+// the wire.
+//
+// Callers must provide cfg with at least one Certificate (or
+// GetCertificate). For dev / test where the proxy runs without an
+// externally issued cert, use GenerateSelfSignedCert() to build a
+// cfg.
+//
+// RFC-038 Phase 1 — sibling of Listen rather than an extension to
+// keep the 14 existing Listen callsites unchanged. Plugins that
+// adopt TLS in Phase 3 switch their listen call from Listen() to
+// ListenTLS(cfg) when an interface declares tls=...
+func ListenTLS(cfg *tls.Config) (net.Listener, string, error) {
+	if cfg == nil {
+		return nil, "", fmt.Errorf("ListenTLS: tls.Config required (use Listen for plaintext)")
+	}
+	ln, listenAddr, err := Listen()
+	if err != nil {
+		return nil, "", err
+	}
+	return tls.NewListener(ln, cfg), listenAddr, nil
+}
+
+// Dial is the upstream-side companion of Listen / ListenTLS. With a
+// nil tlsCfg it behaves like net.DialTimeout("tcp", target, …); with
+// a non-nil cfg it negotiates TLS against the upstream and returns
+// the *tls.Conn (typed as net.Conn).
+//
+// The DialTimeout-equivalent applies to both the TCP connect and
+// the TLS handshake: the function returns the moment either step
+// fails or the deadline expires. ctx cancellation is honoured for
+// the TCP step; the TLS handshake observes the same deadline via
+// SetDeadline so a stalled handshake does not outlive ctx.
+//
+// The hostname used for TLS verification (ServerName) follows
+// cfg.ServerName when set; otherwise it is derived from target's
+// host portion. Plugins typically set ServerName=target-host
+// explicitly so the customer's `tls=tls_cert(ca=...)` material
+// matches whatever certificate the upstream presents.
+//
+// RFC-038 Phase 1 — added so plugins can switch their upstream dial
+// from net.DialTimeout to proxy.Dial without re-implementing TLS
+// per-plugin. Phase 3 migrates plugins one at a time.
+func Dial(ctx context.Context, target string, cfg *tls.Config, timeout time.Duration) (net.Conn, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	d := &net.Dialer{}
+	tcp, err := d.DialContext(dialCtx, "tcp", target)
+	if err != nil {
+		return nil, fmt.Errorf("dial tcp %s: %w", target, err)
+	}
+	if cfg == nil {
+		return tcp, nil
+	}
+
+	// Default ServerName to the host portion of target so the cert's
+	// SAN/CN match without callers having to spell it out. Callers
+	// that need an explicit override (e.g. SNI override for a CDN
+	// upstream) set cfg.ServerName themselves and we leave it alone.
+	if cfg.ServerName == "" {
+		host, _, splitErr := net.SplitHostPort(target)
+		if splitErr == nil {
+			cfg = cfg.Clone()
+			cfg.ServerName = host
+		}
+	}
+
+	tlsConn := tls.Client(tcp, cfg)
+	// Honour the ctx deadline for the handshake too — without this a
+	// stalled handshake would block past ctx cancellation.
+	if deadline, ok := dialCtx.Deadline(); ok {
+		_ = tlsConn.SetDeadline(deadline)
+	}
+	if err := tlsConn.HandshakeContext(dialCtx); err != nil {
+		tcp.Close()
+		return nil, fmt.Errorf("tls handshake %s: %w", target, err)
+	}
+	// Clear the handshake deadline; further reads/writes use plugin-
+	// level deadlines (or none).
+	_ = tlsConn.SetDeadline(time.Time{})
+	return tlsConn, nil
 }
 
 // ListenUDP is the UDP counterpart of Listen. The udp proxy is the

--- a/internal/proxy/tls.go
+++ b/internal/proxy/tls.go
@@ -1,0 +1,109 @@
+// Package proxy — TLS helper material for transparent fault-injection
+// proxies. RFC-038 Phase 1: ship the foundation needed to terminate
+// TLS at the proxy (so per-plugin handlers keep seeing plaintext) and
+// to dial mTLS upstreams.
+//
+// This file owns the auto-generated self-signed cert path, used when
+// a `tls=` interface is declared without an explicit `proxy_cert`.
+// In dev/test that's the common path: customer specs say "this
+// upstream speaks TLS" without spelling out cert files, and we
+// fabricate the proxy-side material on the fly. Stricter
+// environments will plug in their own cert via the spec-language
+// surface that lands in Phase 2.
+
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// GenerateSelfSignedCert returns a *tls.Config with a freshly minted
+// self-signed certificate covering the given hostnames / IPs. The
+// cert chain is in-memory only; nothing touches disk. Each call
+// produces a new cert (new serial, new key, new fingerprint) — fine
+// for testing, hostile to certificate-pinned clients. Phase 1 does
+// not persist; that's the (1c) sub-option in the RFC and we'll
+// revisit if a customer asks.
+//
+// hosts may include DNS names, IP literals, or both. "localhost"
+// and "127.0.0.1" are always included so dev specs that don't list
+// hosts still get a working cert against the loopback dial address
+// returned by Listen / ListenTLS. An empty hosts slice falls back
+// to those two entries only.
+//
+// The cert is valid for 24 hours. Test runs almost always live
+// well under that bound; CI runs that exceed it should regenerate
+// per-test rather than rely on long validity.
+func GenerateSelfSignedCert(hosts []string) (*tls.Config, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate key: %w", err)
+	}
+
+	serialMax := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialMax)
+	if err != nil {
+		return nil, fmt.Errorf("generate serial: %w", err)
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			Organization: []string{"Faultbox Auto-Generated (RFC-038)"},
+			CommonName:   "faultbox-proxy",
+		},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Always include loopback so the host-side dial address from
+	// Listen / ListenTLS works without per-test SAN config.
+	template.DNSNames = append(template.DNSNames, "localhost", "faultbox-proxy")
+	template.IPAddresses = append(template.IPAddresses, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else if h != "" {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, fmt.Errorf("create certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("marshal key: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("load keypair: %w", err)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}

--- a/internal/proxy/tls_test.go
+++ b/internal/proxy/tls_test.go
@@ -1,0 +1,358 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGenerateSelfSignedCert_LoopbackDefaults — the fabricated cert
+// must cover at least localhost + 127.0.0.1 so the host-side dial
+// address Listen() returns ("127.0.0.1:<port>") works without
+// per-test SAN config.
+func TestGenerateSelfSignedCert_LoopbackDefaults(t *testing.T) {
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("want 1 cert, got %d", len(cfg.Certificates))
+	}
+	leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	wantDNS := []string{"localhost"}
+	for _, want := range wantDNS {
+		found := false
+		for _, got := range leaf.DNSNames {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("cert SAN missing DNS name %q (have %v)", want, leaf.DNSNames)
+		}
+	}
+
+	foundLoopback := false
+	for _, ip := range leaf.IPAddresses {
+		if ip.IsLoopback() && ip.To4() != nil {
+			foundLoopback = true
+			break
+		}
+	}
+	if !foundLoopback {
+		t.Errorf("cert SAN missing 127.0.0.1 (have %v)", leaf.IPAddresses)
+	}
+
+	if leaf.NotAfter.Before(time.Now().Add(23 * time.Hour)) {
+		t.Errorf("cert valid window too short: NotAfter=%s", leaf.NotAfter)
+	}
+}
+
+// TestGenerateSelfSignedCert_CustomHosts — extra hosts (DNS or IP
+// literal) get added to the SAN. Test that a customer adding their
+// upstream's hostname to the spec carries through.
+func TestGenerateSelfSignedCert_CustomHosts(t *testing.T) {
+	cfg, err := GenerateSelfSignedCert([]string{"truck-api.local", "10.1.2.3"})
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+	leaf, _ := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+
+	hasDNS := false
+	for _, n := range leaf.DNSNames {
+		if n == "truck-api.local" {
+			hasDNS = true
+			break
+		}
+	}
+	if !hasDNS {
+		t.Errorf("custom DNS name not added: have %v", leaf.DNSNames)
+	}
+
+	hasIP := false
+	for _, ip := range leaf.IPAddresses {
+		if ip.String() == "10.1.2.3" {
+			hasIP = true
+			break
+		}
+	}
+	if !hasIP {
+		t.Errorf("custom IP not added: have %v", leaf.IPAddresses)
+	}
+}
+
+// TestGenerateSelfSignedCert_FreshOnEachCall — every call produces a
+// distinct serial / fingerprint so a long-running runtime that
+// regenerates per-session avoids serial collisions. Also documents
+// the "no persistence" property — clients pinning a fingerprint
+// across runs will break, which is the intentional dev-only tradeoff.
+func TestGenerateSelfSignedCert_FreshOnEachCall(t *testing.T) {
+	a, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("first cert: %v", err)
+	}
+	b, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("second cert: %v", err)
+	}
+	leafA, _ := x509.ParseCertificate(a.Certificates[0].Certificate[0])
+	leafB, _ := x509.ParseCertificate(b.Certificates[0].Certificate[0])
+	if leafA.SerialNumber.Cmp(leafB.SerialNumber) == 0 {
+		t.Errorf("serials collided across calls — randomness broken")
+	}
+}
+
+// TestListenTLS_RejectsNilConfig — defensive: ListenTLS without a
+// cfg makes no sense; calling Listen() is the right path. Surface
+// the misuse early.
+func TestListenTLS_RejectsNilConfig(t *testing.T) {
+	_, _, err := ListenTLS(nil)
+	if err == nil {
+		t.Fatalf("expected error for nil cfg")
+	}
+}
+
+// TestListenTLS_RoundTrip — a TLS client dialing the listenAddr
+// returned by ListenTLS round-trips bytes through tls.Conn.Read /
+// Write. Mirrors the canonical Listen passthrough pattern with
+// crypto wrapped on top.
+func TestListenTLS_RoundTrip(t *testing.T) {
+	t.Setenv(FaultboxProxyBindEnv, "")
+
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+
+	ln, listenAddr, err := ListenTLS(cfg)
+	if err != nil {
+		t.Fatalf("ListenTLS: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(c, buf); err != nil {
+			return
+		}
+		c.Write(buf)
+	}()
+
+	// Build a client cfg that trusts the proxy's auto-generated cert.
+	clientCfg := clientCfgFor(t, cfg)
+	conn, err := tls.Dial("tcp", listenAddr, clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 5)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("byte-identity broken: got %q", got)
+	}
+}
+
+// TestDial_Plaintext — Dial with nil cfg is the plain net.DialTimeout
+// equivalent. A trivial echo server confirms Dial returns a usable
+// net.Conn.
+func TestDial_Plaintext(t *testing.T) {
+	srv, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer srv.Close()
+
+	go func() {
+		c, _ := srv.Accept()
+		if c == nil {
+			return
+		}
+		defer c.Close()
+		io.Copy(c, c)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, srv.Addr().String(), nil, 0)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.Write([]byte("ping"))
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Errorf("got %q", buf)
+	}
+}
+
+// TestDial_TLS — Dial with a non-nil cfg performs the TLS handshake
+// against the upstream and returns a *tls.Conn. Run a TLS server
+// using the auto-generated cert, point Dial at it, verify a round
+// trip works.
+func TestDial_TLS(t *testing.T) {
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+
+	srv, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer srv.Close()
+
+	go func() {
+		c, _ := srv.Accept()
+		if c == nil {
+			return
+		}
+		defer c.Close()
+		io.Copy(c, c)
+	}()
+
+	clientCfg := clientCfgFor(t, cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, srv.Addr().String(), clientCfg, 0)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	if _, ok := conn.(*tls.Conn); !ok {
+		t.Errorf("Dial with cfg returned %T, want *tls.Conn", conn)
+	}
+
+	conn.Write([]byte("ping"))
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Errorf("got %q", buf)
+	}
+}
+
+// TestDial_TLS_HandshakeTimeout — a TCP server that accepts but
+// never sends ServerHello must trigger the handshake deadline.
+// Without ctx + SetDeadline plumbing the call would hang past
+// Dial's timeout argument.
+func TestDial_TLS_HandshakeTimeout(t *testing.T) {
+	srv, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer srv.Close()
+
+	// Accept and hold the conn open without doing TLS — the client's
+	// handshake will block on ServerHello.
+	go func() {
+		c, _ := srv.Accept()
+		if c == nil {
+			return
+		}
+		// Hold open — never write ServerHello.
+		time.Sleep(5 * time.Second)
+		c.Close()
+	}()
+
+	clientCfg := &tls.Config{InsecureSkipVerify: true}
+	start := time.Now()
+	_, err = Dial(context.Background(), srv.Addr().String(), clientCfg, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("Dial waited %v past timeout — deadline not honoured", elapsed)
+	}
+	if !strings.Contains(err.Error(), "tls handshake") && !strings.Contains(err.Error(), "deadline") && !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error doesn't look like a handshake timeout: %v", err)
+	}
+}
+
+// TestDial_TLS_ServerNameDefaultsToTargetHost — when cfg.ServerName
+// is empty, Dial fills it from target's host portion so the
+// auto-generated cert's localhost SAN matches without callers
+// having to set ServerName explicitly.
+func TestDial_TLS_ServerNameDefaultsToTargetHost(t *testing.T) {
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	srv, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer srv.Close()
+	go func() {
+		c, _ := srv.Accept()
+		if c == nil {
+			return
+		}
+		defer c.Close()
+		// Force the handshake by attempting a read; otherwise an
+		// immediate Close races the client's HandshakeContext.
+		buf := make([]byte, 1)
+		c.Read(buf)
+	}()
+
+	// Build a client cfg WITHOUT setting ServerName. Verification
+	// must still succeed because Dial picks "127.0.0.1" from the
+	// target and the cert's IP-SAN covers it.
+	clientCfg := clientCfgFor(t, cfg)
+	clientCfg.ServerName = ""
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, srv.Addr().String(), clientCfg, 0)
+	if err != nil {
+		t.Fatalf("Dial without ServerName: %v", err)
+	}
+	conn.Close()
+}
+
+// clientCfgFor builds a TLS client config that trusts the proxy's
+// auto-generated cert by adding it to a per-test root pool.
+func clientCfgFor(t *testing.T, serverCfg *tls.Config) *tls.Config {
+	t.Helper()
+	pool := x509.NewCertPool()
+	leaf, err := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	pool.AddCert(leaf)
+	return &tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `proxy.ListenTLS()`, `proxy.Dial()`, and `proxy.GenerateSelfSignedCert()` — the transport-layer plumbing every plugin will inherit when the per-plugin migration lands in Phase 3
- Pure infrastructure addition: zero plugin behavior changes, the 14 existing `Listen()` callsites are untouched
- Implements Phase 1 of [RFC-038](https://github.com/faultbox/Faultbox/blob/main/docs/rfcs/0038-tls-aware-proxy.md) (Option B — ALPN-passthrough)

## What ships

- **`proxy.ListenTLS(cfg)`** — wraps the bind-side listener via `tls.NewListener`. Plugins that adopt TLS in Phase 3 flip one call site; the handler still reads/writes plaintext via the wrapped `*tls.Conn`.
- **`proxy.Dial(ctx, target, cfg, timeout)`** — upstream-side companion. Plain `net.DialTimeout` when `cfg=nil`; `tls.Client.HandshakeContext` when `cfg` is set. Honours both `ctx` cancellation and the timeout argument so stalled handshakes don't outlive the call. Auto-fills `cfg.ServerName` from `target`'s host portion when unset.
- **`proxy.GenerateSelfSignedCert(hosts)`** — in-memory ECDSA P-256 self-signed cert. SAN includes `localhost` / `127.0.0.1` / `::1` by default + caller-supplied hosts. 24h validity. New cert per call (RFC sub-option 1a).

## Why a sibling and not extend `Listen()`

`Listen()` has 14 plugin callsites. Adding the TLS path as a sibling helper kept the diff small and lets per-plugin migration roll in one PR at a time. Phase 3 plugins will pick `Listen()` vs `ListenTLS(cfg)` based on whether the interface declares `tls=...`.

## What's NOT in this PR

- Spec-language surface (`tls_cert(...)` Starlark builtin) → **Phase 2**
- Per-plugin upstream-dial migration → **Phase 3**
- `proxy_tls_handshake_complete` event family → **Phase 4** (no point shipping the event before something fires it)

## Tests

9 new tests in `internal/proxy/tls_test.go`:
- `TestGenerateSelfSignedCert_LoopbackDefaults` — SAN covers loopback DNS + IP
- `TestGenerateSelfSignedCert_CustomHosts` — extra hosts threaded through
- `TestGenerateSelfSignedCert_FreshOnEachCall` — distinct serials, no collisions
- `TestListenTLS_RejectsNilConfig` — defensive check
- `TestListenTLS_RoundTrip` — real TLS handshake + byte-identity round trip
- `TestDial_Plaintext` — nil cfg = plain TCP
- `TestDial_TLS` — non-nil cfg = `*tls.Conn`
- `TestDial_TLS_HandshakeTimeout` — stalled handshake honours timeout (≤200ms)
- `TestDial_TLS_ServerNameDefaultsToTargetHost` — auto-SNI works without explicit ServerName

## Verification

- `go test ./...` — all packages green
- `go vet ./...` — clean
- Cross-compile (linux/arm64) — green
- Lima `demo-container` — 4/4 PASS (sanity check; no plugin changes so behavior identical to v0.12.21)

Version: 0.12.21 → 0.12.22.

## Test plan

- [ ] CI: `go test ./...` green
- [ ] CI: cross-compile linux/arm64
- [ ] Manual: customer's existing specs continue to work (no plugin behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)