### PR TITLE
RFC-038 Phase 3 (1/4): http + http2 plugins terminate TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,72 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.24] - 2026-05-02
+
+RFC-038 Phase 3 (1 of 4) — first plugin migrations. The `http` and
+`http2` proxies now terminate TLS at their listener and / or dial the
+upstream over TLS when the spec declares `tls=tls_cert(...)`. The
+plaintext path is unchanged: tests written before RFC-038 keep
+running bit-identical to v0.12.21. Per the customer's gap list, this
+ships items #2 (HTTPS) and partially #1 (gRPC-TLS — Phase 3 PR 2
+wires the gRPC plugin specifically).
+
+### Added
+
+- **`TLSAware` interface** in `internal/proxy/proxy.go` —
+  `SetTLS(server, client *tls.Config)`. Plugins implement this to
+  opt into Phase 3 TLS handling. Plugins that don't implement it
+  stay plain-TCP only and `proxy_tls_pending` is emitted.
+- **`Manager.EnsureProxyTLS(ctx, …, server, client)`** — TLS-aware
+  variant of `EnsureProxy`. Returns a `tlsApplied bool` so the
+  runtime can detect plugins that haven't migrated yet and warn
+  the customer. Existing `EnsureProxy` is unchanged for callers
+  that don't pass TLS material.
+- **`http` plugin migrated** — wraps the listener via `ListenTLS`
+  when `serverTLS` is set; reverse-proxy `Transport.TLSClientConfig`
+  hooks the customer's CA / mTLS material when `clientTLS` is set.
+  Plaintext path runs unchanged.
+- **`http2` plugin migrated** — same pattern, with ALPN `h2`
+  forced on both legs and `http2.ConfigureServer` installed when
+  the listener side speaks TLS so HTTP/2 dispatch works at the
+  http.Server layer. Plaintext h2c upgrade keeps working.
+
+### Wiring
+
+- `preStartProxies` resolves `iface.TLS.ResolveServerConfig` /
+  `ResolveClientConfig` against the spec directory and routes
+  through `EnsureProxyTLS`. The `proxy_started` event's `mode`
+  field is now `"tls"` when the migration applied (formerly
+  always `"passthrough"`); the `proxy_tls_pending` warning only
+  fires when `tlsApplied=false`.
+- Auto self-signed cert path includes the upstream host portion
+  in its SAN list so customers pointing at
+  `interface("main", "http", 8080)` against
+  `target=truck-api.svc.cluster.local:443` get a proxy cert that
+  covers the hostname without spelling out a SAN list.
+
+### Tests
+
+9 new tests in `internal/proxy/http_tls_test.go`:
+
+| Test | Covers |
+|---|---|
+| `TestHTTPProxy_TLSEndToEnd` | client HTTPS → proxy → upstream HTTPS |
+| `TestHTTPProxy_TLSRuleInjection` | path-glob fault rule fires inside the TLS tunnel |
+| `TestHTTPProxy_PlaintextStillWorks` | regression — no SetTLS = pre-RFC-038 behaviour |
+| `TestHTTPProxy_ImplementsTLSAware` | type-assertion contract |
+| `TestHTTP2Proxy_TLSEndToEnd` | h2-over-TLS at both legs, ALPN negotiation |
+| `TestHTTP2Proxy_TLSRuleInjection` | rule fires through h2 + TLS |
+| `TestHTTP2Proxy_PlaintextStillWorks` | h2c regression |
+| `TestHTTP2Proxy_ImplementsTLSAware` | type-assertion contract |
+| `TestEnsureProxyTLS_AppliedFlag` | manager flags TLS-aware vs plain plugins |
+
+Full repo `go test ./...` green; Lima `demo-container` 4/4 PASS
+(no TLS in demo yet — regression check on the http path that the
+demo uses).
+
+Version 0.12.23 → 0.12.24.
+
 ## [0.12.23] - 2026-05-02
 
 RFC-038 Phase 2 — Starlark spec-language surface for TLS. Customers

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.23"
+var version = "0.12.24"
 
 func run() int {
 	args := os.Args[1:]

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -2,9 +2,11 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -19,6 +21,12 @@ type httpProxy struct {
 	server  *http.Server
 	onEvent OnProxyEvent
 	svcName string
+
+	// RFC-038 Phase 3: TLS material when the interface declares
+	// tls=tls_cert(...). Either may be nil — see the TLSAware
+	// docstring in proxy.go for the four combinations.
+	serverTLS *tls.Config
+	clientTLS *tls.Config
 }
 
 func newHTTPProxy(onEvent OnProxyEvent, svcName string) *httpProxy {
@@ -30,22 +38,59 @@ func newHTTPProxy(onEvent OnProxyEvent, svcName string) *httpProxy {
 
 func (p *httpProxy) Protocol() string { return "http" }
 
+// SetTLS implements TLSAware. Must be called before Start.
+func (p *httpProxy) SetTLS(server, client *tls.Config) {
+	p.serverTLS = server
+	p.clientTLS = client
+}
+
 func (p *httpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	// Listen on random port.
-	ln, listenAddr, err := Listen()
+	// Listen on random port. ListenTLS wraps the listener via
+	// tls.NewListener when serverTLS is set; otherwise plain Listen.
+	var ln net.Listener
+	var listenAddr string
+	var err error
+	if p.serverTLS != nil {
+		ln, listenAddr, err = ListenTLS(p.serverTLS)
+	} else {
+		ln, listenAddr, err = Listen()
+	}
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
 
-	targetURL, err := url.Parse("http://" + target)
+	// Upstream URL scheme follows the upstream-side TLS cfg: clientTLS
+	// non-nil ⇒ the proxy dials the upstream over TLS, so the reverse
+	// proxy must speak https://. Otherwise plain http://.
+	scheme := "http"
+	if p.clientTLS != nil {
+		scheme = "https"
+	}
+	targetURL, err := url.Parse(scheme + "://" + target)
 	if err != nil {
 		ln.Close()
 		return "", fmt.Errorf("parse target URL: %w", err)
 	}
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+
+	// When dialing upstream over TLS, hand the resolved cfg to the
+	// reverse proxy's transport so the customer's CA / mTLS material
+	// applies. Otherwise the default transport (plain TCP) keeps
+	// working unchanged.
+	if p.clientTLS != nil {
+		transport := &http.Transport{
+			TLSClientConfig:       p.clientTLS,
+			ForceAttemptHTTP2:     false,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+		reverseProxy.Transport = transport
+	}
 
 	// RFC-034: connection-lifecycle events via http.Server.ConnState.
 	// Per-conn open/close + first-request handshake_complete; byte

--- a/internal/proxy/http2.go
+++ b/internal/proxy/http2.go
@@ -24,6 +24,12 @@ type http2Proxy struct {
 	server  *http.Server
 	onEvent OnProxyEvent
 	svcName string
+
+	// RFC-038 Phase 3: TLS material. serverTLS wraps the listener
+	// (ALPN h2 forced); clientTLS configures the http2.Transport
+	// to dial upstream over TLS with ALPN h2.
+	serverTLS *tls.Config
+	clientTLS *tls.Config
 }
 
 func newHTTP2Proxy(onEvent OnProxyEvent, svcName string) *http2Proxy {
@@ -35,30 +41,58 @@ func newHTTP2Proxy(onEvent OnProxyEvent, svcName string) *http2Proxy {
 
 func (p *http2Proxy) Protocol() string { return "http2" }
 
+// SetTLS implements TLSAware. Must be called before Start.
+func (p *http2Proxy) SetTLS(server, client *tls.Config) {
+	p.serverTLS = server
+	p.clientTLS = client
+}
+
 func (p *http2Proxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, listenAddr, err := Listen()
+	// Listen on random port. ListenTLS wraps the listener with ALPN
+	// h2 negotiated via NextProtos. Plain Listen otherwise (h2c
+	// upgrade happens at the handler level).
+	var ln net.Listener
+	var listenAddr string
+	var err error
+	if p.serverTLS != nil {
+		serverCfg := p.serverTLS.Clone()
+		serverCfg.NextProtos = []string{"h2"}
+		ln, listenAddr, err = ListenTLS(serverCfg)
+	} else {
+		ln, listenAddr, err = Listen()
+	}
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
 
-	targetURL, err := url.Parse("http://" + target)
+	// Upstream URL scheme: clientTLS non-nil ⇒ dial https:// with
+	// ALPN h2; otherwise cleartext h2c http://.
+	scheme := "http"
+	if p.clientTLS != nil {
+		scheme = "https"
+	}
+	targetURL, err := url.Parse(scheme + "://" + target)
 	if err != nil {
 		ln.Close()
 		return "", fmt.Errorf("parse target URL: %w", err)
 	}
 
-	// Upstream transport speaks HTTP/2 over cleartext — matches the most
-	// common service-mesh deployment. For TLS upstream, the transport would
-	// need its TLS config wired from the container trust store; out of scope
-	// for v1.
-	upstream := &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+	upstream := &http2.Transport{}
+	if p.clientTLS != nil {
+		clientCfg := p.clientTLS.Clone()
+		if len(clientCfg.NextProtos) == 0 {
+			clientCfg.NextProtos = []string{"h2"}
+		}
+		upstream.TLSClientConfig = clientCfg
+	} else {
+		// Cleartext upstream — h2c. Same shape as before RFC-038.
+		upstream.AllowHTTP = true
+		upstream.DialTLSContext = func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 			var d net.Dialer
 			return d.DialContext(ctx, network, addr)
-		},
+		}
 	}
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
@@ -73,11 +107,29 @@ func (p *http2Proxy) Start(ctx context.Context, target string) (string, error) {
 	// underlying-TCP-conn (StateNew/StateClosed), not per-stream.
 	connTracker := NewHTTPConnStateTracker(p.onEvent, p.svcName, "main", "http2", target)
 
-	// h2c.NewHandler upgrades prior-knowledge HTTP/2 cleartext connections
-	// in the inbound direction. Clients that send HTTP/1.1 still work.
+	// Listener side: when serverTLS is set, ALPN h2 is negotiated at
+	// the TLS layer and http.Server.Serve dispatches via the http2
+	// stack once http2.ConfigureServer runs. When serverTLS is nil
+	// we keep the h2c upgrade path for prior-knowledge cleartext.
+	var rootHandler http.Handler
+	if p.serverTLS != nil {
+		rootHandler = handler
+	} else {
+		rootHandler = h2c.NewHandler(handler, &http2.Server{})
+	}
+
 	p.server = &http.Server{
-		Handler:   h2c.NewHandler(handler, &http2.Server{}),
+		Handler:   rootHandler,
 		ConnState: connTracker.ConnState,
+	}
+	if p.serverTLS != nil {
+		// Without ConfigureServer, http.Server.Serve falls back to
+		// HTTP/1.1 even when ALPN negotiated h2. ConfigureServer
+		// installs the http2 protocol handler on TLSNextProto.
+		if err := http2.ConfigureServer(p.server, &http2.Server{}); err != nil {
+			ln.Close()
+			return "", fmt.Errorf("configure http2 server: %w", err)
+		}
 	}
 
 	go func() {

--- a/internal/proxy/http_tls_test.go
+++ b/internal/proxy/http_tls_test.go
@@ -1,0 +1,413 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// h2cHandler is a tiny helper that wraps a HandlerFunc for the
+// h2c upgrade path used by the plaintext HTTP/2 regression test.
+func h2cHandler(fn http.HandlerFunc) http.Handler {
+	return h2c.NewHandler(fn, &http2.Server{})
+}
+
+// startMockHTTPS starts a real upstream that speaks HTTPS using the
+// auto-generated cert. Returns the addr (host:port) and a cleanup fn.
+func startMockHTTPS(t *testing.T, handler http.Handler) (string, *tls.Config, func()) {
+	t.Helper()
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+	srv := &http.Server{Handler: handler}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	go srv.Serve(ln)
+	return ln.Addr().String(), cfg, func() { srv.Close(); ln.Close() }
+}
+
+// httpsClientFor builds a TLS client that trusts the proxy's auto-cert
+// (or the upstream's). ServerName=localhost matches the cert's SAN.
+func httpsClientFor(t *testing.T, serverCfg *tls.Config) *http.Client {
+	t.Helper()
+	leaf, err := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				ServerName: "localhost",
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+}
+
+// TestHTTPProxy_TLSEndToEnd exercises the headline RFC-038 case:
+// client speaks HTTPS to the proxy, proxy speaks HTTPS to the
+// upstream, plaintext rule-matching keeps working in the middle.
+func TestHTTPProxy_TLSEndToEnd(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startMockHTTPS(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "ok-from-upstream")
+	}))
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	}
+	serverCfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("server cert: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newHTTPProxy(nil, "test-svc")
+	p.SetTLS(serverCfg, clientCfg)
+	proxyAddr, err := p.Start(ctx, upstreamAddr)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	client := httpsClientFor(t, serverCfg)
+	resp, err := client.Get("https://" + proxyAddr + "/hello")
+	if err != nil {
+		t.Fatalf("HTTPS through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if string(body) != "ok-from-upstream" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// TestHTTPProxy_TLSRuleInjection — fault rules still match against
+// the plaintext seen between the two TLS legs. This is the entire
+// reason RFC-038 picked Option B over Option C (TLS-blind tunnel).
+func TestHTTPProxy_TLSRuleInjection(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startMockHTTPS(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "should not reach upstream")
+	}))
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newHTTPProxy(nil, "test-svc")
+	p.SetTLS(serverCfg, clientCfg)
+	proxyAddr, _ := p.Start(ctx, upstreamAddr)
+	defer p.Stop()
+
+	p.AddRule(Rule{
+		Method: "GET",
+		Path:   "/blocked",
+		Action: ActionRespond,
+		Status: 503,
+		Body:   `{"error":"injected"}`,
+	})
+
+	client := httpsClientFor(t, serverCfg)
+	resp, err := client.Get("https://" + proxyAddr + "/blocked")
+	if err != nil {
+		t.Fatalf("HTTPS: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 503 {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "injected") {
+		t.Errorf("body = %q, want injected", body)
+	}
+}
+
+// TestHTTPProxy_PlaintextStillWorks — regression check. The opt-in
+// TLS path must not break the existing plain-TCP plugin lifecycle.
+// SetTLS is never called, plugin behaves exactly like pre-RFC-038.
+func TestHTTPProxy_PlaintextStillWorks(t *testing.T) {
+	mock := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "plaintext")
+	})}
+	mockLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	go mock.Serve(mockLn)
+	defer mock.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := newHTTPProxy(nil, "test-svc")
+	proxyAddr, _ := p.Start(ctx, mockLn.Addr().String())
+	defer p.Stop()
+
+	resp, err := http.Get("http://" + proxyAddr + "/")
+	if err != nil {
+		t.Fatalf("plain http: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "plaintext" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// TestHTTPProxy_ImplementsTLSAware — Manager.EnsureProxyTLS uses
+// type assertion to detect TLS support; this pins the contract.
+func TestHTTPProxy_ImplementsTLSAware(t *testing.T) {
+	var _ TLSAware = (*httpProxy)(nil)
+}
+
+// TestHTTP2Proxy_TLSEndToEnd — same as the HTTP/1 case but for the
+// HTTP/2 plugin. Upstream speaks h2-over-TLS; proxy terminates and
+// re-establishes h2-over-TLS to the upstream. ALPN is negotiated
+// at both legs.
+func TestHTTP2Proxy_TLSEndToEnd(t *testing.T) {
+	upstreamCfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("upstream cert: %v", err)
+	}
+	upstreamCfg.NextProtos = []string{"h2"}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			fmt.Fprint(w, "h2-from-upstream proto="+r.Proto)
+		}),
+	}
+	if err := http2.ConfigureServer(srv, &http2.Server{}); err != nil {
+		t.Fatalf("ConfigureServer: %v", err)
+	}
+	upstreamLn, err := tls.Listen("tcp", "127.0.0.1:0", upstreamCfg)
+	if err != nil {
+		t.Fatalf("upstream tls.Listen: %v", err)
+	}
+	go srv.Serve(upstreamLn)
+	defer srv.Close()
+	defer upstreamLn.Close()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newHTTP2Proxy(nil, "test-svc")
+	p.SetTLS(serverCfg, clientCfg)
+	proxyAddr, err := p.Start(ctx, upstreamLn.Addr().String())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	tr := &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    clientPool,
+			ServerName: "localhost",
+			NextProtos: []string{"h2"},
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+	resp, err := client.Get("https://" + proxyAddr + "/")
+	if err != nil {
+		t.Fatalf("HTTP/2 through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "HTTP/2.0") {
+		t.Errorf("upstream did not see HTTP/2: body=%q", body)
+	}
+	if resp.Proto != "HTTP/2.0" {
+		t.Errorf("client side proto = %q, want HTTP/2.0", resp.Proto)
+	}
+}
+
+// TestHTTP2Proxy_TLSRuleInjection — fault rule fires inside the TLS
+// tunnel just like the HTTP/1 case.
+func TestHTTP2Proxy_TLSRuleInjection(t *testing.T) {
+	upstreamCfg, _ := GenerateSelfSignedCert(nil)
+	upstreamCfg.NextProtos = []string{"h2"}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			fmt.Fprint(w, "should not reach upstream")
+		}),
+	}
+	_ = http2.ConfigureServer(srv, &http2.Server{})
+	upstreamLn, _ := tls.Listen("tcp", "127.0.0.1:0", upstreamCfg)
+	go srv.Serve(upstreamLn)
+	defer srv.Close()
+	defer upstreamLn.Close()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newHTTP2Proxy(nil, "test-svc")
+	p.SetTLS(serverCfg, clientCfg)
+	proxyAddr, _ := p.Start(ctx, upstreamLn.Addr().String())
+	defer p.Stop()
+
+	p.AddRule(Rule{
+		Method: "GET",
+		Path:   "/blocked",
+		Action: ActionRespond,
+		Status: 503,
+		Body:   `{"error":"injected"}`,
+	})
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	tr := &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    clientPool,
+			ServerName: "localhost",
+			NextProtos: []string{"h2"},
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+	resp, err := client.Get("https://" + proxyAddr + "/blocked")
+	if err != nil {
+		t.Fatalf("h2 through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 503 {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "injected") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// TestHTTP2Proxy_PlaintextStillWorks — regression guard on the h2c
+// path. Without SetTLS the proxy speaks h2c upstream (matches the
+// pre-RFC-038 behaviour); we point it at an h2c upstream and verify
+// a round trip.
+func TestHTTP2Proxy_PlaintextStillWorks(t *testing.T) {
+	// h2c upstream: http.Server wrapped by h2c.NewHandler so it
+	// speaks HTTP/2 over cleartext (matches the proxy's transport
+	// expectation when no clientTLS is set).
+	upstream := &http.Server{}
+	mockLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	upstream.Handler = h2cHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "h2c-plain")
+	})
+	go upstream.Serve(mockLn)
+	defer upstream.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := newHTTP2Proxy(nil, "test-svc")
+	proxyAddr, _ := p.Start(ctx, mockLn.Addr().String())
+	defer p.Stop()
+
+	// Use an h2c client so we exercise the same path as before.
+	tr := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			var d net.Dialer
+			return d.Dial(network, addr)
+		},
+	}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+	resp, err := client.Get("http://" + proxyAddr + "/")
+	if err != nil {
+		t.Fatalf("h2c through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "h2c-plain" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+// TestHTTP2Proxy_ImplementsTLSAware pins the contract.
+func TestHTTP2Proxy_ImplementsTLSAware(t *testing.T) {
+	var _ TLSAware = (*http2Proxy)(nil)
+}
+
+// TestEnsureProxyTLS_AppliedFlag — the runtime depends on the
+// tlsApplied return to decide whether to emit proxy_tls_pending.
+// http supports TLS, tcp doesn't (yet) — verify both signals.
+func TestEnsureProxyTLS_AppliedFlag(t *testing.T) {
+	mock := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})}
+	mockLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	go mock.Serve(mockLn)
+	defer mock.Close()
+
+	mgr := NewManager(nil)
+	defer mgr.StopAll()
+
+	// http: implements TLSAware → applied=true.
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+	_, applied, err := mgr.EnsureProxyTLS(context.Background(), "svc", "http-iface", "http", mockLn.Addr().String(), serverCfg, nil)
+	if err != nil {
+		t.Fatalf("http EnsureProxyTLS: %v", err)
+	}
+	if !applied {
+		t.Errorf("http: expected tlsApplied=true")
+	}
+
+	// tcp: does NOT implement TLSAware → applied=false.
+	_, applied, err = mgr.EnsureProxyTLS(context.Background(), "svc", "tcp-iface", "tcp", mockLn.Addr().String(), serverCfg, nil)
+	if err != nil {
+		t.Fatalf("tcp EnsureProxyTLS: %v", err)
+	}
+	if applied {
+		t.Errorf("tcp: expected tlsApplied=false (plugin not migrated yet)")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,6 +9,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -32,6 +33,20 @@ type Proxy interface {
 
 	// Stop shuts down the proxy.
 	Stop() error
+}
+
+// TLSAware is implemented by protocol plugins that can terminate TLS at
+// their listener and / or dial the upstream over TLS. RFC-038 Phase 3
+// migrates plugins to this interface incrementally — plugins that don't
+// implement it stay plain-TCP only and EnsureProxyTLS falls back to the
+// existing behavior with a pending-tls warning.
+//
+// SetTLS must be called BEFORE Start. server is the cfg the proxy
+// presents to clients on its listener; client is the cfg the proxy
+// uses when dialing the upstream. Either may be nil (e.g. only the
+// listener side is encrypted).
+type TLSAware interface {
+	SetTLS(server, client *tls.Config)
 }
 
 // Rule describes a protocol-level fault to inject.
@@ -200,6 +215,55 @@ func (m *Manager) EnsureProxy(ctx context.Context, svcName, ifaceName, protocol,
 	}
 
 	return listenAddr, nil
+}
+
+// EnsureProxyTLS is the TLS-aware variant of EnsureProxy. It follows
+// the same lifecycle but, after constructing the plugin, attempts a
+// TLSAware type assertion and calls SetTLS(server, client) before
+// Start. Plugins that don't implement TLSAware run in plain-TCP mode
+// and the caller can detect this via the returned tlsApplied flag —
+// the runtime emits a proxy_tls_pending event in that case so users
+// know their tls=tls_cert(...) declaration is currently a no-op for
+// that protocol.
+//
+// Either of server or client may be nil:
+//   - server=nil: the proxy listens plaintext but dials upstream TLS
+//   - client=nil: the proxy listens TLS but dials upstream plaintext
+//   - both non-nil: end-to-end TLS termination at the proxy
+func (m *Manager) EnsureProxyTLS(ctx context.Context, svcName, ifaceName, protocol, targetAddr string, server, client *tls.Config) (listenAddr string, tlsApplied bool, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := svcName + ":" + ifaceName
+	if rp, ok := m.proxies[key]; ok {
+		return rp.listenAddr, false, nil // already running
+	}
+
+	p, err := newProxy(protocol, m.onEvent, svcName)
+	if err != nil {
+		return "", false, fmt.Errorf("create %s proxy for %s: %w", protocol, key, err)
+	}
+
+	if t, ok := p.(TLSAware); ok {
+		t.SetTLS(server, client)
+		tlsApplied = true
+	}
+
+	pCtx, cancel := context.WithCancel(context.Background())
+	addr, err := p.Start(pCtx, targetAddr)
+	if err != nil {
+		cancel()
+		return "", false, fmt.Errorf("start %s proxy for %s: %w", protocol, key, err)
+	}
+
+	m.proxies[key] = &runningProxy{
+		proxy:      p,
+		listenAddr: addr,
+		target:     targetAddr,
+		cancel:     cancel,
+	}
+
+	return addr, tlsApplied, nil
 }
 
 // AddRule adds a fault rule to the proxy for the given service interface.

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1023,25 +1023,53 @@ func (rt *Runtime) preStartProxies(ctx context.Context, svcName string, svc *Ser
 			continue // already running (container reuse across tests)
 		}
 		targetAddr := proxyTargetAddr(iface)
-		proxyAddr, err := rt.proxyMgr.EnsureProxy(ctx, svcName, ifaceName, iface.Protocol, targetAddr)
+
+		// RFC-038 Phase 3: when iface.TLS is set, resolve the cert
+		// material and route through EnsureProxyTLS so plugins
+		// that implement TLSAware (http, http2 in this PR) can
+		// terminate TLS at the listener and / or dial upstream
+		// over TLS. EnsureProxyTLS reports whether the plugin
+		// accepted the TLS material — when it didn't, we emit
+		// proxy_tls_pending so the customer knows their tls=
+		// declaration is currently a no-op for that protocol.
+		var proxyAddr string
+		var tlsApplied bool
+		var err error
+		if iface.TLS != nil {
+			serverCfg, sErr := iface.TLS.ResolveServerConfig(rt.baseDir, []string{targetHostname(targetAddr)})
+			if sErr != nil {
+				return fmt.Errorf("proxy %s.%s: resolve server tls: %w", svcName, ifaceName, sErr)
+			}
+			clientCfg, cErr := iface.TLS.ResolveClientConfig(rt.baseDir)
+			if cErr != nil {
+				return fmt.Errorf("proxy %s.%s: resolve client tls: %w", svcName, ifaceName, cErr)
+			}
+			proxyAddr, tlsApplied, err = rt.proxyMgr.EnsureProxyTLS(ctx, svcName, ifaceName, iface.Protocol, targetAddr, serverCfg, clientCfg)
+		} else {
+			proxyAddr, err = rt.proxyMgr.EnsureProxy(ctx, svcName, ifaceName, iface.Protocol, targetAddr)
+		}
 		if err != nil {
 			return fmt.Errorf("proxy %s.%s: %w", svcName, ifaceName, err)
+		}
+
+		mode := "passthrough"
+		if tlsApplied {
+			mode = "tls"
 		}
 		rt.events.Emit("proxy_started", svcName, map[string]string{
 			"interface": ifaceName,
 			"protocol":  iface.Protocol,
 			"listen":    proxyAddr,
 			"target":    targetAddr,
-			"mode":      "passthrough",
+			"mode":      mode,
 		})
 
-		// RFC-038 Phase 2: spec accepted tls=tls_cert(...) but no
-		// plugin terminates TLS yet (Phase 3 ships per-plugin
-		// migration). Emit a one-time warning so customers know the
-		// declaration parsed but isn't actively wrapping the
-		// listener — silence here would let a "TLS handshake fails
-		// against proxy" debugging session burn an hour.
-		if iface.TLS != nil {
+		// Spec declared TLS but the plugin doesn't implement
+		// TLSAware yet. Phase 3 lands plugins incrementally
+		// (http/http2 → grpc → kafka → redis); the rest defer to
+		// RFC-039. Make the gap visible so debugging doesn't
+		// burn an hour on "TLS handshake fails against proxy."
+		if iface.TLS != nil && !tlsApplied {
 			rt.log.Warn("tls= declared but plugin not yet migrated — listener stays plaintext until RFC-038 Phase 3 lands this protocol",
 				slog.String("service", svcName),
 				slog.String("interface", ifaceName),
@@ -1055,6 +1083,17 @@ func (rt *Runtime) preStartProxies(ctx context.Context, svcName string, svc *Ser
 		}
 	}
 	return nil
+}
+
+// targetHostname strips the port from "host:port" for SAN-list
+// inclusion when auto-generating a self-signed proxy cert.
+// Customers usually point at a hostname (postgres-prod.svc.local)
+// and want the cert to cover it without spelling out a SAN list.
+func targetHostname(target string) string {
+	if i := strings.LastIndex(target, ":"); i > 0 {
+		return target[:i]
+	}
+	return target
 }
 
 // runSeedCallback executes the seed() Starlark callable for a service.


### PR DESCRIPTION
## Summary

- First per-plugin migration. `http` and `http2` proxies now wrap their listener via `proxy.ListenTLS` when `iface.TLS` declares server-side material, and dial upstream over HTTPS when client-side material is set.
- Plaintext path runs unchanged — every test written before RFC-038 keeps passing bit-identical.
- Ships items #2 (HTTPS) and partially #1 (gRPC-TLS) of inDrive's customer gap list. PR 2 of Phase 3 wires the gRPC plugin specifically.

## What ships

### `TLSAware` interface (proxy package)

```go
type TLSAware interface {
    SetTLS(server, client *tls.Config)
}
```

Plugins implement this to opt into Phase 3 TLS handling. Plugins that don't implement it stay plain-TCP only and `proxy_tls_pending` is emitted (warning + event).

### `Manager.EnsureProxyTLS`

Sibling of `EnsureProxy`. Returns a `tlsApplied bool` so the runtime can detect plugins that haven't migrated yet. Plain-TCP callers (tests, etc.) keep using `EnsureProxy`.

### `http` plugin

- `ListenTLS(serverTLS)` when set; `Listen()` otherwise.
- `http.Transport.TLSClientConfig` hooks the customer's CA / mTLS material when `clientTLS` is set; reverse-proxy URL becomes `https://target`.
- Plaintext path: no behavior change.

### `http2` plugin

- `ListenTLS` with `NextProtos=["h2"]` on the listener side; `http2.ConfigureServer` installed on the `http.Server` so HTTP/2 dispatch works at the TLS layer.
- `http2.Transport.TLSClientConfig` with `NextProtos=["h2"]` on the upstream side.
- Plaintext h2c upgrade keeps working unchanged.

### Runtime wiring

`preStartProxies` resolves `iface.TLS` via the Phase 2 helpers (`ResolveServerConfig` / `ResolveClientConfig`) against `rt.baseDir` and routes through `EnsureProxyTLS`. The `proxy_started` event's `mode` is `"tls"` when TLS applied (otherwise `"passthrough"`). Auto self-signed cert SAN includes the upstream hostname so customers don't need to spell out a SAN list.

## What's NOT in this PR

- gRPC plugin → **Phase 3 PR 2**
- Kafka plugin → **Phase 3 PR 3**
- Redis plugin → **Phase 3 PR 4**
- postgres / mysql / mongodb / cassandra / clickhouse / memcached / nats / amqp / tcp / udp → **deferred to RFC-039** (single follow-up RFC; SSLRequest-upgrade design problem warrants its own design document)
- `proxy_tls_handshake_complete` event → **Phase 4**
- `tls_cert()` docs in `spec-language.md` → **Phase 5**

## Tests

9 new tests in `internal/proxy/http_tls_test.go`:

| Test | Covers |
|---|---|
| `TestHTTPProxy_TLSEndToEnd` | HTTPS client → proxy → HTTPS upstream round trip |
| `TestHTTPProxy_TLSRuleInjection` | path-glob fault rule fires inside the TLS tunnel |
| `TestHTTPProxy_PlaintextStillWorks` | regression — no SetTLS = pre-RFC-038 behavior |
| `TestHTTPProxy_ImplementsTLSAware` | type-assertion contract |
| `TestHTTP2Proxy_TLSEndToEnd` | h2-over-TLS at both legs, ALPN negotiation |
| `TestHTTP2Proxy_TLSRuleInjection` | rule fires through h2 + TLS |
| `TestHTTP2Proxy_PlaintextStillWorks` | h2c regression |
| `TestHTTP2Proxy_ImplementsTLSAware` | type-assertion contract |
| `TestEnsureProxyTLS_AppliedFlag` | manager flags TLS-aware vs plain plugins |

## Verification

- `go test ./...` — all 17 packages green
- `go vet ./...` — clean
- Cross-compile (linux/arm64) — green
- Lima `demo-container` — 4/4 PASS (regression check on the http path the demo uses)

Version: 0.12.23 → 0.12.24.

## Test plan

- [ ] CI: `go test ./...` green
- [ ] CI: cross-compile linux/arm64
- [ ] Manual: a customer spec with `interface("main", "http", 443, tls=tls_cert())` against an HTTPS upstream parses, the proxy terminates TLS, and `http.error(path=...)` rules still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)