### PR TITLE
RFC-038 Phase 3 (4/4): Redis plugin terminates TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,64 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.27] - 2026-05-02
+
+RFC-038 Phase 3 (4 of 4) — Redis plugin TLS migration. **Phase 3
+is now complete** for the four customer-priority plugins (http,
+http2, gRPC, Kafka, Redis). The remaining 10 plugins —
+postgres, mysql, mongodb, cassandra, clickhouse, memcached, nats,
+amqp, tcp, udp — are deferred to RFC-039 (separate follow-up RFC
+covering the SSLRequest-upgrade design and the protocols that
+need it).
+
+### Changed
+
+- **`redis` plugin migrated to TLSAware.** Redis 6+ supports TLS
+  via a separate `tls-port` config entry — no in-band SSL upgrade,
+  just "TLS from byte 1" on the configured port. Same wrap-and-dial
+  pattern as Kafka:
+  - Listener: `proxy.ListenTLS(serverTLS)` when set; plain
+    `Listen()` otherwise.
+  - Upstream: `proxy.Dial(ctx, target, clientTLS, 5s)` replaces
+    `net.DialTimeout`.
+  - Plaintext path runs unchanged — `redis_test.go`'s RESP3 corpus
+    keeps green.
+- **Coverage gate exemption dropped** for `redis.go`. The existing
+  `redis_test.go` (RESP3 HELLO map / set / attribute regression
+  suite from v0.12.15.x) already satisfied the #84 requirement;
+  the exemption was stale. Removed.
+
+### Tests
+
+4 new tests in `internal/proxy/redis_tls_test.go`:
+
+| Test | Covers |
+|---|---|
+| `TestRedisProxy_TLSEndToEnd` | RESP-over-TLS at both legs |
+| `TestRedisProxy_TLSRuleInjection` | key-glob error rule fires inside TLS tunnel |
+| `TestRedisProxy_PlaintextStillWorks` | plaintext regression |
+| `TestRedisProxy_ImplementsTLSAware` | type-assertion contract |
+
+### Phase 3 wrap-up
+
+Five plugins now terminate TLS at the proxy and / or dial upstream
+over TLS, covering the customer's three explicit gaps:
+- ✅ HTTPS responses (#2): http plugin
+- ✅ gRPC-TLS (#1): gRPC plugin (and http2 for HTTPS HTTP/2)
+- ✅ Kafka TLS: Kafka plugin (broker SSL listener)
+- ✅ Redis TLS: Redis plugin (`tls-port`)
+
+The customer's fourth implicit ask — TLS-Postgres / TLS-MySQL
+(#3) — remains gated on the SSLRequest-upgrade design and
+follows in RFC-039. Until then, declarations like
+`interface("db", "postgres", 5432, tls=...)` continue to emit
+the `proxy_tls_pending` warning.
+
+Full repo `go test ./... -race` green; cross-compile + Lima
+demo-container 4/4 PASS.
+
+Version 0.12.26 → 0.12.27.
+
 ## [0.12.26] - 2026-05-02
 
 RFC-038 Phase 3 (3 of 4) — Kafka plugin TLS migration. Brokers

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.26"
+var version = "0.12.27"
 
 func run() int {
 	args := os.Args[1:]

--- a/internal/proxy/coverage_test.go
+++ b/internal/proxy/coverage_test.go
@@ -77,7 +77,6 @@ var coverageExemptions = map[string]bool{
 	"http2.go":     true, // ditto
 	"memcached.go": true,
 	"nats.go":      true,
-	"redis.go":     true,
 	"udp.go":       true, // covered by clickhouse/cassandra adjacency tests; no dedicated udp passthrough yet
 }
 

--- a/internal/proxy/redis.go
+++ b/internal/proxy/redis.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand"
@@ -22,6 +23,13 @@ type redisProxy struct {
 	svcName  string
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
+
+	// RFC-038 Phase 3: TLS material. Redis 6+ supports TLS via a
+	// separate `tls-port` config entry — no in-band SSL upgrade,
+	// just "TLS from byte 1" on the configured port. So the
+	// wrap-and-dial pattern from http.go applies cleanly.
+	serverTLS *tls.Config
+	clientTLS *tls.Config
 }
 
 func newRedisProxy(onEvent OnProxyEvent, svcName string) *redisProxy {
@@ -33,10 +41,23 @@ func newRedisProxy(onEvent OnProxyEvent, svcName string) *redisProxy {
 
 func (p *redisProxy) Protocol() string { return "redis" }
 
+// SetTLS implements TLSAware. Must be called before Start.
+func (p *redisProxy) SetTLS(server, client *tls.Config) {
+	p.serverTLS = server
+	p.clientTLS = client
+}
+
 func (p *redisProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
 
-	ln, listenAddr, err := Listen()
+	var ln net.Listener
+	var listenAddr string
+	var err error
+	if p.serverTLS != nil {
+		ln, listenAddr, err = ListenTLS(p.serverTLS)
+	} else {
+		ln, listenAddr, err = Listen()
+	}
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
@@ -69,8 +90,10 @@ func (p *redisProxy) Start(ctx context.Context, target string) (string, error) {
 func (p *redisProxy) handleConn(ctx context.Context, clientConn net.Conn) {
 	defer clientConn.Close()
 
-	// Connect to real Redis.
-	serverConn, err := net.DialTimeout("tcp", p.target, 5*time.Second)
+	// proxy.Dial routes through tls.Client + HandshakeContext when
+	// clientTLS is set; otherwise it's net.DialTimeout. The 5s
+	// budget covers both the TCP connect and the TLS handshake.
+	serverConn, err := Dial(ctx, p.target, p.clientTLS, 5*time.Second)
 	if err != nil {
 		return
 	}

--- a/internal/proxy/redis_tls_test.go
+++ b/internal/proxy/redis_tls_test.go
@@ -1,0 +1,206 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// startFakeRedisTLS is the TLS variant of startFakeRedis from
+// redis_test.go. The upstream terminates TLS itself (matching how a
+// production Redis broker with `tls-port` works), and the proxy
+// has to dial it with proxy.Dial + clientCfg.
+func startFakeRedisTLS(t *testing.T, reply string) (string, *tls.Config, func()) {
+	t.Helper()
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("upstream cert: %v", err)
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				if _, err := readRESPArray(br); err != nil {
+					return
+				}
+				_, _ = c.Write([]byte(reply))
+			}(c)
+		}
+	}()
+	return ln.Addr().String(), cfg, func() { ln.Close() }
+}
+
+// TestRedisProxy_TLSEndToEnd — RFC-038 case for redis: client
+// speaks RESP-over-TLS to the proxy, proxy speaks RESP-over-TLS to
+// the upstream, plaintext command parsing keeps working in the
+// middle so key-glob / command rules still fire.
+func TestRedisProxy_TLSEndToEnd(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startFakeRedisTLS(t, "+OK\r\n")
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	p := newRedisProxy(nil, "cache")
+	p.SetTLS(serverCfg, clientCfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, err := p.Start(ctx, upstreamAddr)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	c, err := tls.Dial("tcp", proxyAddr, &tls.Config{
+		RootCAs:    clientPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.Write([]byte("*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n")); err != nil {
+		t.Fatalf("write SET: %v", err)
+	}
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(c)
+	got, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if !strings.HasPrefix(got, "+OK") {
+		t.Errorf("reply = %q, want +OK", got)
+	}
+}
+
+// TestRedisProxy_TLSRuleInjection — fault rule fires inside the TLS
+// tunnel. Customer's exact use case: TLS Redis upstream + key-glob
+// fault.
+func TestRedisProxy_TLSRuleInjection(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startFakeRedisTLS(t, "+OK\r\n")
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	var ruleHits int32
+	p := newRedisProxy(func(evt ProxyEvent) {
+		if evt.Action == "error" {
+			atomic.AddInt32(&ruleHits, 1)
+		}
+	}, "cache")
+	p.SetTLS(serverCfg, clientCfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, _ := p.Start(ctx, upstreamAddr)
+	defer p.Stop()
+
+	p.AddRule(Rule{
+		Command: "GET",
+		Key:     "session:*",
+		Action:  ActionError,
+		Error:   "ERR injected",
+	})
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	c, err := tls.Dial("tcp", proxyAddr, &tls.Config{
+		RootCAs:    clientPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := fmt.Fprintf(c, "*2\r\n$3\r\nGET\r\n$10\r\nsession:42\r\n"); err != nil {
+		t.Fatalf("write GET: %v", err)
+	}
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(c)
+	got, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if !strings.Contains(got, "injected") {
+		t.Errorf("reply = %q, want injected error", got)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if atomic.LoadInt32(&ruleHits) == 0 {
+		t.Errorf("expected at least one error event, got 0")
+	}
+}
+
+// TestRedisProxy_PlaintextStillWorks — regression check. Without
+// SetTLS the plugin retains pre-RFC-038 behavior verbatim. The
+// existing redis_test.go tests cover RESP correctness exhaustively;
+// this file pins the no-TLS-call code path that earlier tests
+// implicitly exercised.
+func TestRedisProxy_PlaintextStillWorks(t *testing.T) {
+	upstreamAddr, stop := startFakeRedis(t, "+OK\r\n")
+	defer stop()
+
+	p := newRedisProxy(nil, "cache")
+	// No SetTLS call.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, err := p.Start(ctx, upstreamAddr)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	c, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.Write([]byte("*1\r\n$4\r\nPING\r\n")); err != nil {
+		t.Fatalf("write PING: %v", err)
+	}
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(c)
+	got, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.HasPrefix(got, "+OK") {
+		t.Errorf("plaintext reply = %q, want +OK", got)
+	}
+}
+
+// TestRedisProxy_ImplementsTLSAware pins the contract.
+func TestRedisProxy_ImplementsTLSAware(t *testing.T) {
+	var _ TLSAware = (*redisProxy)(nil)
+}


### PR DESCRIPTION
## Summary

- **Phase 3 is now complete** for the customer-priority plugins (http, http2, gRPC, Kafka, Redis).
- Redis 6+ exposes TLS via separate `tls-port` — no in-band SSL upgrade — so the same wrap-and-dial pattern from Kafka applies cleanly.
- Drops the stale `redis.go` exemption from `coverageExemptions` (existing `redis_test.go` RESP3 corpus already covered the gate).

## What ships

`redis` plugin implements `TLSAware`. `SetTLS(server, client)` threads:
- **Listener**: `proxy.ListenTLS(serverTLS)` when set; plain `Listen()` otherwise.
- **Upstream**: `proxy.Dial(ctx, target, clientTLS, 5s)` replaces `net.DialTimeout`.
- Plaintext path unchanged — RESP3 HELLO map / set / attribute regression suite from v0.12.15.x keeps green.

## Tests

4 new tests in `internal/proxy/redis_tls_test.go`:

| Test | Covers |
|---|---|
| `TestRedisProxy_TLSEndToEnd` | RESP-over-TLS at both legs |
| `TestRedisProxy_TLSRuleInjection` | key-glob error rule fires inside TLS tunnel |
| `TestRedisProxy_PlaintextStillWorks` | plaintext regression |
| `TestRedisProxy_ImplementsTLSAware` | type-assertion contract |

## Phase 3 wrap-up

Five plugins now terminate TLS at the proxy and / or dial upstream over TLS, covering the customer's three explicit gaps:

- ✅ HTTPS responses (#2): http plugin (#101)
- ✅ gRPC-TLS (#1): gRPC plugin + http2 for HTTPS HTTP/2 (#101, #102)
- ✅ Kafka TLS: Kafka plugin (broker SSL listener) (#103)
- ✅ Redis TLS: Redis plugin (`tls-port`) (this PR)

The customer's fourth implicit ask — TLS-Postgres / TLS-MySQL (#3) — remains gated on the SSLRequest-upgrade design and follows in **RFC-039** (single follow-up RFC covering postgres / mysql / mongodb / cassandra / clickhouse / memcached / nats / amqp / tcp / udp).

Until RFC-039 lands, `interface("db", "postgres", 5432, tls=...)` continues to emit the `proxy_tls_pending` warning so customers know their declaration parsed but isn't actively wrapping the listener.

## Verification

- `go test ./... -race` — all 17 packages green
- `go vet ./...` — clean
- Cross-compile (linux/arm64) — green
- Lima `demo-container` — 4/4 PASS (regression check; demo doesn't use Redis directly)

Version: 0.12.26 → 0.12.27.

## Phase 3 progress

- [x] PR 1 — http + http2 (#101)
- [x] PR 2 — gRPC (#102)
- [x] PR 3 — Kafka (#103)
- [x] PR 4 — Redis (this PR)
- [ ] RFC-039 — postgres / mysql / mongodb / cassandra / clickhouse / memcached / nats / amqp / tcp / udp deferred

## Test plan

- [ ] CI: `go test ./...` green
- [ ] CI: cross-compile linux/arm64
- [ ] Manual: a customer spec with `interface("cache", "redis", 6380, tls=tls_cert(ca="..."))` against a TLS Redis upstream parses, the proxy terminates TLS, and `redis.error(key="session:*")` rules still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)