### PR TITLE
RFC-038 Phase 3 (5/4): generic TCP plugin terminates TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,61 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.12.28] - 2026-05-02
+
+RFC-038 Phase 3 (5 of 4) — generic TCP plugin TLS migration.
+A late addition: TCP is the long-tail escape hatch for any custom-
+protocol service that uses TLS but doesn't have a dedicated
+Faultbox plugin. Same wrap-and-dial pattern as kafka / redis;
+prefix-peek rule predicate (Rule.Method) still fires against the
+plaintext bytes between the two TLS legs.
+
+### Changed
+
+- **`tcp` plugin migrated to TLSAware.** `SetTLS(server, client)`:
+  - Listener: `proxy.ListenTLS(serverTLS)` when set; plain
+    `Listen()` otherwise.
+  - Upstream: `proxy.Dial(ctx, target, clientTLS, 5s)` replaces
+    `net.DialTimeout`.
+  - Plaintext path runs unchanged (existing TestTCPProxyPassThrough,
+    TestTCPProxyDropRule, TestTCPProxyRespondRule, TestTCPProxyPrefixMatch
+    keep green).
+- Added a small ctx-watcher goroutine that closes the listener on
+  ctx cancel. The pre-existing `*net.TCPListener` SetDeadline
+  trick in `acceptLoop` doesn't apply to the wrapped TLS listener
+  (`*tls.listener` is a private type), so without explicit close
+  Accept could leak past ctx cancellation. The watcher unblocks
+  Accept the moment ctx fires regardless of whether Stop() is also
+  called — matches the behavior of the SetDeadline polling loop.
+
+### Tests
+
+4 new tests in `internal/proxy/tcp_tls_test.go`:
+
+| Test | Covers |
+|---|---|
+| `TestTCPProxy_TLSEndToEnd` | client TLS → proxy → upstream TLS, byte-identity round trip |
+| `TestTCPProxy_TLSPrefixRuleStillFires` | prefix-match rule fires on plaintext between the two TLS legs |
+| `TestTCPProxy_PlaintextStillWorks` | plaintext regression (parallel guard to existing TestTCPProxyPassThrough) |
+| `TestTCPProxy_ImplementsTLSAware` | type-assertion contract |
+
+`TestEnsureProxyTLS_AppliedFlag` (added in #101) was probing
+`tcp` as the "plugin not migrated yet" exemplar; updated to use
+`amqp` instead so the false-path of the assertion stays exercised.
+
+### RFC-039 deferred set is now smaller
+
+Phase 3 deferred protocols left after this PR: postgres, mysql,
+mongodb, cassandra, clickhouse, memcached, nats, amqp, udp.
+Postgres/mysql still need the SSLRequest-upgrade design; the rest
+cluster around either the wrap-and-dial pattern (we know how) or
+no-meaningful-TLS (udp).
+
+Full repo `go test ./... -race` green; cross-compile + Lima
+demo-container 4/4 PASS.
+
+Version 0.12.27 → 0.12.28.
+
 ## [0.12.27] - 2026-05-02
 
 RFC-038 Phase 3 (4 of 4) — Redis plugin TLS migration. **Phase 3

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.12.27"
+var version = "0.12.28"
 
 func run() int {
 	args := os.Args[1:]

--- a/internal/proxy/http_tls_test.go
+++ b/internal/proxy/http_tls_test.go
@@ -402,12 +402,16 @@ func TestEnsureProxyTLS_AppliedFlag(t *testing.T) {
 		t.Errorf("http: expected tlsApplied=true")
 	}
 
-	// tcp: does NOT implement TLSAware → applied=false.
-	_, applied, err = mgr.EnsureProxyTLS(context.Background(), "svc", "tcp-iface", "tcp", mockLn.Addr().String(), serverCfg, nil)
+	// amqp: does NOT implement TLSAware → applied=false. (tcp is
+	// now migrated as of v0.12.28; pick an unmigrated plugin from
+	// the RFC-039 deferred set so the false-path of the assertion
+	// stays exercised. amqp will outlive http/http2/grpc/kafka/
+	// redis/tcp until its own TLS PR lands.)
+	_, applied, err = mgr.EnsureProxyTLS(context.Background(), "svc", "amqp-iface", "amqp", mockLn.Addr().String(), serverCfg, nil)
 	if err != nil {
-		t.Fatalf("tcp EnsureProxyTLS: %v", err)
+		t.Fatalf("amqp EnsureProxyTLS: %v", err)
 	}
 	if applied {
-		t.Errorf("tcp: expected tlsApplied=false (plugin not migrated yet)")
+		t.Errorf("amqp: expected tlsApplied=false (plugin not migrated yet)")
 	}
 }

--- a/internal/proxy/tcp.go
+++ b/internal/proxy/tcp.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand"
@@ -36,6 +37,14 @@ type tcpProxy struct {
 	svcName  string
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
+
+	// RFC-038 Phase 3: TLS material. The generic TCP plugin handles
+	// any "TLS from byte 1" service Faultbox doesn't have a dedicated
+	// plugin for — same wrap-and-dial pattern as kafka / redis. The
+	// prefix-peek rule predicate (Rule.Method) still fires against
+	// the plaintext bytes between the two TLS legs.
+	serverTLS *tls.Config
+	clientTLS *tls.Config
 }
 
 func newTCPProxy(onEvent OnProxyEvent, svcName string) *tcpProxy {
@@ -44,14 +53,37 @@ func newTCPProxy(onEvent OnProxyEvent, svcName string) *tcpProxy {
 
 func (p *tcpProxy) Protocol() string { return "tcp" }
 
+// SetTLS implements TLSAware. Must be called before Start.
+func (p *tcpProxy) SetTLS(server, client *tls.Config) {
+	p.serverTLS = server
+	p.clientTLS = client
+}
+
 func (p *tcpProxy) Start(ctx context.Context, target string) (string, error) {
 	p.target = target
-	ln, listenAddr, err := Listen()
+	var ln net.Listener
+	var listenAddr string
+	var err error
+	if p.serverTLS != nil {
+		ln, listenAddr, err = ListenTLS(p.serverTLS)
+	} else {
+		ln, listenAddr, err = Listen()
+	}
 	if err != nil {
 		return "", fmt.Errorf("listen: %w", err)
 	}
 	p.listener = ln
 	ctx, p.cancel = context.WithCancel(ctx)
+
+	// When the listener is TLS-wrapped (*tls.listener), the
+	// SetDeadline-on-TCPListener trick in acceptLoop doesn't apply —
+	// the type assertion fails silently. Close the listener on ctx
+	// cancel so Accept returns and the loop exits cleanly without
+	// relying on a Stop() call from the manager.
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
 
 	p.wg.Add(1)
 	go p.acceptLoop(ctx)
@@ -89,7 +121,10 @@ func (p *tcpProxy) handle(ctx context.Context, client net.Conn) {
 	defer p.wg.Done()
 	defer client.Close()
 
-	upstream, err := net.DialTimeout("tcp", p.target, 5*time.Second)
+	// proxy.Dial routes through tls.Client + HandshakeContext when
+	// clientTLS is set; otherwise it's net.DialTimeout. The 5s
+	// budget covers both the TCP connect and the TLS handshake.
+	upstream, err := Dial(ctx, p.target, p.clientTLS, 5*time.Second)
 	if err != nil {
 		return
 	}

--- a/internal/proxy/tcp_tls_test.go
+++ b/internal/proxy/tcp_tls_test.go
@@ -1,0 +1,192 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startTCPEchoTLS is a TLS-wrapped echo server. The proxy dials it
+// via proxy.Dial(clientCfg) and the test verifies the bytes survive
+// the round trip through both TLS legs. Returns (addr, srvCfg, stop).
+func startTCPEchoTLS(t *testing.T) (string, *tls.Config, func()) {
+	t.Helper()
+	cfg, err := GenerateSelfSignedCert(nil)
+	if err != nil {
+		t.Fatalf("upstream cert: %v", err)
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				io.Copy(c, c)
+			}()
+		}
+	}()
+	return ln.Addr().String(), cfg, func() { ln.Close() }
+}
+
+// TestTCPProxy_TLSEndToEnd — RFC-038 case for the generic TCP
+// plugin: client speaks TLS to the proxy, proxy speaks TLS to the
+// upstream, raw bytes survive the round trip in both directions.
+func TestTCPProxy_TLSEndToEnd(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startTCPEchoTLS(t)
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	p := newTCPProxy(nil, "custom")
+	p.SetTLS(serverCfg, clientCfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, err := p.Start(ctx, upstreamAddr)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	c, err := tls.Dial("tcp", proxyAddr, &tls.Config{
+		RootCAs:    clientPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer c.Close()
+
+	want := []byte("hello-tls-tunnel")
+	if _, err := c.Write(want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len(want))
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(c, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("byte-identity broken: got %q, want %q", got, want)
+	}
+}
+
+// TestTCPProxy_TLSPrefixRuleStillFires — the headline value of TLS
+// for the generic TCP plugin: prefix-based rules see plaintext
+// between the two TLS legs and fire as if there were no encryption.
+func TestTCPProxy_TLSPrefixRuleStillFires(t *testing.T) {
+	upstreamAddr, upstreamCfg, stop := startTCPEchoTLS(t)
+	defer stop()
+
+	upstreamLeaf, _ := x509.ParseCertificate(upstreamCfg.Certificates[0].Certificate[0])
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamLeaf)
+	clientCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+	serverCfg, _ := GenerateSelfSignedCert(nil)
+
+	p := newTCPProxy(nil, "custom")
+	p.SetTLS(serverCfg, clientCfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, _ := p.Start(ctx, upstreamAddr)
+	defer p.Stop()
+
+	// Respond rule keyed on a byte prefix the client will send.
+	// Plaintext match against the TLS-decoded bytes.
+	p.AddRule(Rule{
+		Method: "BANNED",
+		Action: ActionRespond,
+		Body:   "BLOCKED",
+	})
+
+	leaf, _ := x509.ParseCertificate(serverCfg.Certificates[0].Certificate[0])
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(leaf)
+	c, err := tls.Dial("tcp", proxyAddr, &tls.Config{
+		RootCAs:    clientPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer c.Close()
+
+	c.Write([]byte("BANNED-payload"))
+	got := make([]byte, 7)
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(c, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "BLOCKED") {
+		t.Errorf("rule did not fire: got %q", got)
+	}
+}
+
+// TestTCPProxy_PlaintextStillWorks — regression check. Without
+// SetTLS the plugin retains pre-RFC-038 behavior verbatim. The
+// existing TestTCPProxyPassThrough already covers this; we add a
+// second test here to keep the TLS-vs-plain contrast explicit in
+// the same file.
+func TestTCPProxy_PlaintextStillWorks(t *testing.T) {
+	srv, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer srv.Close()
+	go func() {
+		c, _ := srv.Accept()
+		if c == nil {
+			return
+		}
+		defer c.Close()
+		io.Copy(c, c)
+	}()
+
+	p := newTCPProxy(nil, "custom")
+	// No SetTLS call.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyAddr, err := p.Start(ctx, srv.Addr().String())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	c, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	want := []byte("ping-plain")
+	c.Write(want)
+	got := make([]byte, len(want))
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(c, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("plaintext byte-identity broken: %q", got)
+	}
+}
+
+// TestTCPProxy_ImplementsTLSAware pins the contract.
+func TestTCPProxy_ImplementsTLSAware(t *testing.T) {
+	var _ TLSAware = (*tcpProxy)(nil)
+}


### PR DESCRIPTION
## Summary

- Late addition to Phase 3 — the TCP plugin is the long-tail escape hatch for any custom-protocol service that uses TLS but doesn't have a dedicated Faultbox plugin.
- Same wrap-and-dial pattern as Kafka / Redis. Prefix-peek rule predicate (`Rule.Method`) still fires against the plaintext bytes between the two TLS legs.
- Updates the `TestEnsureProxyTLS_AppliedFlag` test from #101 to use `amqp` as the "not migrated yet" exemplar (since `tcp` is now migrated).

## What ships

`tcp` plugin implements `TLSAware`. `SetTLS(server, client)` threads:
- **Listener**: `proxy.ListenTLS(serverTLS)` when set; plain `Listen()` otherwise.
- **Upstream**: `proxy.Dial(ctx, target, clientTLS, 5s)` replaces `net.DialTimeout`.
- Plaintext path runs unchanged.

Also adds a small ctx-watcher goroutine that closes the listener on ctx cancel. The pre-existing `*net.TCPListener` SetDeadline trick in `acceptLoop` doesn't apply to the wrapped TLS listener (`*tls.listener` is a private type), so without explicit close `Accept` could leak past ctx cancellation.

## Tests

4 new tests in `internal/proxy/tcp_tls_test.go`:

| Test | Covers |
|---|---|
| `TestTCPProxy_TLSEndToEnd` | client TLS → proxy → upstream TLS, byte-identity round trip |
| `TestTCPProxy_TLSPrefixRuleStillFires` | prefix-match rule fires on plaintext between the two TLS legs |
| `TestTCPProxy_PlaintextStillWorks` | plaintext regression (parallel guard to existing tests) |
| `TestTCPProxy_ImplementsTLSAware` | type-assertion contract |

`TestEnsureProxyTLS_AppliedFlag` updated to use `amqp` as the unmigrated exemplar (was `tcp` before this PR).

## Verification

- `go test ./... -race` — all 17 packages green
- `go vet ./...` — clean
- Cross-compile (linux/arm64) — green
- Lima `demo-container` — 4/4 PASS (**important** regression check; demo postgres uses `interface("main", "tcp", 5432)` which routes through the TCP plugin)

Version: 0.12.27 → 0.12.28.

## RFC-039 deferred set is now smaller

After this PR: postgres, mysql, mongodb, cassandra, clickhouse, memcached, nats, amqp, udp. Postgres/mysql still need the SSLRequest-upgrade design; the rest cluster around either the wrap-and-dial pattern (we know how) or no-meaningful-TLS (udp).

## Test plan

- [ ] CI: `go test ./...` green
- [ ] CI: cross-compile linux/arm64
- [ ] Manual: a customer spec with `interface("custom", "tcp", 9999, tls=tls_cert(ca="..."))` against a TLS-only custom upstream parses, the proxy terminates TLS, and prefix-match rules still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)