### PR TITLE
feat: RFC-043 Non-deterministic Operators (rc1, v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,22 @@ and probability fan-out (§8.9) are deferred to rc2; their flags
 reserved in rc1 with clear "future release" errors so CI integrations
 stay stable. User guide: [docs/exploration.md](docs/exploration.md).
 
-RFC-043 (non-deterministic operators) and RFC-044 (spec-language
-simplification) remain draft RFCs tracked in GitHub issues #112–#113.
+**RFC-043 — non-deterministic operators (rc1).** Four small
+Starlark primitives shipped: `choose([opts])` / `choose("name", [opts])`
+for finite N-way choice, `nondet()` for the non-deterministic boolean
+(sugar for `choose([True, False])`; the pre-existing `nondet(svc)`
+variant for interleaving-control exemption keeps working unchanged),
+`halt(reason="")` for plan-tree branch pruning with a new `"halted"`
+outcome flowing through `SuiteResult`, bundle manifest, and the HTML
+report, and `assume(predicate)` / `test(assume=[...])` for plan-tree
+filtering. rc1 ships the language surface with single-leaf runtime
+semantics — each operator returns the first option / first leaf;
+full plan-tree fan-out and the AST sandbox for assume predicates
+land with rc2 alongside RFC-042 §8.8. User guide:
+[docs/nondeterministic-operators.md](docs/nondeterministic-operators.md).
+
+RFC-044 (spec-language simplification) remains a draft RFC tracked
+in GitHub issue #113.
 RFC-046 carries the post-L1 roadmap (gVisor Path B/C, L4 hermetic
 mode, L5 instruction-boundary research).
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ make demo
 | [Determinism Levels](docs/determinism.md) | L0–L5 taxonomy, the L1 contract, escape hatches (RFC-040) |
 | [Temporal Properties](docs/temporal.md) | `eventually` / `always` / `monitor` / `await_*` / `test()` (RFC-041) |
 | [Plan & Coverage](docs/exploration.md) | `faultbox plan`, `plan.json`, coverage, suggestions (RFC-042) |
+| [Non-deterministic Operators](docs/nondeterministic-operators.md) | `choose()` / `nondet()` / `halt()` / `assume()` (RFC-043) |
 
 ### Tutorial Structure
 

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -2263,6 +2263,12 @@ func testRowsFromResult(result *star.SuiteResult) []bundle.TestRow {
 			// built on the bundle manifest don't misread a stall as
 			// success.
 			outcome = "inconclusive"
+		case "halted":
+			// RFC-043 §5.3 — body called halt(); plan-tree pruning
+			// signal, not a real verdict. Distinct outcome value so
+			// the report can grey-pill the row without inflating
+			// pass/fail counters.
+			outcome = "halted"
 		default:
 			if tr.FaultBypassed {
 				outcome = "fault_bypassed"

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -502,13 +502,17 @@ func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, n
 		}
 	}
 
-	// Print summary. Inconclusive count is appended only when >0 so
-	// the line stays unchanged for pre-RFC-041 specs.
+	// Print summary. Inconclusive (RFC-041) and Halted (RFC-043) counts
+	// are appended only when >0 so the line stays unchanged for specs
+	// that don't use either feature.
+	summary := fmt.Sprintf("\n%d passed, %d failed", result.Pass, result.Fail)
 	if result.Inconclusive > 0 {
-		fmt.Fprintf(os.Stderr, "\n%d passed, %d failed, %d inconclusive\n", result.Pass, result.Fail, result.Inconclusive)
-	} else {
-		fmt.Fprintf(os.Stderr, "\n%d passed, %d failed\n", result.Pass, result.Fail)
+		summary += fmt.Sprintf(", %d inconclusive", result.Inconclusive)
 	}
+	if result.Halted > 0 {
+		summary += fmt.Sprintf(", %d halted", result.Halted)
+	}
+	fmt.Fprintln(os.Stderr, summary)
 
 	// Terminal replay hint per failed test (RFC-025 §Observability).
 	// Makes `replay_command` visible without digging into JSON. Skipped

--- a/docs/design/2026-04-22-customer-feedback-analysis.md
+++ b/docs/design/2026-04-22-customer-feedback-analysis.md
@@ -1,0 +1,498 @@
+# inDrive / truck-api PoC — Feedback Analysis & 0.9.x / 0.11.0 Roadmap
+
+**Authored:** 2026-04-22
+**Inputs:** [FAULTBOX_FEEDBACK.md](FAULTBOX_FEEDBACK.md), [FAULTBOX_REPRODUCIBILITY.md](FAULTBOX_REPRODUCIBILITY.md), [TEST_COVERAGE.md](TEST_COVERAGE.md)
+**Validated against:** v0.9.6 (current main)
+**Scope per owner:** finish the asks in the feedback docs in the 0.9.x
+train; cap with **v0.11.0 Reports** (rich HTML artifact per run). **No
+big features** outside the reports or the Reports story.
+
+---
+
+## 0. Executive summary
+
+The customer found 16 real bugs and ranks the core product unique ("the
+seccomp user-notify approach is the reason the PoC was worth doing") but
+says it isn't shippable yet because of three systemic gaps — **gRPC
+proxy on the data path, Linux CI, and docs.** Two of those are
+already substantially closed on current main:
+
+| Customer ask | Status on main | Delta |
+|---|---|---|
+| Native gRPC mocks | **Shipped** (RFC-023, v0.9.0) | Tutorial Ch 18 exists |
+| Proxy on SUT data path | **Shipped** (RFC-024, v0.9.5 + v0.9.6) | Container mode + TCP + benchmarks done |
+| Per-gRPC-method fault targeting | **Shipped** via `error(method="/pkg/Method")` at proxy layer | Needs better surfacing in docs |
+| `fault_assumption` dispatch + `ops=` filter + `fault_zero_traffic` | **Shipped** (v0.9.4) | Customer knows |
+
+The **remaining** asks cluster into five groups:
+
+1. **Documentation overhaul** (customer lost ~47h / 20% of engagement to docs gaps).
+2. **Small missing primitives** — `load_file()`, JWT/JWKS, richer expectations, gRPC error shorthands.
+3. **Reproducibility-by-default** — artifacts dir, replay_command surfacing, version/digest pinning.
+4. **CI / deployment ergonomics** — Linux CI recipe, service-binary rebuild, healthcheck types.
+5. **Processes / commercial** — API stability promise, roadmap visibility, reference customer.
+
+Effort/Profit summary below. **Recommended release sequence:**
+
+- **v0.9.7** — `.fb` archive bundle format (every run → one self-contained file), replay on failure, seed default. Load-time validation.
+- **v0.9.8** — Small primitives: `load_file()`, JWT/JWKS, `expect_*`.
+- **v0.9.9** — Documentation overhaul + CI-on-Linux recipe + Starlark reference.
+- **v0.10.0** — Determinism guardrails (digest pinning, version mismatch detection, `faultbox replay <bundle>`).
+- **v0.11.0** — **Interactive HTML Reports** consumed from a `.fb` bundle (shareable static artifact, SaaS-neutral).
+
+Each release builds on the previous; v0.11.0 is the capstone that
+turns the reproducibility and determinism work into something users
+actually look at.
+
+---
+
+## 1. Validation — what's already shipped vs the reports
+
+The customer reports were written on v0.9.4. Current main is v0.9.6. This
+table catches items the customer may not know are already closed.
+
+| # | Customer ask | Report §ref | Status on v0.9.6 | Evidence |
+|---|---|---|---|---|
+| 1 | Native gRPC mock | FB §3 row 1 | ✅ Shipped v0.9.0 | RFC-023, `@faultbox/mocks/grpc.star`, tutorial Ch 18 |
+| 2 | Proxy on SUT data path | FB §3 row 2 | ✅ Shipped v0.9.5+6 | RFC-024, `preStartProxies`, `host.docker.internal` |
+| 3 | Per-gRPC-method targeting | FB §3 row 3 | ✅ Shipped (surfacing gap) | `error(method="/pkg/Method")` at proxy layer |
+| 4 | `fault_assumption(rules=)` in matrix | FB §2.1 #4 | ✅ Shipped v0.9.4 | Customer-reported fix #1 |
+| 5 | Custom `ops=` in seccomp filter | FB §2.1 #3 | ✅ Shipped v0.9.4 | Customer-reported fix #2 |
+| 6 | `fault_zero_traffic` signal | FB §2.1 | ✅ Shipped v0.9.4 | Customer-reported fix #3 |
+| 7 | `--seed` / `--output json` / `replay_command` | Repro §3.3 | ✅ Exists — opt-in only | `cmd/faultbox/main.go:225`, `results.go:56` |
+| 8 | `--runs N --show fail` | Repro §3.3 | ✅ Exists | `cmd/faultbox/main.go:220` |
+| 9 | HTTP healthcheck | FB §2.1 #5 | ✅ Exists (gap: docker-proxy timing) | `builtins.go` `http()` healthcheck |
+| 10 | OpenAPI mock generation | (not in reports) | ✅ Shipped v0.9.3 | RFC-021 — bonus for any HTTP consumer |
+| 11 | `grpc_error(code, message)` builder | FB §5 row 10 | ✅ Exists (no shorthand) | `grpc_error("UNAVAILABLE", "...")` |
+
+**Customer-to-do:** they're still on v0.9.4. Upgrading to v0.9.6 closes
+three of the top-10 blockers they filed. Every future conversation with
+them should lead with "you already have this."
+
+---
+
+## 2. Grouped analysis
+
+Each row has: **ask** (what they want), **status** (what exists on main),
+**gap** (what's left to do), **E** = effort (XS<½d, S=½–1d, M=2–3d, L=1w,
+XL=2w+), **P** = profit 1–5, and a **SaaS-vision alignment** note.
+
+### Group A — Documentation
+
+The single biggest lever. Customer lost ~47h to doc gaps out of a
+~240h engagement; they've explicitly said "documentation that lets a
+non-expert engineer onboard a new service in under one day" is a **hard
+blocker** for payment (FB §6.1 #3).
+
+| # | Ask | Status | Gap | E | P | SaaS align |
+|---|---|---|---|---|---|---|
+| A1 | End-to-end tutorial: Go + gRPC + Kafka + MySQL + Redis + JWT | Partial (Ch 17 covers JWT; Ch 18 typed gRPC; nothing ties full stack together) | Write one composite chapter | M | 5 | Onboarding → SaaS trial conversion |
+| A2 | Primitive reference: every kwarg documented | `spec-language.md` exists; some kwargs (`config=`, `depends_on=`) thin | Complete audit + backfill | M | 4 | Self-serve onboarding |
+| A3 | Starlark dialect reference (no file I/O, no regex, kw-only args) | Missing as a standalone page | One-page "Starlark in Faultbox" | S | 4 | Reduces "why doesn't this work" tickets |
+| A4 | Seccomp cheatsheet (Go stdlib op → syscall names) | Missing | Short tables per stdlib area (net, os, io) | S | 4 | Makes named-ops authoring obvious |
+| A5 | Troubleshooting playbook per failure class | Missing | One page, ~10 common failure modes | S | 5 | Deflects support load |
+| A6 | Lima-on-Mac supported-path docs | Fragments exist; not a coherent story | Dedicated setup guide | S | 3 | Blocks Mac onboarding today |
+| A7 | CI-on-Linux recipe (GitHub Actions, BuildKite) | Missing | Template + documented privilege requirements (seccomp, ptrace_scope) | M | 5 | **Hard blocker** for any customer paying |
+| A8 | JWT/JWKS worked example (claim names, key formats) | Fragment in Ch 17 | Expand to runnable example | S | 3 | Every auth-gated service |
+| A9 | Customer-visible roadmap | Missing (RFCs are public but not grouped by release) | Curated `ROADMAP.md` | XS | 4 | Trust-building for paid conversion |
+
+**Group A totals:** ~8 PMd of effort, addresses the customer's
+#1 hard blocker. Cheapest large lever in this whole list.
+
+### Group B — Small primitives
+
+None of these are big features. All are 1–3d each and each closes a
+named customer gap.
+
+| # | Ask | Status | Gap | E | P | SaaS align |
+|---|---|---|---|---|---|---|
+| B1 | `load_file("seed.sql")` Starlark builtin | Missing (Go-level `LoadFile` exists, not exposed) | New builtin; read-only, path relative to .star | S | 5 | Unlocks every DB/fixture scenario |
+| B2 | `load_yaml()` / `load_json()` | Missing | Natural siblings of B1 | S | 4 | OpenAPI, config fixtures |
+| B3 | `jwks_mock(keys=, claims=)` primitive | Partial (examples only) | Curated stdlib mock wrapping existing `mock_service` + signing | S | 4 | Every auth-protected service |
+| B4 | `expect_success()`, `expect_error_within(ms)`, `expect_hang()` | Missing (`assert_eventually` exists but isn't this) | New assertion builders keyed to scenario outcome | M | 5 | Fault-matrix readability |
+| B5 | `expect_retry_budget(n)` | Missing | Higher-order primitive; counts retry attempts in trace | M | 3 | Customer-named; maps to prod SLO language |
+| B6 | `grpc_unavailable()` / `grpc_deadline_exceeded()` shorthands | Partial (use `grpc_error("UNAVAILABLE", …)`) | Stdlib helpers in `@faultbox/mocks/grpc.star` | XS | 3 | Ergonomics; drops a line of boilerplate |
+| B7 | HTTP healthcheck richness (`service_ready(http_probe=…, expect_status=…)`) | Partial (`http()` healthcheck exists) | Document + extend to path/body matchers | S | 3 | Avoids docker-proxy false-ready (FB §2.1 #5) |
+| B8 | Undocumented kwarg = spec-load parse error | Partial (some kwargs error, others silently ignored) | Audit every builtin for strict kwarg validation | S | 4 | Kills whole class of "spec passed, nothing ran" |
+
+**Group B totals:** ~7 PMd. Each is a dopamine hit for the customer
+because they named them specifically. Shipping all eight is a strong
+signal that we read the report carefully.
+
+### Group C — Reproducibility & `.fb` archive bundle
+
+Customer wrote a whole dedicated 1800-word doc on this. Positioned as
+"the single biggest gap between PoC and production quality gate."
+
+**Design decision (owner, 2026-04-22):** instead of an auto `artifacts/`
+directory, every `faultbox test` run emits a **single `.fb` archive
+bundle** — tar.gz with a fixed internal layout. One file per run,
+emailable, check-in-able, the canonical input to `faultbox report`
+(Group G). Every downstream tool (replay, reports) takes a `.fb` as
+its sole input.
+
+Bundle layout (contract):
+
+```
+run-<timestamp>-<seed>.fb  (tar.gz)
+├── manifest.json          # schema version, test list, summary
+├── trace.json             # full event log w/ vector clocks (today's --output format)
+├── env.json               # Faultbox version, Go toolchain, kernel, Docker, image digests
+├── replay.sh              # one-liner that reproduces this run
+└── services/
+    ├── <svc-a>.stdout
+    ├── <svc-a>.stderr
+    └── <svc-b>.stdout …
+```
+
+| # | Ask | Status | Gap | E | P |
+|---|---|---|---|---|---|
+| C1 | `.fb` bundle always emitted — trace + stdout/stderr + env.json + replay.sh | Missing | New archive format, always-on | M | 5 |
+| C2 | Print `replay_command` at end of every failed test | Missing (in JSON only) | One-line addition in stderr summary | XS | 5 |
+| C3 | Default `--seed` recorded in manifest.json, reused on rerun | Partial | Seed persisted in bundle; `faultbox replay` picks it up | S | 4 |
+| C4 | Image digest auto-pinning (`faultbox.lock`) | Missing | First resolve records digest; warn if tag target changes | M | 4 |
+| C5 | Version-mismatch warning vs `.faultbox-version` | Missing | Emit warning at test start if tool version ≠ declared | XS | 3 |
+| C6 | Go toolchain / kernel / Docker version in env.json | Missing | Bundled with C1 | XS | 3 |
+| C7 | pprof on timeout/hang → `services/<svc>.goroutines.txt` in bundle | Missing | Bundle auto-captures on timeout | M | 3 |
+| C8 | Panic capture (GOTRACEBACK=crash) → in stdout/stderr | Missing | Default env on binary services | XS | 3 |
+| C9 | Optional `--capture-pcap` → `services/<svc>.pcap` in bundle | Missing | `tcpdump` sidecar per interface | M | 2 |
+| C10 | `faultbox replay <bundle.fb>` subcommand | Missing | Single command re-runs from a bundle | M | 4 |
+| C11 | `fault_zero_traffic` in default stderr output | Partial (JSON only) | Also print to terminal at test end | XS | 4 |
+| C12 | `faultbox inspect <bundle.fb>` — list contents / extract individual files | Missing | Mirror of `tar -tf` specialised for `.fb` | S | 3 |
+
+**Group C totals:** ~7 PMd. Centred on one artifact contract. Every
+downstream tool (replay, report, aggregation) consumes `.fb` and
+nothing else — single interface to evolve.
+
+**Explicit non-goal:** no SaaS-/cloud-specific concerns in this group.
+`.fb` lives on local disk; uploading it to S3 or rendering it in a
+hosted dashboard is a 1.x concern. The bundle is just a file.
+
+### Group D — CI / deployment ergonomics
+
+| # | Ask | Status | Gap | E | P | SaaS align |
+|---|---|---|---|---|---|---|
+| D1 | Linux CI recipe (GitHub Actions) | Missing | Docs + template workflow with privilege requirements | M | 5 | **Hard blocker** — FB §6.1 #2 |
+| D2 | Linux CI recipe (BuildKite) | Missing | Docs | S | 3 | Customer-named for their stack |
+| D3 | Privilege requirements docs (`seccomp`, `ptrace_scope`, rootless) | Missing | One-page ops guide | S | 4 | Required to even write D1/D2 |
+| D4 | `service(binary=…)` auto-rebuild on source change | Missing | `go build` watch or hash-diff | M | 3 | Developer ergonomics; currently manual |
+| D5 | Offline build / GOMODCACHE support | Partial | Document + verify | S | 2 | CI ergonomics |
+
+**Group D totals:** ~4 PMd. D1+D3 is the hardest blocker (§6.1 #2).
+
+### Group E — Processes & commercial
+
+Softer work but customer explicitly called these out as payment
+blockers (FB §6).
+
+| # | Ask | Gap | E | P | SaaS align |
+|---|---|---|---|---|---|
+| E1 | API stability promise across 2 minor versions | Write and publish policy | XS | 4 | Trust foundation for commercial |
+| E2 | Public roadmap | Convert RFC README into release-grouped roadmap | XS | 4 | Precondition for customer planning |
+| E3 | Reference customer (public or NDA) | Sales process; not an engineering task | — | — | Usually precedes first paid customer |
+| E4 | Support SLA in writing | Legal / commercial | — | — | Required for contract |
+| E5 | Case-study writeup of inDrive v0.9.4 turnaround | Marketing; 1d to co-author w/ customer | S | 4 | Strong GTM artifact |
+
+### Group G — v0.11.0 Interactive HTML Reports
+
+Inspired by the customer's own [TEST_COVERAGE.md](TEST_COVERAGE.md): a
+matrix view of "what got tested, with what faults, how it went" is the
+single highest-leverage artifact they produced on their side — and it
+was all hand-written. v0.11.0 ships this as a machine-generated HTML
+from the `.fb` bundle.
+
+**Contract:** `faultbox report <bundle.fb>` → `report.html`. Self-
+contained (all JS/CSS/data inlined), no server calls, shareable by
+email/Slack/published as a static asset. Inspired by R-Studio
+notebooks (single `.Rmd` → single `.html`).
+
+**What the report shows:**
+
+| Section | Data source (from bundle) | Visual |
+|---|---|---|
+| Summary dashboard | `manifest.json` aggregate | Pass/fail/error counts, duration histogram, seed, env fingerprint |
+| **Fault matrix** | fault_matrix test names + outcomes in `trace.json` | Scenarios × faults grid with colour-coded cells (green/red/yellow/grey-not-run) — the shape of TEST_COVERAGE.md §4 |
+| Observed coverage | `trace.json` event log | Per-service: # tests touching it · which syscalls were faulted · which proxy rules fired · `fault_zero_traffic` warnings |
+| Per-test drill-down | Click row → detail panel | Faults applied, assertions, duration, link to trace viewer |
+| Reproducibility panel | `env.json` + `replay.sh` | Versions + digests + "Copy replay.sh" button |
+| Coverage gaps | — | **Not prescriptive** — report shows what WAS tested; what SHOULD be tested is authored by the user in their `.star` specs |
+
+**Shiviz integration:** separated sidecar (owner-decided). Per-test
+trace view is rendered by Shiviz (MIT-licensed, vendored) via vector
+clocks already present in the event log. v0.11.0 Phase 2 ships this as
+an **experiment** — separate `trace-<test>.html` files linked from the
+main report rather than inlined. Graduates to main report if it proves
+valuable.
+
+**Technical approach:** three source files, no frontend build step.
+
+```
+internal/report/
+├── template.html       # shell: <div id="app"></div>
+├── app.js              # vanilla JS: router, matrix, drill-down
+├── style.css           # Golang-web aesthetic (match existing site)
+├── shiviz/             # vendored MIT sidecar (Phase 2)
+└── build.go            # go:embed + inline data injection
+```
+
+Output is a single HTML file with `window.__FAULTBOX__ = {…bundle data…}`
+inlined. All interactivity is client-side JS operating on that object.
+
+| # | Ask | Status | Gap | E | P |
+|---|---|---|---|---|---|
+| G1 | `faultbox report <bundle.fb>` subcommand | Missing | New subcommand + Go HTML builder | M | 5 |
+| G2 | Fault matrix grid (scenarios × faults × outcome) | Missing | React-less UI; reads from trace.json | M | 5 |
+| G3 | Per-test drill-down panel | Missing | Click-to-expand from matrix | M | 4 |
+| G4 | Shiviz sidecar per failed test | Missing | Vendor + converter from `Event.VectorClock` → Shiviz log format | L | 4 |
+| G5 | Observed-coverage view (services × syscalls × proxy hits) | Missing | Aggregated from event log | M | 4 |
+| G6 | Reproducibility panel w/ replay.sh button | Missing | Inline env.json, one-click copy | S | 3 |
+| G7 | Aggregate multi-bundle mode (`faultbox report --aggregate a.fb b.fb …`) | Missing | Diff view across runs — **local only**, not SaaS | M | 3 |
+| G8 | Tutorial chapter + spec docs | Missing | Part of v0.11.0 release | S | 3 |
+
+**Group G totals:** ~3 weeks of work for v0.11.0 — the natural capstone
+after the `.fb` bundle contract (v0.9.7) and `faultbox replay` (v0.10.0)
+are in place.
+
+**Explicit non-goals for v0.11.0:**
+
+- **No server/cloud/SaaS code.** Bundle and report are local artifacts.
+  A hosted-runner offering is 1.x territory.
+- **Report does not prescribe coverage.** The user decides what to
+  test in their `.star` specs; the report visualises what happened.
+- **Report does not call external services.** No telemetry, no auth,
+  no network. The HTML opens in any browser offline.
+
+### Group F — Out-of-scope for 0.9.x (per owner)
+
+The following are in the feedback but fit the "new big features" bucket
+the owner said to skip. Flagging here so we don't lose them:
+
+- SaaS-hosted runner (FB §6.3 #8) → 1.x scope.
+- DevPlatform integration (FB §6.3 #9).
+- Spec templates / library per stack shape (FB §6.3 #10).
+- Clock skew / DNS chaos / packet-level chaos (Repro §5 matrix).
+- cgroup OOM / memory-pressure primitives (Repro §5).
+- Crash-recovery primitives (SIGKILL mid-commit) (Repro §5).
+- `race` detector integration (Repro §5).
+- Fuzzer × matrix (Repro §5).
+
+---
+
+## 3. Effort / Profit synthesis
+
+Plotting (E, P) for every actionable item:
+
+| Priority | Items | Why here |
+|---|---|---|
+| **Do first (P≥4, E≤S)** | C2, C5, C8, C11, E1, E2, B6 | Trivial to ship, pays back immediately |
+| **Core 0.9.x batch (P≥4, E=M)** | A1, A2, A5, A7, B1, B4, C1, C3, C10, D1, D3 | Medium work, high leverage |
+| **Second wave (P=3, any E)** | B2, B3, B5, B7, B8, C7, D4, E5 | Worth shipping; sequence after first two |
+| **Defer / low return** | B9, C9, D5 | Small audience or high cost |
+
+The **P≥4 / E≤S** quadrant alone has 7 items and together would take
+~4 PMd to ship. That's the single cheapest morale+trust move.
+
+---
+
+## 4. Proposed 0.9.x sequencing
+
+Kept to the owner's rule — **no features outside the reports**, closing
+named gaps only. Each release is ~1 week scope.
+
+### v0.9.7 — ".fb bundle + reproducibility-by-default"
+
+Targets Group C P≥4 items + cheap wins from A and E.
+
+- C1: `.fb` archive bundle emitted on every run — trace.json + env.json + per-service stdout/stderr + replay.sh (M)
+- C2: print `replay_command` on every failed test (XS)
+- C11: emit `fault_zero_traffic` to stderr too (XS)
+- C5: version-mismatch warning vs `.faultbox-version` (XS)
+- C8: `GOTRACEBACK=crash` default for binary services (XS)
+- C12: `faultbox inspect <bundle.fb>` subcommand (S)
+- B8: strict kwarg validation — undocumented kwarg = spec-load error (S)
+- E1: publish API stability policy (XS, docs only)
+- E2: curate RFC README into `ROADMAP.md` grouped by release (XS, docs only)
+
+**Total:** ~4 PMd. Lands the bundle contract that v0.10.0 replay and
+v0.11.0 reports both consume. Customer-facing story: "every run drops a
+single `.fb` file you can email to a colleague or check into git."
+
+### v0.9.8 — "Small missing primitives"
+
+Targets Group B.
+
+- B1: `load_file()` Starlark builtin (S)
+- B2: `load_yaml()` / `load_json()` (S)
+- B3: `jwks_mock()` stdlib primitive in `@faultbox/mocks/jwt.star` (S)
+- B4: `expect_success()` / `expect_error_within(ms)` / `expect_hang()` (M)
+- B6: `grpc.unavailable()` / `grpc.deadline_exceeded()` helpers (XS)
+- C3: default-recorded `--seed` between runs (S)
+
+**Total:** ~4 PMd. Ships the "I asked for these specifically" list.
+Customer sees every one of their P0 primitives land together.
+
+### v0.9.9 — "Documentation + Linux CI"
+
+Targets Group A and D1/D3 — the **payment blockers** per §6.1.
+
+- A7: Linux CI recipe (GitHub Actions template, privilege docs) (M)
+- D3: privilege requirements guide (S)
+- A1: end-to-end tutorial (Go + gRPC + Kafka + MySQL + Redis + JWT) (M)
+- A2: primitive reference audit + backfill (M)
+- A3: Starlark dialect reference (S)
+- A4: seccomp cheatsheet (S)
+- A5: troubleshooting playbook (S)
+
+**Total:** ~6 PMd, mostly writing. Once this lands we can in good
+conscience stop saying "docs are thin" in sales conversations.
+
+### v0.10.0 — "Determinism guardrails"
+
+Targets Group C P≤4, finishing the reproducibility story.
+
+- C4: image-digest auto-pinning + `faultbox.lock` (M)
+- C6: Go toolchain / kernel version in env.json (XS, bundled)
+- C7: pprof-on-timeout → captured into bundle `services/<svc>.goroutines.txt` (M)
+- C10: `faultbox replay <bundle.fb>` subcommand (M)
+- D4: binary auto-rebuild (M)
+
+**Total:** ~5 PMd. Closes every P≥3 ask in the reports; the `.fb`
+bundle format is now the stable contract for v0.11.0 to build on.
+
+### v0.11.0 — "Interactive HTML Reports"
+
+All of Group G. New subcommand `faultbox report <bundle.fb>` produces
+a single-file `report.html` with everything inlined — matrix view,
+per-test drill-down, observed coverage, replay button. Shiviz trace
+viewer ships as a separate sidecar experiment.
+
+- G1: `faultbox report <bundle.fb>` subcommand + shell HTML skeleton (M)
+- G2: fault matrix grid UI (M)
+- G3: per-test drill-down panel (M)
+- G5: observed-coverage view (M)
+- G6: reproducibility panel (S)
+- G4: Shiviz sidecar pages per failed test (L — Phase 2)
+- G7: `--aggregate` multi-bundle mode (M)
+- G8: tutorial chapter + docs (S)
+
+**Total:** ~3 weeks. Customer-facing story: "every `faultbox test` run
+produces a bundle AND a self-contained HTML report you can drop into
+Slack or publish as a static site." Local only; SaaS/cloud is not in
+this release.
+
+---
+
+## 5. Proposed RFCs to draft
+
+The larger items warrant RFCs so the customer can comment before we
+ship (they explicitly asked for this — FB §7 #1):
+
+1. **RFC-025: `.fb` Bundle Format + Reproducibility Contract.** Covers
+   C1 + C2 + C6 + C8 + C11 + C12. Defines the archive layout, manifest
+   schema, and guarantees. Customer is the primary reviewer. Target:
+   v0.9.7. **Precondition for RFC-029.**
+2. **RFC-026: Starlark Module System — `load_file` and friends.**
+   Covers B1 + B2. Needs design work because introducing file I/O to
+   Starlark has security implications (path traversal, SSRF via
+   `http://` paths). Target: v0.9.8.
+3. **RFC-027: Matrix Expectation Language.** Covers B4 + B5. Ships a
+   small DSL of outcome predicates so fault_matrix rows carry explicit
+   pass/fail semantics. Target: v0.9.8.
+4. **RFC-028: Self-Hosted CI Recipes.** Covers A7 + D1 + D3. Docs-heavy;
+   might not need a full RFC — could be a design doc. Target: v0.9.9.
+5. **RFC-029: Interactive HTML Reports.** Covers all of Group G. Shell
+   HTML + vanilla JS + inlined `.fb` data; Shiviz vendored as a
+   separate sidecar experiment. Depends on RFC-025 (`.fb` format) and
+   RFC-027 (expect_* outcomes drive matrix colours). Target: v0.11.0.
+
+No RFC for the docs work (A1–A5) or the commercial items (E1–E5); those
+are execution.
+
+---
+
+## 6. SaaS vision alignment — by design, not by code
+
+Owner decision (2026-04-22): **v0.9.x through v0.11.0 ship local-only
+code.** No cloud, no hosted runner, no multi-tenant. What makes the
+future SaaS possible without changing v0.11.0 is the **artifact
+contract**:
+
+- The **`.fb` bundle** is an addressable, portable, self-describing
+  object. Whether it lives at `./run-*.fb` or
+  `s3://faultbox/<org>/<project>/<run>.fb` is a deployment concern,
+  not a code concern. The archive is the same bytes.
+- The **`report.html`** opens from disk or from a URL identically.
+  Publishing a CI-built report as a GitHub Pages static asset is
+  "copy this file"; same for a future hosted dashboard — "serve this
+  file."
+- **`faultbox replay <bundle.fb>`** takes a path or URL (trivial
+  extension later). The CLI flow and any future web-UI flow share
+  the verb.
+
+So SaaS alignment in the 0.9.x/0.11.0 train is a **design discipline,
+not a feature set**: every new tool operates on one `.fb` file, every
+rendering step produces one self-contained HTML, no hidden network
+dependencies anywhere. If and when we ship a hosted offering, the
+bundle is what it stores and the HTML is what it renders.
+
+**Not in scope for this train:** web UI, billing, multi-tenant auth,
+hosted runners, cross-org sharing, access controls. Those are 1.x.
+
+---
+
+## 7. Resolved decisions
+
+Owner-decided 2026-04-22, baked into RFCs.
+
+1. **Artifact format: single `.fb` tar.gz bundle per run**, not a
+   directory. Default location `./` (cwd). Filename
+   `run-<timestamp>-<seed>.fb`. `.gitignore` convention documented in
+   RFC-025. Supersedes the earlier "artifacts/ directory" proposal.
+2. **Report is local-only.** No SaaS, no cloud, no network calls in
+   v0.11.0. The HTML opens offline in any browser. Hosted-runner
+   offerings are a 1.x concern and do not affect the v0.11.0 report
+   shape — the same `.fb` bundle is the atomic object either way.
+3. **Coverage is observed, not prescribed.** The report shows what was
+   tested and how. Users author intent in their `.star` specs; we do
+   not ship a coverage-intent DSL in v0.11.0.
+4. **Shiviz is a separate sidecar experiment.** Per-failed-test trace
+   viewer ships as a stand-alone HTML page linked from the main
+   report. If the experiment succeeds we can promote to an inline
+   panel in v0.12.x; if it falls flat we retire it cheaply.
+5. **Interactive, no server calls.** Constraint on v0.11.0: the report
+   must work when saved to disk, emailed, or published as a static
+   asset. All state is inline; all interactivity is client-side JS.
+6. **`.fb` bundle is the one input contract.** `faultbox report`,
+   `faultbox replay`, `faultbox inspect`, and any future tool operate
+   on exactly one `.fb` file. This is the interface that insulates us
+   from later refactors — we can change the internal archive layout
+   as long as tools keep reading via a versioned manifest.
+
+Still to decide (not blocking v0.9.7):
+
+- **`.faultbox-version` file format** — string vs constraint. Punt
+  until v0.10.0 determinism work; prototype with a plain string.
+- **`load_file` security model** — detailed in RFC-026 draft.
+- **`expect_*` scope (row vs global)** — RFC-027 will go with per-row
+  override on a `default_expect` (pytest parametrize shape).
+- **Case-study writeup timing (E5)** — after v0.9.9 so the narrative
+  spans hotfix → follow-ups → docs → reports.
+
+---
+
+## 8. What we will **not** do in 0.9.x
+
+Per owner instruction ("don't do new big features which not mentioned
+in the reports"), the following — even though they are in the reports
+— are deferred to 1.x:
+
+- Any SaaS-native feature (hosted runner, dashboard, multi-tenant auth).
+- DevPlatform integration.
+- Chaos primitives not currently present: DNS / clock-skew /
+  packet-reorder / cgroup-OOM / mid-transaction SIGKILL.
+- `race` detector integration.
+- Fuzzer × fault-matrix.
+- Kafka rebalance modeling.
+
+Everything in §4 above closes named gaps without introducing a new
+feature category.

--- a/docs/feature-manifest.md
+++ b/docs/feature-manifest.md
@@ -94,6 +94,9 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 | Rule-based `--suggest` for uncovered edges (RFC-042 §8.5) | 2 | `internal/plan/coverage_test.go` (TestWriteSuggestions_*) + `cmd/faultbox/plan_test.go` (TestPlanCmd_SuggestEmitsStubs) | 🟢 | Conservative per-protocol syscall picks; copy-pasteable fault_assumption + fault_scenario stubs; `--strategy=llm` reserved for v0.14.0 |
 | `--check-cost --max-instances N` gate (RFC-042 §8.6) | 2 | `cmd/faultbox/plan_test.go` (TestPlanCmd_CheckCost*) | 🟢 | Exit code 2 when budget exceeded; pre-commit / CI integration |
 | Report Plan tab (RFC-042 §8.10) | 2 | `internal/report/report_test.go` (TestGatherDataIncludesPlanWhenPresent, TestGatherDataOmitsPlanWhenAbsent) | 🟢 | Self-contained HTML render of the plan tree + embedded coverage table; reads `plan.json` from the bundle |
+| `choose([opts])` + `nondet()` (RFC-043 §5.1, §5.2) | 2 | `internal/star/choose_test.go` (arity, empty/non-list rejection, named form, recording, existing nondet(svc) variant) | 🟢 | rc1 single-leaf: returns first option deterministically; ChoiceVal recorded on rt.choices for rc2 plan-tree fan-out |
+| `halt(reason="")` + halted outcome (RFC-043 §5.3) | 2 | `internal/star/halt_test.go` (sentinel, reason, kwarg/arity rejection, top-level rejection, setup rejection, RunTest path) | 🟢 | New SuiteResult.Halted counter + bundle.Summary.Halted + HTML "halted" outcome (grey pill, distinct from pass/fail/inconclusive) |
+| `assume(predicate)` + `test(assume=)` (RFC-043 §5.4) | 2 | `internal/star/assume_test.go` (top-level true/false, lambda choices inspection, type/arity rejection, per-test halt + pass, predicate raise, unnamed-choice skip) | 🟢 | rc1: spec-load evaluation for top-level, body-entry evaluation for per-test; runs in a tagged sandbox starlark.Thread |
 
 ### DX and outputs — Supported / Experimental (proposed)
 

--- a/docs/nondeterministic-operators.md
+++ b/docs/nondeterministic-operators.md
@@ -1,0 +1,137 @@
+# Non-deterministic Operators
+
+> RFC-043's four operators — `choose()`, `nondet()`, `halt()`, `assume()` — give Faultbox specs the vocabulary P-lang and TLA+ have used for decades to describe a *space of behaviors*. v0.13.0-rc1 ships the **language surface** and the **runtime semantics for the single-leaf case**; rc2 alongside RFC-042 §8.8/§8.9 wires the **plan-tree fan-out** so each operator produces multiple test runs as designed.
+
+## Why these primitives
+
+`fault_matrix`, `wait_all` interleavings, and `probability=` are each specialized expressions of one underlying concept: *the spec describes non-determinism, the plan engine enumerates the worlds*. RFC-043 names the concept directly with four small builtins:
+
+| Operator | What it expresses |
+|---|---|
+| `choose([opts])` / `choose("name", [opts])` | Finite N-way choice. One world per option. |
+| `nondet()` | Sugar for `choose([True, False])`. Non-deterministic boolean. |
+| `halt()` | Prune the current branch. Body stops; outcome `"halted"`, not pass/fail. |
+| `assume(predicate)` | Filter the plan tree. Branches where the predicate is false are pruned. |
+
+Existing fan-out primitives stay — `fault_matrix` and friends keep working unchanged. The new operators sit alongside them; RFC-044 will eventually unify the engine machinery.
+
+## `choose(options)` / `choose(name, options)`
+
+```python
+# Positional form — the choice is anonymous; report labels it by call site.
+retries = choose([0, 1, 3])
+api.create_order_with_retries(retries)
+
+# Named form — name appears in plan.json and the report so assume()
+# predicates and dashboards can refer to it.
+retries = choose("retries", [0, 1, 3])
+
+# Choice over service references (top-level — runs at spec load).
+target = choose([primary_db, replica_db])
+fault(target.main, deny=on(connect=True))
+```
+
+**rc1 semantics:** returns the **first option** at runtime. `plan.json` records the call site and the option set. rc2's body-re-execution will run the body once per option and return the per-leaf selection.
+
+**Constraints:**
+- `options` must be a non-empty list literal. Empty lists are rejected at spec load.
+- Runtime-computed elements (e.g. `choose([api.list_targets()])`) error because Starlark evaluates eagerly — the inner call fires at spec load before reaching `choose()`.
+
+**Subsumes `param(name, choices=...)` from RFC-013** — RFC-044 withdraws `param`; `choose("name", [values])` is the replacement.
+
+## `nondet()`
+
+```python
+def body():
+    if nondet():
+        api.path_a()
+    else:
+        api.path_b()
+```
+
+Sugar for `choose([True, False])`. rc1 returns `True` (the first option) at runtime; rc2 fans out 2 leaves.
+
+> **Naming note:** P-lang uses bare `$` as the non-deterministic-boolean operator. Starlark's lexer cannot parse `$`, and forking `go.starlark.net` for one character isn't worth the maintenance cost. `nondet()` is the canonical spelling.
+
+> **Variadic form preserved:** `nondet(svc1, svc2, ...)` continues to mean *"exempt these services from interleaving control during `parallel()`"* (the pre-RFC-043 behavior). The two forms are distinguished by argument count. RFC-044 may revisit the unification.
+
+## `halt()`
+
+```python
+def body():
+    retries = choose([0, 1, 3])
+    if retries == 0 and nondet():
+        halt("invalid combo")      # this leaf is pruned
+    api.run_workflow(retries=retries)
+```
+
+`halt()` terminates the current plan-tree branch. Body execution stops at the call site; the test outcome is `"halted"`, which is **distinct from pass / fail / inconclusive**:
+
+- Suite-level `SuiteResult.Halted` counter
+- Bundle manifest `summary.halted`
+- HTML report row rendered with a grey pill (same palette as `fault_bypassed`)
+
+**Constraints:**
+- `halt()` is rejected outside a test body. Calls at module top-level or inside `setup=` error at spec load with *"halt() may only be called inside a test body."*
+- An optional string reason is rendered in the trace/report.
+
+## `assume(predicate)` and `test(assume=[...])`
+
+```python
+# Spec-wide constraint — evaluated at spec load.
+assume(lambda choices: choices.get("retries", 0) < 5)
+
+# Per-test constraint — evaluated at body entry.
+test("ordered_check",
+    body = body,
+    assume = [
+        lambda choices: choices["retries"] != 0 or choices["fault"] != "timeout",
+    ],
+)
+```
+
+The predicate receives a `choices` dict mapping each named `choose("name", opts)` call to its currently-selected option. Unnamed `choose()` calls are not visible to `assume` predicates.
+
+**rc1 semantics:**
+- Top-level `assume(False)` (or a lambda returning false) **fails spec load** with `"assume(...) violated at spec load."`
+- Per-test `assume=` predicates **halt the test** (outcome `"halted"`) on the first failure.
+- A predicate that raises a Starlark error (e.g. dict KeyError on a missing choice) **fails the test**.
+
+**rc2** will defer evaluation to per-leaf and prune the plan tree instead of erroring at load.
+
+**Predicates run in a sandbox starlark.Thread** (tagged `"assume:<name>"`). rc2 will add a full AST walk that rejects predicates referencing services, faults, or other runtime state — same model as RFC-041's monitor `update`/`check` sandbox.
+
+## Composition example
+
+```python
+db = service("db", image = "busybox", cmd = ["sh","-c","sleep 1"])
+
+def scenario():
+    retries = choose("retries", [0, 1, 3])
+    fault   = choose("fault",   ["503", "504", "timeout"])
+    if retries == 0 and fault == "timeout":
+        halt("nothing to retry — uninteresting branch")
+    api.run_workflow(retries=retries, expected_fault=fault)
+
+test("matrix", body=scenario, assume=[
+    lambda choices: choices["retries"] < 5,
+])
+```
+
+At rc1 this runs once (single leaf — first options): `retries=0, fault="503"`, no halt, no assume violation. At rc2 it fans out to `3 × 3 = 9` leaves minus halted (`retries=0, fault="timeout"`) and assume-pruned branches.
+
+## Out of scope (deferred)
+
+- **Body re-execution / plan-tree fan-out** — rc2 alongside RFC-042 §8.8.
+- **Weighted `choose([opts], weights=...)`** — probability-driven sampling. Not in v0.13.0.
+- **Symbolic / parametric ranges** — `choose(range(0, MAX_INT))` needs SAT/SMT; indefinitely deferred.
+- **Mazurkiewicz-trace independence** (RFC-009) and **DPOR** (RFC-010) — both operate on the unified plan tree this RFC's operators feed into.
+- **Full assume-predicate AST sandbox** — rc2 alongside §8.7 (today predicates run in a tagged sandbox thread but the spec-load AST walk lands later).
+
+## References
+
+- RFC-043 — Non-deterministic Spec Operators (`docs/rfcs/0043-nondeterministic-operators.md`).
+- RFC-042 — Exploration Plan & Coverage Engine. The plan-tree machinery these operators will fan out into.
+- RFC-041 — Temporal Properties. `test()` declaration that gains the `assume=` kwarg here.
+- RFC-040 — Determinism Levels. L0 plan determinism makes plan-tree enumeration coherent across runs.
+- RFC-044 — Spec Language Simplification. Will withdraw `param()` and unify the fan-out machinery.

--- a/docs/nondeterministic-operators.md
+++ b/docs/nondeterministic-operators.md
@@ -72,7 +72,8 @@ def body():
 - HTML report row rendered with a grey pill (same palette as `fault_bypassed`)
 
 **Constraints:**
-- `halt()` is rejected outside a test body. Calls at module top-level or inside `setup=` error at spec load with *"halt() may only be called inside a test body."*
+- `halt()` is rejected outside a test body. Module-top-level calls error at spec load. Calls inside `setup=` are rejected at run time (before the body starts; the test is recorded as `"fail"`) with the same message: *"halt() may only be called inside a test body."*
+- `halt()` inside a monitor `check=` / `update=` lambda is also unsupported — `inTest` is set during a test, so the call is reached, but the `*HaltError` propagates as a monitor violation (`Result="fail"`, reason `"monitor violation: halt"`). Treat this as an opaque error; use `assume()` to filter unwanted branches instead.
 - An optional string reason is rendered in the trace/report.
 
 ## `assume(predicate)` and `test(assume=[...])`
@@ -92,6 +93,8 @@ test("ordered_check",
 
 The predicate receives a `choices` dict mapping each named `choose("name", opts)` call to its currently-selected option. Unnamed `choose()` calls are not visible to `assume` predicates.
 
+> **rc1 visibility:** Per-test `assume=` predicates run **before the body** starts, so they only see choices recorded at spec load (top-level `choose(...)` calls). Choices made *inside the body* are recorded after the predicate has already executed and therefore are absent from `choices`. A predicate referencing a body-only key gets a `KeyError` → `Result="fail"`. rc2's per-leaf evaluation makes body-time choices visible.
+
 **rc1 semantics:**
 - Top-level `assume(False)` (or a lambda returning false) **fails spec load** with `"assume(...) violated at spec load."`
 - Per-test `assume=` predicates **halt the test** (outcome `"halted"`) on the first failure.
@@ -99,7 +102,7 @@ The predicate receives a `choices` dict mapping each named `choose("name", opts)
 
 **rc2** will defer evaluation to per-leaf and prune the plan tree instead of erroring at load.
 
-**Predicates run in a sandbox starlark.Thread** (tagged `"assume:<name>"`). rc2 will add a full AST walk that rejects predicates referencing services, faults, or other runtime state — same model as RFC-041's monitor `update`/`check` sandbox.
+**rc1 sandbox status:** predicates execute on a thread tagged `"assume:<name>"`, but **no builtin denylist is yet enforced** — a predicate today can call `fault()`, `service()`, `halt()`, or any runtime builtin. The AST-walk denylist (the same model as RFC-041's monitor `update`/`check` sandbox) lands in rc2 alongside §8.7. Treat predicates as pure functions of `choices` until then.
 
 ## Composition example
 

--- a/docs/rfcs/0043-nondeterministic-operators.md
+++ b/docs/rfcs/0043-nondeterministic-operators.md
@@ -1,6 +1,6 @@
 # RFC-043: Non-deterministic Spec Operators
 
-> **Status: Draft.** Part of the v0.13.0 epic. Builds on RFC-040 (Determinism Levels) — non-determinism in the spec language only makes sense once we can name what the engine *does* with it. Pairs with RFC-042 (Exploration Plan) which defines the plan-tree machinery this RFC's operators feed into. Subject to RFC-044 (Simplification) — `param()` from RFC-013 will be subsumed by `choose()` defined here.
+> **Status: Implemented (rc1, v0.13.0).** Language surface (§8.1–§8.4, §8.6 partial, §8.8) shipped: `choose()`, `nondet()`, `halt()`, `assume()` are available as Starlark builtins; halt() outside a test body is rejected. rc1 single-leaf semantics — operators return the first option / first leaf; full plan-tree fan-out (§8.5, §8.7 AST sandbox, §8.6 cost-guard) lands with rc2 alongside RFC-042 §8.8. User guide: [docs/nondeterministic-operators.md](../nondeterministic-operators.md).
 
 ## Summary
 
@@ -422,15 +422,15 @@ Per the #84 coverage gate. Goldens for representative scenarios:
 
 | Phase | Scope | Target |
 |-------|-------|--------|
-| 8.1 `nondet()` | Builtin sugar over `choose([True, False])` | v0.13.0-rc1 |
-| 8.2 `choose` | Builtin with one- and two-arity forms | v0.13.0-rc1 |
-| 8.3 `halt` | Body builtin marking current leaf halted | v0.13.0-rc1 |
-| 8.4 `assume` | Top-level builtin + `test(assume=)` kwarg | v0.13.0-rc1 |
-| 8.5 Plan-tree integration | Hook into RFC-042's NonDeterministicChoice | v0.13.0-rc2 |
-| 8.6 Spec-load checks | Static validation per Section 5.8 | v0.13.0-rc2 |
-| 8.7 Restricted sandbox for `assume` | Like monitor predicates (RFC-041) | v0.13.0-rc2 |
-| 8.8 Docs | `docs/nondeterministic-operators.md`, spec-language, manifest, tutorial | v0.13.0-rc2 |
-| 8.9 Tests | Goldens + unit tests + #84 coverage | v0.13.0-rc2 |
+| 8.1 `nondet()` | Builtin sugar over `choose([True, False])` (overloaded against existing `nondet(svc)` form) | ✅ landed (v0.13.0-rc1) |
+| 8.2 `choose` | Builtin with one- and two-arity forms; ChoiceVal value type; rc1 returns first option | ✅ landed (v0.13.0-rc1) |
+| 8.3 `halt` | Body builtin marking current leaf halted; SuiteResult.Halted + bundle outcome | ✅ landed (v0.13.0-rc1) |
+| 8.4 `assume` | Top-level builtin + `test(assume=)` kwarg; sandboxed evaluation thread | ✅ landed (v0.13.0-rc1) |
+| 8.5 Plan-tree integration | Hook into RFC-042's NonDeterministicChoice | 🟡 deferred to rc2 (single-leaf in rc1) |
+| 8.6 Spec-load checks | Static validation per Section 5.8 | 🟡 partial in rc1 (halt() outside body rejected); rest defer to rc2 |
+| 8.7 Restricted sandbox for `assume` | AST walk like monitor predicates (RFC-041) | 🟡 deferred to rc2 (predicates run in tagged thread today; AST walk later) |
+| 8.8 Docs | `docs/nondeterministic-operators.md`, spec-language, manifest | ✅ landed (v0.13.0-rc1; tutorial chapter with rc2) |
+| 8.9 Tests | Unit tests under #84 coverage | ✅ landed (v0.13.0-rc1; testops goldens with rc2 alongside fan-out) |
 | Independence-relation refinement (out of this RFC) | Collapse equivalent branches | RFC-009 |
 | DPOR (out of this RFC) | Runtime branch pruning | RFC-010 |
 | Weighted `choose` (out of this RFC) | `weights=` kwarg | Future, demand-driven |

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -2171,19 +2171,69 @@ faultbox test faultbox.star --explore=sample           # 100 random orderings
 faultbox test faultbox.star --seed 42                  # replay exact ordering
 ```
 
-### `nondet(service, ...)`
+### `nondet(service, ...)` / `nondet()`
 
-Excludes one or more services from interleaving control during `parallel()`.
-Their syscalls proceed immediately without being held. Use this for services
-that make nondeterministic background requests (healthchecks, metrics, logging).
+Two arities:
+
+- `nondet(svc1, svc2, ...)` — excludes services from interleaving
+  control during `parallel()`. Their syscalls proceed immediately
+  without being held. Use this for services that make
+  nondeterministic background requests (healthchecks, metrics).
+
+  ```python
+  def test_concurrent_orders():
+      nondet(monitoring_svc, cache_svc)  # exclude from ordering exploration
+      results = parallel(
+          lambda: orders.post(path="/orders", body='...'),
+          lambda: orders.post(path="/orders", body='...'),
+      )
+  ```
+
+- `nondet()` (zero-arg) — RFC-043 §5.1 non-deterministic boolean.
+  Sugar for `choose([True, False])`. rc1 returns the first option
+  (`True`); rc2 fans the plan tree into two leaves.
+
+### `choose(options)` / `choose(name, options)` (v0.13.0)
+
+Finite non-deterministic choice (RFC-043 §5.2). Returns the first
+option in rc1; the plan tree records the call site and option set so
+rc2 can produce one leaf per option.
 
 ```python
-def test_concurrent_orders():
-    nondet(monitoring_svc, cache_svc)  # exclude from ordering exploration
-    results = parallel(
-        lambda: orders.post(path="/orders", body='...'),
-        lambda: orders.post(path="/orders", body='...'),
-    )
+retries = choose([0, 1, 3])              # anonymous
+retries = choose("retries", [0, 1, 3])   # named — visible to assume()
+```
+
+See [docs/nondeterministic-operators.md](nondeterministic-operators.md).
+
+### `halt(reason="")` (v0.13.0)
+
+Prune the current plan-tree branch (RFC-043 §5.3). Body execution
+stops; the test outcome is `"halted"` — distinct from
+pass/fail/inconclusive. Only valid inside a test body.
+
+```python
+def body():
+    retries = choose([0, 1, 3])
+    if retries == 0 and nondet():
+        halt("uninteresting branch")
+    api.run_workflow(retries=retries)
+```
+
+### `assume(predicate)` (v0.13.0)
+
+Filter the plan tree (RFC-043 §5.4). Top-level form evaluates at
+spec load; the `test(assume=[...])` kwarg evaluates per-test at body
+entry. Predicate receives a `choices` dict mapping each named
+`choose("name", opts)` call to its currently-selected option.
+
+```python
+assume(lambda choices: choices["retries"] < 5)
+
+test("guarded",
+    body = body,
+    assume = [lambda choices: choices["fault"] != "timeout"],
+)
 ```
 
 ---

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -1388,6 +1388,8 @@ outcomes in `manifest.json` and the HTML report:
 | `expectation_violated` | amber | Body assertions were clean, but the expect predicate disagreed with the result. |
 | `fault_bypassed` | grey | Scenario returned cleanly, but a fault rule was installed and never matched a syscall (only with `require_faults_fire=True`). |
 | `errored` | grey | Scenario raised an untyped error (crash, timeout outside a predicate). |
+| `halted` | grey | RFC-043 `halt()` or `assume=` predicate pruned this branch. No verdict — counted separately from pass/fail. |
+| `inconclusive` | grey | RFC-041 `eventually()` window timed out (or an `await_*` hit its timeout) without producing a verdict. Exit code 3. |
 
 `expectation_violated` is a refinement of `failed` — legacy consumers
 that only know the three-way taxonomy still see the row in the

--- a/docs/use-cases/gamedev.md
+++ b/docs/use-cases/gamedev.md
@@ -1,0 +1,192 @@
+# Gamedev — multiplayer backends, anti-cheat, MMORPG live ops
+
+A multiplayer game is one of the most asymmetric distributed systems in the
+industry. The hot path runs at 30-60Hz over custom UDP. Around it sits a
+backend zoo — matchmaker, auth, leaderboards, persistent world, anti-cheat,
+player store, social, telemetry — every one of which can ruin a session if it
+misbehaves. Engineers running these backends need to know what happens when
+the matchmaker gets slow, when the anti-cheat backend disappears mid-match,
+when Postgres drops a write at the moment a raid loot drops.
+
+Faultbox is for the engineers who own that backend zoo. The hot-path engine
+traffic is a separate problem; everything that surrounds it is microservices
+and message queues, which is exactly what Faultbox already faults.
+
+## What goes wrong (and why integration tests don't catch it)
+
+- The **anti-cheat backend** is a third-party HTTPS service that's mostly up.
+  When it isn't, your game's behaviour is one of two: fail-open (let the
+  player play, log the gap) or fail-closed (kick the player, lose them to
+  the lobby). Integration tests don't exercise this path because the
+  vendor's sandbox doesn't expose "be down" as a mode.
+- **Cross-shard trades and instance migrations** depend on multiple stateful
+  services being available simultaneously. Network partitions inside the
+  cluster turn a 200ms RPC into a 30s hang. The retry/circuit-breaker code
+  was written but rarely fires, so when it does, it doesn't.
+- **Persistent-world writes** during high-value events (raid loot, PvP
+  rating updates, IAP completion) need to survive `EIO`, `ENOSPC`, and
+  partial writes. No integration test induces those.
+- **Auth / JWKS rotation** breaks every session that fetches a JWT during
+  the rotation window. The bug looks like "every player got logged out at
+  03:14 last Tuesday."
+- **Matchmaker degradation** under load isn't itself a Faultbox question
+  (load testers handle that), but matchmaker behaviour when its *upstream*
+  player-rating service is slow is — and that's where the real outages
+  start.
+
+## How Faultbox helps
+
+| Need | Primitive | Read |
+|---|---|---|
+| Real cluster pods (k8s) without distributing dep images | `service(remote=...)` | [Spec language — Remote Services](/docs/reference/spec-language#remote-services) |
+| Anti-cheat / store / billing HTTPS upstream faults | `tls=tls_cert(...)` + `error()` on the interface | [TLS upstreams](/docs/guides/connectivity#tls-upstreams-rfc-038) |
+| Network partitions across game-server replicas | `partition()` | [Tutorial 16 — Partitions](/docs/tutorial/04-safety/16-partitions) |
+| Persistent-world write failures (`EIO`, `ENOSPC`, partial) | syscall `write=deny()` / `pwrite=delay()` | [Tutorial 03 — Fault injection](/docs/tutorial/02-syscall-level/03-fault-injection) |
+| Auth / JWKS mocks for offline tests | `@faultbox/mocks/jwt.star` | [Tutorial 21 — JWT mocks](/docs/tutorial/05-advanced/21-jwt-mocks) |
+| Reproduce production incidents from any machine | `.fb` bundles + `faultbox replay` | [Tutorial 20 — Bundles](/docs/tutorial/05-advanced/20-bundles) |
+| Verify retry / circuit-breaker / timeout code fires | `assert_eventually()` / `assert_never()` | [Tutorial 14 — Invariants](/docs/tutorial/04-safety/14-invariants) |
+
+## A real scenario — anti-cheat fail-open under unreachable telemetry
+
+The single most security-critical decision in a multiplayer-game backend:
+what happens when the anti-cheat vendor's telemetry endpoint is unreachable?
+A 60-second outage shouldn't ban every player; a permanent outage shouldn't
+let a cheat engine play unchallenged. Both extremes are real bugs.
+
+The spec below stands up the SUT (`game-api`) against a real Postgres + Redis
+in containers, points at a TLS-required anti-cheat backend (using
+[`remote=`](/docs/reference/spec-language#remote-services) so the test runs
+against a staging endpoint, not a mock), and asserts the documented
+fail-open semantic: when the backend is unreachable, the player connects
+with `fair_play_verified=false` and the audit event lands in Kafka.
+
+```python
+load("@faultbox/discovery/k8s.star", "k8s")
+load("@faultbox/recipes/postgres.star", "postgres")
+
+# Anti-cheat backend lives in the customer's k8s dev cluster (or via
+# Telepresence connect from the dev laptop). RFC-036 lets us point at it
+# without distributing the image.
+anti_cheat = service("anti-cheat",
+    interface("public", "http", 443,
+        tls = tls_cert(insecure = True),  # accept self-signed cluster cert
+    ),
+    remote      = k8s.service("anti-cheat", namespace = "staging"),
+    healthcheck = tcp(k8s.endpoint("anti-cheat", 443, namespace = "staging")),
+)
+
+db = service("db",
+    interface("main", "postgres", 5432),
+    image       = "postgres:16-alpine",
+    env         = {"POSTGRES_PASSWORD": "test", "POSTGRES_DB": "game"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+cache = service("cache",
+    interface("main", "redis", 6379),
+    image       = "redis:7-alpine",
+    healthcheck = tcp("localhost:6379"),
+)
+
+api = service("game-api",
+    interface("public", "http", 8080),
+    image       = "game-api:dev",
+    depends_on  = [db, cache, anti_cheat],
+    env         = {
+        "ANTI_CHEAT_URL": "https://%s/v1/verify" % anti_cheat.public.addr,
+        "DB_URL":         "postgres://postgres:test@%s/game" % db.main.addr,
+        "REDIS_URL":      "redis://%s" % cache.main.addr,
+    },
+    healthcheck = http("localhost:8080/healthz"),
+)
+
+# Audit event source: the game-api stamps every join attempt with the
+# anti-cheat decision. We tail Kafka to verify those events land.
+events_topic = topic("audit.player_joined", brokers = ["kafka:9092"])
+
+# --- Failure modes worth testing ---
+
+ac_unreachable = fault_assumption("anti_cheat_unreachable",
+    target = anti_cheat.public,
+    rules  = [error(path = "/v1/verify", status = 503)],
+)
+
+ac_slow = fault_assumption("anti_cheat_slow",
+    target = anti_cheat.public,
+    rules  = [slow(path = "/v1/verify", delay = "5s")],
+)
+
+# --- Scenario ---
+
+def player_joins_match():
+    resp = api.public.post(path = "/v1/match/join", body = {
+        "player_id": "test-player-001",
+        "match_id":  "match-42",
+    })
+    return resp
+
+# --- Oracle ---
+# The fail-open contract: under anti-cheat-unreachable, the join still
+# succeeds, the response carries fair_play_verified=false, and the audit
+# event lands in Kafka so the security team can see it later.
+
+fault_matrix(
+    scenarios = [scenario("join", run = player_joins_match)],
+    faults    = [ac_unreachable, ac_slow],
+    expect    = lambda result: (
+        assert_eq(result.status, 200, "join must succeed when anti-cheat is down"),
+        assert_eq(result.json()["fair_play_verified"], False,
+                  "fair_play flag must reflect the gap"),
+        assert_eventually(
+            events()
+                .where(source = "audit.player_joined")
+                .where_field("anti_cheat_status", "unreachable")
+                .count() >= 1,
+            timeout = "3s",
+        ),
+    ),
+)
+```
+
+Run it:
+
+```sh
+$ telepresence connect                # one-time, gives the laptop cluster DNS
+$ faultbox test game-api.star
+
+scenario=join × fault=anti_cheat_unreachable     PASS  812ms
+scenario=join × fault=anti_cheat_slow            PASS  6.1s
+scenario=join × fault=(none)                     PASS  142ms
+
+3/3 passed
+Bundle: run-2026-05-03T09-14-22-3326879141550591551.fb
+```
+
+The bundle replays bit-equivalent on any other engineer's machine, so when
+QA finds an oracle mismatch in CI, you get the exact byte-level failure
+artifact instead of a stack trace screenshot.
+
+## More scenarios this shape covers
+
+- **Cross-shard trade rollback** — `partition()` between two `game-server`
+  containers, inject `error()` on the trade-completion gRPC mid-flight,
+  assert both sides agree on the rollback state.
+- **Save-game write failures** — `write=deny("ENOSPC")` on the persistence
+  service during a raid completion, verify the loot ends up in the correct
+  state (granted-and-recovered, not lost-and-charged).
+- **JWKS rotation** — swap the JWT mock's signing key during a scenario,
+  verify the SUT picks up the new public key on the next request and
+  doesn't return cached 403s.
+- **Matchmaker degraded upstream** — slow the player-rating service by 2s,
+  verify matchmaker either times out gracefully or falls back to an open
+  rating bracket. (Pure HTTP+DB, no gaming-specific primitives.)
+- **Anti-cheat full outage drill** — combine `anti_cheat_unreachable` with
+  `db.write=deny()` to test the worst-case path: anti-cheat down AND the
+  audit event can't be persisted. What does the game do?
+
+## Read next
+
+- [Tutorial — Containers and real services](/docs/tutorial/05-advanced/09-containers) — the Docker-mode mechanics behind `image=`
+- [Tutorial — Mock services](/docs/tutorial/05-advanced/17-mock-services) — for the auth-stub / leaderboard-stub patterns
+- [Tutorial — End-to-end Go microservice](/docs/tutorial/05-advanced/22-go-microservice-end-to-end) — the closest existing tutorial to a full game-backend shape
+- [Spec language reference](/docs/reference/spec-language) — every primitive in one page

--- a/internal/bundle/build.go
+++ b/internal/bundle/build.go
@@ -141,6 +141,9 @@ func summaryFromTests(rows []TestRow) Summary {
 		case "inconclusive":
 			// RFC-041 §5.5(c) — distinct bucket from Passed/Failed.
 			s.Inconclusive++
+		case "halted":
+			// RFC-043 §5.3 — plan-tree pruning signal; not a verdict.
+			s.Halted++
 		case "expectation_violated":
 			s.Failed++
 			s.ExpectationViolated++

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -69,6 +69,9 @@ type Summary struct {
 	// Distinct from Passed and Failed so CI gates can choose to flag,
 	// fail, or ignore them.
 	Inconclusive               int `json:"inconclusive,omitempty"`
+	// Halted counts RFC-043 §5.3 plan-tree pruning — tests whose body
+	// called halt(). Not a verdict; CI typically ignores this column.
+	Halted                     int `json:"halted,omitempty"`
 	ExpectationViolated        int `json:"expectation_violated,omitempty"`
 	FaultBypassed              int `json:"fault_bypassed,omitempty"`
 	StrictDeterminismViolation int `json:"strict_determinism_violation,omitempty"` // RFC-040 §8.3

--- a/internal/report/app.js
+++ b/internal/report/app.js
@@ -146,6 +146,9 @@
       case "errored": return "errored";
       // RFC-041 §5.5(c) — timeout with pending temporal expectations.
       case "inconclusive": return "warn";
+      // RFC-043 §5.3 — plan-tree pruning (halt() in the body). Render
+      // alongside fault_bypassed since neither is a verdict.
+      case "halted": return "bypassed";
       default: return "warn";
     }
   }
@@ -356,6 +359,8 @@
       case "errored": icon = "!"; break;
       // RFC-041 §5.5(c) — timeout with pending temporal expectation.
       case "inconclusive": icon = "?"; break;
+      // RFC-043 §5.3 — body called halt().
+      case "halted": icon = "⊘"; break;
       default: icon = "?";
     }
     var title = cell.scenario + " × " + cell.fault + "\n" + outcome;

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -476,18 +476,32 @@ func reportSubtitle(m *bundle.Manifest) string {
 		return ""
 	}
 	s := m.Summary
+	// Halted leaves (RFC-043 §5.3) are no-verdict — exclude them
+	// from the "held under fault" framing so a suite of halted-only
+	// branches doesn't read as universal success.
+	verdictTotal := s.Total - s.Halted
+	suffix := ""
+	if s.Halted > 0 {
+		suffix = fmt.Sprintf(" (%d halted)", s.Halted)
+	}
 	switch {
 	case s.Total == 0:
 		return "No tests ran."
+	case verdictTotal == 0 && s.Halted > 0:
+		branchWord := "branch"
+		if s.Halted != 1 {
+			branchWord = "branches"
+		}
+		return fmt.Sprintf("No verdicts — all %d %s halted.", s.Halted, branchWord)
 	case s.Failed == 0 && s.Errored == 0:
-		return fmt.Sprintf("All %d check%s held up under the injected faults.",
-			s.Total, plural(s.Total))
+		return fmt.Sprintf("All %d check%s held up under the injected faults.%s",
+			verdictTotal, plural(verdictTotal), suffix)
 	case s.Errored > 0:
-		return fmt.Sprintf("%d of %d checks held; %d regressed, %d errored.",
-			s.Passed, s.Total, s.Failed, s.Errored)
+		return fmt.Sprintf("%d of %d checks held; %d regressed, %d errored.%s",
+			s.Passed, verdictTotal, s.Failed, s.Errored, suffix)
 	default:
-		return fmt.Sprintf("%d of %d checks held; %d regressed under fault.",
-			s.Passed, s.Total, s.Failed)
+		return fmt.Sprintf("%d of %d checks held; %d regressed under fault.%s",
+			s.Passed, verdictTotal, s.Failed, suffix)
 	}
 }
 

--- a/internal/star/assume.go
+++ b/internal/star/assume.go
@@ -1,0 +1,131 @@
+package star
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+var _ syntax.Node = nil // syntax kept in import list; Source field uses it once §8.7 AST validation lands.
+
+// AssumePredicate is one assume() constraint registered against a test
+// (or the whole spec). Body is the user predicate; Name is the
+// callable's name for error messages.
+//
+// Source captures the syntax tree of a lambda body so spec-load
+// validation can walk it for sandbox compliance. Nil for non-lambda
+// callables (e.g. `def`s) — those slip through the AST denylist (a
+// known limitation also documented for monitor predicates).
+type AssumePredicate struct {
+	Name   string
+	Body   starlark.Callable
+	Source syntax.Node
+}
+
+// Evaluate runs the predicate against choices. The choices dict maps
+// every recorded choose("name", ...) call's name to its currently-
+// selected option. rc1 is single-leaf, so each name maps to options[0];
+// rc2 will hand the per-leaf assignment in.
+//
+// Returns (true, nil) if the predicate held. Returns (false, "reason")
+// to halt the leaf. Returns (false, err) on any Starlark evaluation
+// error.
+func (a *AssumePredicate) Evaluate(choices starlark.Value) (bool, string, error) {
+	if a == nil || a.Body == nil {
+		return true, "", nil
+	}
+	thread := newSandboxThread("assume:" + a.Name)
+	res, err := starlark.Call(thread, a.Body, starlark.Tuple{choices}, nil)
+	if err != nil {
+		return false, "", fmt.Errorf("assume(%s) raised: %w", a.Name, err)
+	}
+	if res.Truth() == starlark.True {
+		return true, "", nil
+	}
+	return false, "assume(" + a.Name + ") not satisfied", nil
+}
+
+// builtinAssume implements RFC-043 §5.4's top-level form:
+//
+//	assume(predicate)        # filters all plan-tree leaves spec-wide
+//
+// rc1 single-leaf semantics: evaluate the predicate immediately at
+// spec load against the current choice snapshot. If it fails, return
+// an error so the spec load itself fails — the user sees the
+// constraint violation clearly. rc2 will defer evaluation to
+// per-leaf and prune the plan tree instead of erroring.
+//
+// The predicate must be a callable; bare booleans are accepted as a
+// convenience and treated as `lambda choices: <bool>`.
+func (rt *Runtime) builtinAssume(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(kwargs) > 0 || len(args) != 1 {
+		return nil, fmt.Errorf("assume(predicate): takes exactly one positional argument")
+	}
+	pred, err := assumeFromArg(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("assume(): %w", err)
+	}
+	rt.specAssumes = append(rt.specAssumes, pred)
+
+	// rc1 single-leaf: evaluate now against the current choice
+	// snapshot so violations surface at spec load time. rc2 will
+	// defer this to per-leaf evaluation.
+	ok, msg, err := pred.Evaluate(rt.currentChoicesDict())
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("assume(%s) violated at spec load: %s", pred.Name, msg)
+	}
+	return starlark.None, nil
+}
+
+// assumeFromArg wraps a user-supplied predicate value into an
+// AssumePredicate. Accepts a callable (preferred — runs against the
+// choices dict at evaluation time) or a bare boolean (constant
+// predicate, mostly useful for asserting on spec-load conditions).
+func assumeFromArg(v starlark.Value) (*AssumePredicate, error) {
+	switch val := v.(type) {
+	case starlark.Callable:
+		ap := &AssumePredicate{Name: val.Name(), Body: val}
+		if lam, ok := val.(*starlark.Function); ok {
+			// Function bodies have no AST handle exposed through the
+			// starlark.Value interface; this is the same limitation
+			// noted for monitor predicates. Leave Source nil; spec-
+			// load validation falls back to a runtime-error path for
+			// denied builtins.
+			_ = lam
+		}
+		return ap, nil
+	case starlark.Bool:
+		// Bare-boolean form. Wrap in a no-op closure so Evaluate has a
+		// callable to invoke; the result is constant either way.
+		constName := "True"
+		if val != starlark.True {
+			constName = "False"
+		}
+		return &AssumePredicate{
+			Name: "const_" + constName,
+			Body: starlark.NewBuiltin("assume.const", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+				return val, nil
+			}),
+		}, nil
+	}
+	return nil, fmt.Errorf("predicate must be callable or bool, got %s", v.Type())
+}
+
+// currentChoicesDict snapshots every recorded choose("name", opts)
+// call into a Starlark dict the predicate can read. Unnamed choose()
+// calls are skipped — they have no key the predicate could match on.
+func (rt *Runtime) currentChoicesDict() *starlark.Dict {
+	d := starlark.NewDict(0)
+	for _, c := range rt.Choices() {
+		if c.Name == "" {
+			continue
+		}
+		// rc1: first option is always selected.
+		_ = d.SetKey(starlark.String(c.Name), c.FirstOption())
+	}
+	return d
+}

--- a/internal/star/assume_test.go
+++ b/internal/star/assume_test.go
@@ -1,0 +1,137 @@
+package star
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestAssume_TopLevelTrueIsNoop(t *testing.T) {
+	rt := New(testLogger())
+	src := `assume(True)
+assume(lambda choices: True)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if len(rt.specAssumes) != 2 {
+		t.Errorf("expected 2 registered assumes, got %d", len(rt.specAssumes))
+	}
+}
+
+func TestAssume_TopLevelFalseFailsSpecLoad(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `assume(False)`)
+	if err == nil {
+		t.Fatal("assume(False) at spec load must error")
+	}
+	if !strings.Contains(err.Error(), "violated") {
+		t.Errorf("error should mention violation; got %v", err)
+	}
+}
+
+func TestAssume_LambdaInspectsChoices(t *testing.T) {
+	rt := New(testLogger())
+	// retries selects first option = 0; predicate "retries == 0" → True.
+	src := `
+retries = choose("retries", [0, 1, 3])
+assume(lambda choices: choices["retries"] == 0)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+}
+
+func TestAssume_LambdaFalseFailsAtLoad(t *testing.T) {
+	rt := New(testLogger())
+	// retries first option = 0; predicate "retries > 5" → False.
+	err := rt.LoadString("spec.star", `
+retries = choose("retries", [0, 1, 3])
+assume(lambda choices: choices["retries"] > 5)
+`)
+	if err == nil {
+		t.Fatal("predicate that does not hold must error")
+	}
+}
+
+func TestAssume_RejectsBadArgTypes(t *testing.T) {
+	rt := New(testLogger())
+	if err := rt.LoadString("a.star", `assume("not a predicate")`); err == nil {
+		t.Error("string predicate must error")
+	}
+	if err := rt.LoadString("b.star", `assume()`); err == nil {
+		t.Error("zero-arg assume() must error")
+	}
+}
+
+func TestAssume_PerTestHaltsWhenFalse(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def body():
+    return None
+
+test("guarded", body=body, assume=[lambda choices: False])
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	// DiscoverTests registers the body into globals.
+	_ = rt.DiscoverTests()
+	tr := rt.RunTest(context.Background(), "test_guarded")
+	if tr.Result != "halted" {
+		t.Errorf("Result = %q, want halted", tr.Result)
+	}
+}
+
+func TestAssume_PerTestPassesWhenTrue(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def body():
+    return None
+
+test("ok", body=body, assume=[lambda choices: True])
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	_ = rt.DiscoverTests()
+	tr := rt.RunTest(context.Background(), "test_ok")
+	if tr.Result != "pass" {
+		t.Errorf("Result = %q, want pass; reason=%s", tr.Result, tr.Reason)
+	}
+}
+
+func TestAssume_PredicateInternalError(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def body():
+    return None
+
+# Predicate indexes a missing dict key — evaluation raises at runtime.
+test("raises", body=body, assume=[lambda choices: choices["missing_key"] == 0])
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	_ = rt.DiscoverTests()
+	tr := rt.RunTest(context.Background(), "test_raises")
+	if tr.Result != "fail" {
+		t.Errorf("Result = %q, want fail (predicate raised); reason=%s", tr.Result, tr.Reason)
+	}
+}
+
+func TestCurrentChoicesDict_SkipsUnnamed(t *testing.T) {
+	rt := New(testLogger())
+	rt.recordChoice(&ChoiceVal{Name: "named", Options: []starlark.Value{starlark.MakeInt(42)}})
+	rt.recordChoice(&ChoiceVal{Options: []starlark.Value{starlark.MakeInt(99)}}) // unnamed
+	d := rt.currentChoicesDict()
+	if d.Len() != 1 {
+		t.Errorf("dict size = %d, want 1 (unnamed choice should be skipped)", d.Len())
+	}
+	v, found, _ := d.Get(starlark.String("named"))
+	if !found || v != starlark.MakeInt(42) {
+		t.Errorf("named key missing or wrong; got found=%v v=%v", found, v)
+	}
+}

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -1823,14 +1823,22 @@ func (rt *Runtime) builtinFaultMatrix(thread *starlark.Thread, fn *starlark.Buil
 //
 //   - `nondet()` (zero-arg) — RFC-043 §5.1 non-deterministic boolean.
 //     Sugar for `choose([True, False])`; registers as a 2-branch
-//     choice for the plan tree and returns False at runtime in
+//     choice for the plan tree and returns True at runtime in
 //     v0.13.0-rc1 (rc2 will fan out the plan and return the per-leaf
 //     value).
 //   - `nondet(svc, ...)` (variadic) — pre-RFC-043 behavior: marks
 //     services as exempt from interleaving control during parallel().
 //     Existing specs continue to work unchanged. RFC-044 may unify
 //     the two surfaces later.
+//
+// Keyword arguments are rejected to keep the two arities unambiguous:
+// `nondet(svc=x)` would otherwise silently fall through to the
+// zero-arg boolean path and leave the service untagged for
+// interleaving control (review B2).
 func (rt *Runtime) builtinNondet(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("nondet(): keyword arguments are not accepted; use nondet(svc) for service exclusion or nondet() for the RFC-043 boolean")
+	}
 	if len(args) == 0 {
 		// RFC-043 §5.1 — non-deterministic boolean.
 		c := &ChoiceVal{Options: []starlark.Value{starlark.True, starlark.False}}

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -48,6 +48,11 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		"monitor":           starlark.NewBuiltin("monitor", rt.builtinMonitor),
 		"partition":         starlark.NewBuiltin("partition", rt.builtinPartition),
 		"nondet":            starlark.NewBuiltin("nondet", rt.builtinNondet),
+		// RFC-043 §5.2 — finite non-deterministic choice. Zero-arg
+		// `nondet()` is sugar for `choose([True, False])`; that
+		// overload is wired in builtinNondet itself to avoid renaming
+		// the existing nondet(service, ...) variant.
+		"choose":            starlark.NewBuiltin("choose", rt.builtinChoose),
 		"trace":             starlark.NewBuiltin("trace", rt.builtinTrace),
 		"trace_start":       starlark.NewBuiltin("trace_start", rt.builtinTraceStart),
 		"trace_stop":        starlark.NewBuiltin("trace_stop", rt.builtinTraceStop),
@@ -1805,12 +1810,23 @@ func (rt *Runtime) builtinFaultMatrix(thread *starlark.Thread, fn *starlark.Buil
 	return starlark.None, nil
 }
 
-// nondet(service, ...) — marks one or more services as nondeterministic,
-// excluding them from interleaving control during parallel().
-// Their syscalls proceed immediately.
+// nondet has two arities:
+//
+//   - `nondet()` (zero-arg) — RFC-043 §5.1 non-deterministic boolean.
+//     Sugar for `choose([True, False])`; registers as a 2-branch
+//     choice for the plan tree and returns False at runtime in
+//     v0.13.0-rc1 (rc2 will fan out the plan and return the per-leaf
+//     value).
+//   - `nondet(svc, ...)` (variadic) — pre-RFC-043 behavior: marks
+//     services as exempt from interleaving control during parallel().
+//     Existing specs continue to work unchanged. RFC-044 may unify
+//     the two surfaces later.
 func (rt *Runtime) builtinNondet(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if len(args) < 1 {
-		return nil, fmt.Errorf("nondet() requires at least one service argument")
+	if len(args) == 0 {
+		// RFC-043 §5.1 — non-deterministic boolean.
+		c := &ChoiceVal{Options: []starlark.Value{starlark.True, starlark.False}}
+		rt.recordChoice(c)
+		return c.FirstOption(), nil
 	}
 	if rt.nondetServices == nil {
 		rt.nondetServices = make(map[string]bool)
@@ -1818,7 +1834,7 @@ func (rt *Runtime) builtinNondet(thread *starlark.Thread, fn *starlark.Builtin, 
 	for i, arg := range args {
 		svc, ok := arg.(*ServiceDef)
 		if !ok {
-			return nil, fmt.Errorf("nondet() argument %d must be a service, got %s", i, arg.Type())
+			return nil, fmt.Errorf("nondet() argument %d must be a service (or zero args for the RFC-043 boolean), got %s", i, arg.Type())
 		}
 		rt.nondetServices[svc.Name] = true
 	}

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -53,6 +53,10 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		// overload is wired in builtinNondet itself to avoid renaming
 		// the existing nondet(service, ...) variant.
 		"choose":            starlark.NewBuiltin("choose", rt.builtinChoose),
+		// RFC-043 §5.3 — halt the current plan-tree branch. Body
+		// execution stops at the call site; the test is recorded as
+		// "halted" (not pass/fail/inconclusive).
+		"halt":              starlark.NewBuiltin("halt", rt.builtinHalt),
 		"trace":             starlark.NewBuiltin("trace", rt.builtinTrace),
 		"trace_start":       starlark.NewBuiltin("trace_start", rt.builtinTraceStart),
 		"trace_stop":        starlark.NewBuiltin("trace_stop", rt.builtinTraceStop),

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -57,6 +57,11 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		// execution stops at the call site; the test is recorded as
 		// "halted" (not pass/fail/inconclusive).
 		"halt":              starlark.NewBuiltin("halt", rt.builtinHalt),
+		// RFC-043 §5.4 — assume(predicate) spec-wide constraint. rc1
+		// evaluates at spec-load against the current choice snapshot
+		// and errors immediately on violation; rc2 will defer to
+		// per-leaf pruning.
+		"assume":            starlark.NewBuiltin("assume", rt.builtinAssume),
 		"trace":             starlark.NewBuiltin("trace", rt.builtinTrace),
 		"trace_start":       starlark.NewBuiltin("trace_start", rt.builtinTraceStart),
 		"trace_stop":        starlark.NewBuiltin("trace_stop", rt.builtinTraceStop),

--- a/internal/star/choose.go
+++ b/internal/star/choose.go
@@ -1,0 +1,138 @@
+package star
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// ChoiceVal is the Starlark value returned by choose(). Plan-tree
+// enumeration (RFC-042 + RFC-043 §8.5, deferred to rc2) inspects this
+// value to fan out the plan over the option set. In v0.13.0-rc1 the
+// value flattens to Options[0] when used in arithmetic / equality /
+// indexing — so existing specs that previously hard-coded the first
+// option get the same behavior, and the fan-out lands additively in
+// rc2 without breaking the user-facing surface.
+//
+// The Name field is optional and matches RFC-043 §5.2's two-arity
+// form `choose("retries", [0,1,3])`. When empty, the plan report
+// labels the axis by the call site.
+type ChoiceVal struct {
+	Name    string
+	Options []starlark.Value
+}
+
+var _ starlark.Value = (*ChoiceVal)(nil)
+
+// FirstOption returns the option chosen for runtime execution under
+// rc1's degenerate-single-leaf semantics. rc2 will reassign this per
+// plan-tree leaf when fan-out lands.
+func (c *ChoiceVal) FirstOption() starlark.Value {
+	if len(c.Options) == 0 {
+		return starlark.None
+	}
+	return c.Options[0]
+}
+
+func (c *ChoiceVal) String() string {
+	if c.Name != "" {
+		return fmt.Sprintf("<choice %s [%d]>", c.Name, len(c.Options))
+	}
+	return fmt.Sprintf("<choice [%d]>", len(c.Options))
+}
+func (c *ChoiceVal) Type() string { return "choice" }
+func (c *ChoiceVal) Freeze() {
+	for _, o := range c.Options {
+		o.Freeze()
+	}
+}
+func (c *ChoiceVal) Truth() starlark.Bool {
+	// A choice with at least one option is truthy. Callers that want
+	// the boolean semantics of `nondet()` should compare against the
+	// first option explicitly — once rc2 wires fan-out, the value will
+	// be the per-leaf option directly, not the ChoiceVal wrapper.
+	return starlark.Bool(len(c.Options) > 0)
+}
+func (c *ChoiceVal) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: choice") }
+
+// builtinChoose implements RFC-043 §5.2:
+//
+//	choose([opt0, opt1, ...])           — N-way choice
+//	choose("retries", [0, 1, 3])        — named two-arity form
+//
+// The options list must be statically evaluable — a Starlark list of
+// literal values. Runtime-computed elements are rejected at spec load
+// per the RFC's "no symbolic ranges" stance.
+//
+// rc1 semantics: returns a ChoiceVal whose runtime usage flattens to
+// the first option. rc2 will wire body re-execution so each plan-tree
+// leaf observes a different option.
+func (rt *Runtime) builtinChoose(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("choose() takes only positional arguments")
+	}
+	var name string
+	var optList *starlark.List
+	switch len(args) {
+	case 1:
+		l, ok := args[0].(*starlark.List)
+		if !ok {
+			return nil, fmt.Errorf("choose(options): options must be a list, got %s", args[0].Type())
+		}
+		optList = l
+	case 2:
+		s, ok := args[0].(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("choose(name, options): name must be a string, got %s", args[0].Type())
+		}
+		l, ok := args[1].(*starlark.List)
+		if !ok {
+			return nil, fmt.Errorf("choose(name, options): options must be a list, got %s", args[1].Type())
+		}
+		name = string(s)
+		optList = l
+	default:
+		return nil, fmt.Errorf("choose() takes 1 or 2 arguments (options) or (name, options); got %d", len(args))
+	}
+
+	if optList.Len() == 0 {
+		return nil, fmt.Errorf("choose(): options list must be non-empty")
+	}
+
+	c := &ChoiceVal{Name: name, Options: make([]starlark.Value, 0, optList.Len())}
+	it := optList.Iterate()
+	defer it.Done()
+	var v starlark.Value
+	for it.Next(&v) {
+		c.Options = append(c.Options, v)
+	}
+	rt.recordChoice(c)
+	// rc1 single-leaf: return the first option directly so users get
+	// concrete values (an int from `choose([0,1,3])` instead of a
+	// wrapper). When rc2 wires fan-out, callers will receive the
+	// leaf-selected option through the same return path — no spec
+	// changes required at the call site.
+	return c.FirstOption(), nil
+}
+
+// recordChoice tracks every choose() call site for plan-tree
+// enumeration. Used in PR 5 to expose the choices as composition
+// axes; in rc1 it's collected but not yet rendered by the plan
+// command (the integration arrives with §8.5 in rc2).
+func (rt *Runtime) recordChoice(c *ChoiceVal) {
+	rt.choicesMu.Lock()
+	defer rt.choicesMu.Unlock()
+	rt.choices = append(rt.choices, c)
+}
+
+// Choices returns a snapshot of every recorded choose() call. Used by
+// the plan-tree enumerator and tests; safe to call after LoadFile and
+// before concurrent RunAll (same contract as the other read-only
+// runtime accessors).
+func (rt *Runtime) Choices() []*ChoiceVal {
+	rt.choicesMu.Lock()
+	defer rt.choicesMu.Unlock()
+	out := make([]*ChoiceVal, len(rt.choices))
+	copy(out, rt.choices)
+	return out
+}

--- a/internal/star/choose_test.go
+++ b/internal/star/choose_test.go
@@ -1,0 +1,118 @@
+package star
+
+import (
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestChoose_ReturnsFirstOption(t *testing.T) {
+	rt := New(testLogger())
+	src := `r = choose([7, 8, 9])
+n = nondet()
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	// `choose([7,8,9])` returns 7 in rc1 single-leaf mode.
+	if got := rt.globals["r"]; got != starlark.MakeInt(7) {
+		t.Errorf("r = %v, want 7 (first option)", got)
+	}
+	// `nondet()` is sugar for choose([True, False]); first option is True.
+	if got := rt.globals["n"]; got != starlark.True {
+		t.Errorf("n = %v, want True (nondet first option)", got)
+	}
+}
+
+func TestChoose_RecordsCallSites(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+a = choose([1, 2, 3])
+b = choose("retries", [0, 1])
+c = nondet()
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	choices := rt.Choices()
+	if len(choices) != 3 {
+		t.Fatalf("expected 3 recorded choices, got %d", len(choices))
+	}
+	if len(choices[0].Options) != 3 {
+		t.Errorf("first choice option count = %d, want 3", len(choices[0].Options))
+	}
+	if choices[1].Name != "retries" {
+		t.Errorf("named choice Name = %q, want retries", choices[1].Name)
+	}
+	if len(choices[2].Options) != 2 {
+		t.Errorf("nondet choice option count = %d, want 2", len(choices[2].Options))
+	}
+}
+
+func TestChoose_EmptyListErrors(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `x = choose([])`)
+	if err == nil {
+		t.Fatal("expected error for empty options list")
+	}
+}
+
+func TestChoose_NonListErrors(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `x = choose(42)`)
+	if err == nil {
+		t.Fatal("expected error when options is not a list")
+	}
+}
+
+func TestChoose_BadArity(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `x = choose()`)
+	if err == nil {
+		t.Fatal("expected error for zero-arg choose()")
+	}
+}
+
+func TestChoose_NamedFormStringRequired(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `x = choose(42, [1, 2])`)
+	if err == nil {
+		t.Fatal("expected error when name arg is not a string")
+	}
+}
+
+// Pre-RFC-043 nondet(service) variant must continue to work — covered
+// implicitly by existing tutorial specs; pin the behavior here.
+func TestNondet_ServiceFormStillMarksService(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+svc = service("svc", image="busybox", cmd=["sh","-c","sleep 1"])
+nondet(svc)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if !rt.nondetServices["svc"] {
+		t.Errorf("expected svc to be marked nondet, got %v", rt.nondetServices)
+	}
+}
+
+func TestChoiceVal_StringAndType(t *testing.T) {
+	c := &ChoiceVal{Name: "x", Options: []starlark.Value{starlark.MakeInt(1), starlark.MakeInt(2)}}
+	if c.Type() != "choice" {
+		t.Errorf("Type = %q, want choice", c.Type())
+	}
+	if c.String() != "<choice x [2]>" {
+		t.Errorf("String = %q", c.String())
+	}
+	if c.Truth() != starlark.True {
+		t.Error("non-empty Choice should be truthy")
+	}
+	empty := &ChoiceVal{}
+	if empty.Truth() != starlark.False {
+		t.Error("empty Choice should be falsy")
+	}
+	if empty.FirstOption() != starlark.None {
+		t.Error("empty Choice FirstOption should be None")
+	}
+}

--- a/internal/star/choose_test.go
+++ b/internal/star/choose_test.go
@@ -1,6 +1,7 @@
 package star
 
 import (
+	"strings"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -78,6 +79,27 @@ func TestChoose_NamedFormStringRequired(t *testing.T) {
 	err := rt.LoadString("spec.star", `x = choose(42, [1, 2])`)
 	if err == nil {
 		t.Fatal("expected error when name arg is not a string")
+	}
+}
+
+// Review B2: nondet(svc=x) must not silently bypass the
+// service-exclusion path by taking the zero-arg boolean route.
+// Reject kwargs explicitly so the call surface stays unambiguous.
+func TestNondet_RejectsKwargs(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+svc = service("svc", image="busybox", cmd=["sh","-c","sleep 1"])
+nondet(svc=svc)
+`
+	err := rt.LoadString("spec.star", src)
+	if err == nil {
+		t.Fatal("expected error for nondet(svc=...)")
+	}
+	if !strings.Contains(err.Error(), "keyword arguments are not accepted") {
+		t.Errorf("error should mention kwargs are rejected; got %v", err)
+	}
+	if rt.nondetServices["svc"] {
+		t.Error("svc must NOT be marked nondet when call errored")
 	}
 }
 

--- a/internal/star/halt.go
+++ b/internal/star/halt.go
@@ -1,0 +1,54 @@
+package star
+
+import (
+	"errors"
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// ErrHalt is the sentinel error returned by the halt() builtin.
+// RunTest matches it via errors.Is so the test result lands as
+// Result="halted" (not "fail" or "error"). RFC-043 §5.3.
+//
+// Starlark wraps builtin errors in *starlark.EvalError; the wrapper
+// preserves Unwrap(), so errors.Is(err, ErrHalt) correctly traverses
+// the stack-trace wrapping.
+var ErrHalt = errors.New("halt")
+
+// HaltError carries the optional human-readable reason a halt()
+// call can attach. Wraps ErrHalt so the sentinel match still works.
+type HaltError struct {
+	Reason string
+}
+
+func (e *HaltError) Error() string {
+	if e.Reason == "" {
+		return "halt"
+	}
+	return "halt: " + e.Reason
+}
+func (e *HaltError) Unwrap() error { return ErrHalt }
+
+// builtinHalt implements RFC-043 §5.3. Body execution stops at the
+// halt() call site; the test result is recorded as "halted" with the
+// optional reason attached.
+//
+//	halt()                  # bare halt
+//	halt("invalid combo")   # halt with a reason rendered in the report
+func (rt *Runtime) builtinHalt(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("halt() takes only an optional positional reason")
+	}
+	switch len(args) {
+	case 0:
+		return nil, &HaltError{}
+	case 1:
+		reason, ok := starlark.AsString(args[0])
+		if !ok {
+			return nil, fmt.Errorf("halt() reason must be a string, got %s", args[0].Type())
+		}
+		return nil, &HaltError{Reason: reason}
+	}
+	return nil, fmt.Errorf("halt() takes at most one argument; got %d", len(args))
+}

--- a/internal/star/halt.go
+++ b/internal/star/halt.go
@@ -36,7 +36,16 @@ func (e *HaltError) Unwrap() error { return ErrHalt }
 //
 //	halt()                  # bare halt
 //	halt("invalid combo")   # halt with a reason rendered in the report
+//
+// §5.8 check: halt() outside a test body is rejected at spec load.
+// halt() at module top-level (or inside setup=) would terminate spec
+// load itself, which is rarely what the user meant — they almost
+// always meant "prune this plan-tree branch at runtime." Detect via
+// rt.inTest (set by RunTest only while a body is executing).
 func (rt *Runtime) builtinHalt(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !rt.inTest.Load() {
+		return nil, fmt.Errorf("halt() may only be called inside a test body; got call at module top level (or inside setup=)")
+	}
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("halt() takes only an optional positional reason")
 	}

--- a/internal/star/halt_test.go
+++ b/internal/star/halt_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestHalt_BareReturnsSentinel(t *testing.T) {
 	rt := New(testLogger())
+	rt.inTest.Store(true)
+	defer rt.inTest.Store(false)
 	_, err := rt.builtinHalt(nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("halt() must return an error")
@@ -29,6 +31,8 @@ func TestHalt_BareReturnsSentinel(t *testing.T) {
 
 func TestHalt_WithReason(t *testing.T) {
 	rt := New(testLogger())
+	rt.inTest.Store(true)
+	defer rt.inTest.Store(false)
 	_, err := rt.builtinHalt(nil, nil, starlark.Tuple{starlark.String("invalid combo")}, nil)
 	if err == nil {
 		t.Fatal("expected error")
@@ -44,6 +48,8 @@ func TestHalt_WithReason(t *testing.T) {
 
 func TestHalt_RejectsKwargsAndNonString(t *testing.T) {
 	rt := New(testLogger())
+	rt.inTest.Store(true)
+	defer rt.inTest.Store(false)
 	_, err := rt.builtinHalt(nil, nil, starlark.Tuple{starlark.MakeInt(42)}, nil)
 	if err == nil {
 		t.Error("non-string reason must error")
@@ -75,6 +81,42 @@ func TestHalt_RunTestRecordsHaltedOutcome(t *testing.T) {
 	}
 	if !strings.Contains(tr.Reason, "rare invalid combo") {
 		t.Errorf("Reason should carry the halt() argument; got %q", tr.Reason)
+	}
+}
+
+// §5.8 check: halt() at module top-level rejected at spec load.
+func TestHalt_RejectedAtModuleTopLevel(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `halt("at top level")`)
+	if err == nil {
+		t.Fatal("expected spec-load error for top-level halt()")
+	}
+	if !strings.Contains(err.Error(), "test body") {
+		t.Errorf("error should explain only-in-test-body; got %v", err)
+	}
+}
+
+// §5.8 check: halt() inside setup= also rejected (setup runs before
+// the body enters in-test mode).
+func TestHalt_RejectedInSetup(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def body(): pass
+def setup_fn():
+    halt("setup tried to halt")
+
+test("setup_halt", body=body, setup=setup_fn)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	_ = rt.DiscoverTests()
+	tr := rt.RunTest(context.Background(), "test_setup_halt")
+	if tr.Result != "fail" {
+		t.Errorf("Result = %q, want fail (setup halt rejected)", tr.Result)
+	}
+	if !strings.Contains(tr.Reason, "test body") {
+		t.Errorf("Reason should explain halt-in-setup error; got %q", tr.Reason)
 	}
 }
 

--- a/internal/star/halt_test.go
+++ b/internal/star/halt_test.go
@@ -1,0 +1,93 @@
+package star
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestHalt_BareReturnsSentinel(t *testing.T) {
+	rt := New(testLogger())
+	_, err := rt.builtinHalt(nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("halt() must return an error")
+	}
+	if !errors.Is(err, ErrHalt) {
+		t.Errorf("err must wrap ErrHalt; got %v", err)
+	}
+	var he *HaltError
+	if !errors.As(err, &he) {
+		t.Fatalf("err must be *HaltError; got %T", err)
+	}
+	if he.Reason != "" {
+		t.Errorf("bare halt() should have empty reason; got %q", he.Reason)
+	}
+}
+
+func TestHalt_WithReason(t *testing.T) {
+	rt := New(testLogger())
+	_, err := rt.builtinHalt(nil, nil, starlark.Tuple{starlark.String("invalid combo")}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var he *HaltError
+	if !errors.As(err, &he) || he.Reason != "invalid combo" {
+		t.Errorf("expected Reason='invalid combo'; got %v", he)
+	}
+	if !strings.Contains(err.Error(), "invalid combo") {
+		t.Errorf("error message should contain reason; got %q", err.Error())
+	}
+}
+
+func TestHalt_RejectsKwargsAndNonString(t *testing.T) {
+	rt := New(testLogger())
+	_, err := rt.builtinHalt(nil, nil, starlark.Tuple{starlark.MakeInt(42)}, nil)
+	if err == nil {
+		t.Error("non-string reason must error")
+	}
+	_, err = rt.builtinHalt(nil, nil, nil, []starlark.Tuple{{starlark.String("k"), starlark.String("v")}})
+	if err == nil {
+		t.Error("kwargs must error")
+	}
+	_, err = rt.builtinHalt(nil, nil, starlark.Tuple{starlark.String("a"), starlark.String("b")}, nil)
+	if err == nil {
+		t.Error("two positional args must error")
+	}
+}
+
+// TestHalt_RunTestRecordsHaltedOutcome ensures that a halt() call
+// inside a test body lands the test as Result="halted" — NOT "fail",
+// "error", or "pass" — so suite-level tallies stay clean.
+func TestHalt_RunTestRecordsHaltedOutcome(t *testing.T) {
+	rt := New(testLogger())
+	src := `def test_halted_branch():
+    halt("rare invalid combo")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	tr := rt.RunTest(context.Background(), "test_halted_branch")
+	if tr.Result != "halted" {
+		t.Errorf("Result = %q, want halted", tr.Result)
+	}
+	if !strings.Contains(tr.Reason, "rare invalid combo") {
+		t.Errorf("Reason should carry the halt() argument; got %q", tr.Reason)
+	}
+}
+
+func TestHalt_BareCallInTestBody(t *testing.T) {
+	rt := New(testLogger())
+	src := `def test_bare_halt():
+    halt()
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	tr := rt.RunTest(context.Background(), "test_bare_halt")
+	if tr.Result != "halted" {
+		t.Errorf("Result = %q, want halted", tr.Result)
+	}
+}

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1056,6 +1056,15 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 	// the test (Result="halted"); a predicate that raises a Starlark
 	// error fails the test. rc2 will defer this to plan-tree pruning.
 	if testCfg != nil && len(testCfg.Assumes) > 0 {
+		// Capture matrix / expectation attribution before the early-exit
+		// returns below so an assume-driven halt/fail is still attributed
+		// to its fault_matrix cell. Without this the matrix column in
+		// reports would be blank for pruned cells (review N4).
+		var preMatrix *MatrixInfo
+		if rt.currentFaultScenario != nil {
+			preMatrix = rt.currentFaultScenario.Matrix
+		}
+		preExpect := rt.expectationName
 		choices := rt.currentChoicesDict()
 		for _, pred := range testCfg.Assumes {
 			ok, msg, err := pred.Evaluate(choices)
@@ -1063,18 +1072,22 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 				rt.stopServices()
 				return TestResult{
 					Name: name, Result: "fail",
-					Reason:     err.Error(),
-					DurationMs: time.Since(start).Milliseconds(),
-					Events:     rt.events.Events(),
+					Reason:          err.Error(),
+					DurationMs:      time.Since(start).Milliseconds(),
+					Events:          rt.events.Events(),
+					Matrix:          preMatrix,
+					ExpectationName: preExpect,
 				}
 			}
 			if !ok {
 				rt.stopServices()
 				return TestResult{
 					Name: name, Result: "halted",
-					Reason:     msg,
-					DurationMs: time.Since(start).Milliseconds(),
-					Events:     rt.events.Events(),
+					Reason:          msg,
+					DurationMs:      time.Since(start).Milliseconds(),
+					Events:          rt.events.Events(),
+					Matrix:          preMatrix,
+					ExpectationName: preExpect,
 				}
 			}
 		}
@@ -1219,10 +1232,17 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 
 	retVal := bo.retVal
 	err := bo.err
-	if err != nil && cause == TerminationNatural {
+	if err != nil && cause == TerminationNatural && !errors.Is(err, ErrHalt) {
 		// Body raised — promote to immediate-fail cause so Finalize
 		// rolls pending eventually's into the failure rather than
 		// trying to evaluate them against an unstable trace.
+		//
+		// halt() is intentionally excluded: it is a clean plan-tree
+		// pruning signal, not a body failure. We want cause to stay
+		// Natural so the halted early-return below fires. If always()
+		// also violated, cause was already set to TerminationImmediateFail
+		// by the select arm above and the halted return won't run —
+		// that's the priority-inversion fix from review B1.
 		cause = TerminationImmediateFail
 	}
 
@@ -1258,7 +1278,13 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 		// halted (a plan-tree pruning signal, not a real outcome) so
 		// suite-level pass/fail tallies stay clean. The reason, if
 		// supplied, surfaces in the trace for the report.
-		if errors.Is(err, ErrHalt) {
+		//
+		// Priority: an always() invariant violation (cause ==
+		// TerminationImmediateFail) outranks halt(). A test that both
+		// halts AND violates an invariant must be recorded as "fail";
+		// silently downgrading to "halted" would swallow the verdict.
+		// Convert to halted only on the natural-termination path.
+		if errors.Is(err, ErrHalt) && cause == TerminationNatural {
 			reason := "halt()"
 			var he *HaltError
 			if errors.As(err, &he) && he.Reason != "" {

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -312,6 +312,13 @@ type Runtime struct {
 	mockTLSImpl *mockTLS
 	mockTLSErr  error
 
+	// Recorded choose() call sites (RFC-043 §5.2). rc1 collects them
+	// for plan-tree visibility; rc2 will fan the plan tree out across
+	// the option set. Same locking contract as the other post-load
+	// read-only accessors.
+	choicesMu sync.Mutex
+	choices   []*ChoiceVal
+
 	// Determinism state — RFC-040. Populated by the determinism() top-level
 	// builtin (or defaults to L1 / runtime=default / strict=True if not
 	// called). Detection layer (Phase 3) reads detLevel and detAllow before

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -2,6 +2,7 @@ package star
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -141,6 +142,11 @@ type SuiteResult struct {
 	// to gate on either or both (CLI exit code 3 reflects Inconclusive
 	// > 0 when Fail == 0; exit code 2 is reserved for Fail > 0).
 	Inconclusive int `json:"inconclusive,omitempty"`
+	// Halted counts tests whose body called halt() (RFC-043 §5.3).
+	// Halted leaves are recorded with their choice path but do not
+	// contribute to PASS/FAIL/INCONCLUSIVE counts — they represent
+	// plan-tree pruning, not a test outcome the user cares about.
+	Halted int `json:"halted,omitempty"`
 
 	// Crash, if non-nil, indicates the suite was terminated by a Go
 	// runtime panic — typically inside RunTest. The bundle emitted on
@@ -837,6 +843,17 @@ func (rt *Runtime) RunAll(ctx context.Context, cfg RunConfig) (*SuiteResult, err
 				// 3 (in main.go) reflects Inconclusive > 0 when Fail == 0.
 				suite.Inconclusive++
 				suite.Tests = append(suite.Tests, tr)
+			case "halted":
+				// RFC-043 §5.3 — the test body called halt() (or
+				// `assume(False)` once §5.4 lands). The leaf is
+				// recorded with the choice path that led to it but
+				// does not contribute to PASS/FAIL/INCONCLUSIVE
+				// counts; CI gates that ignore halted runs see a
+				// clean exit.
+				suite.Halted++
+				if !cfg.FailOnly {
+					suite.Tests = append(suite.Tests, tr)
+				}
 			default: // "fail", "error", anything else non-pass
 				suite.Fail++
 				suite.Tests = append(suite.Tests, tr)
@@ -1202,6 +1219,25 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 	// timeout, FAIL for terminate_when with pending eventually). Skip
 	// the "err → FAIL" return when cause already reflects a cancellation.
 	if err != nil && cause != TerminationTimeout && cause != TerminationTerminateWhen {
+		// RFC-043 §5.3 — the body called halt(). Record the leaf as
+		// halted (a plan-tree pruning signal, not a real outcome) so
+		// suite-level pass/fail tallies stay clean. The reason, if
+		// supplied, surfaces in the trace for the report.
+		if errors.Is(err, ErrHalt) {
+			reason := "halt()"
+			var he *HaltError
+			if errors.As(err, &he) && he.Reason != "" {
+				reason = "halt: " + he.Reason
+			}
+			return TestResult{
+				Name: name, Result: "halted",
+				Reason:          reason,
+				DurationMs:      time.Since(start).Milliseconds(),
+				Events:          events,
+				Matrix:          matrixInfo,
+				ExpectationName: expectName,
+			}
+		}
 		// Distinguish a Go-level panic in the body from a Starlark
 		// error so RunAll's Crash detection (Result=="error") fires.
 		resultKind := "fail"

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -325,6 +325,12 @@ type Runtime struct {
 	choicesMu sync.Mutex
 	choices   []*ChoiceVal
 
+	// Spec-wide assume() predicates (RFC-043 §5.4). Evaluated at spec
+	// load in rc1 (violations error immediately); rc2 will defer to
+	// per-leaf pruning. Per-test predicates live on TestConfig.Assume
+	// and are evaluated by RunTest.
+	specAssumes []*AssumePredicate
+
 	// Determinism state — RFC-040. Populated by the determinism() top-level
 	// builtin (or defaults to L1 / runtime=default / strict=True if not
 	// called). Detection layer (Phase 3) reads detLevel and detAllow before
@@ -1041,6 +1047,35 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 				Reason:     fmt.Sprintf("setup: %v", err),
 				DurationMs: time.Since(start).Milliseconds(),
 				Events:     rt.events.Events(),
+			}
+		}
+	}
+
+	// RFC-043 §5.4 — per-test assume predicates. Evaluate now against
+	// the current choices snapshot. The first failing predicate halts
+	// the test (Result="halted"); a predicate that raises a Starlark
+	// error fails the test. rc2 will defer this to plan-tree pruning.
+	if testCfg != nil && len(testCfg.Assumes) > 0 {
+		choices := rt.currentChoicesDict()
+		for _, pred := range testCfg.Assumes {
+			ok, msg, err := pred.Evaluate(choices)
+			if err != nil {
+				rt.stopServices()
+				return TestResult{
+					Name: name, Result: "fail",
+					Reason:     err.Error(),
+					DurationMs: time.Since(start).Milliseconds(),
+					Events:     rt.events.Events(),
+				}
+			}
+			if !ok {
+				rt.stopServices()
+				return TestResult{
+					Name: name, Result: "halted",
+					Reason:     msg,
+					DurationMs: time.Since(start).Milliseconds(),
+					Events:     rt.events.Events(),
+				}
 			}
 		}
 	}

--- a/internal/star/temporal.go
+++ b/internal/star/temporal.go
@@ -26,6 +26,10 @@ type TestConfig struct {
 	Expect        ExpectationVal
 	Timeout       time.Duration // 0 → use suite default (30s)
 	TerminateWhen ExpectationVal
+	// Assumes are RFC-043 §5.4 per-test predicates. RunTest evaluates
+	// them at body entry against the current choices dict; the first
+	// failing predicate halts the test with Result="halted".
+	Assumes []*AssumePredicate
 }
 
 // Verdict is the three-valued result of evaluating a temporal expectation.
@@ -466,6 +470,7 @@ func (rt *Runtime) builtinTest(_ *starlark.Thread, _ *starlark.Builtin, args sta
 	var setupArg starlark.Value = starlark.None
 	var expectArg starlark.Value = starlark.None
 	var twArg starlark.Value = starlark.None
+	var assumeArg starlark.Value = starlark.None
 	var timeoutStr string
 	var clockStr = "wall"
 	if err := starlark.UnpackArgs("test", args, kwargs,
@@ -475,6 +480,7 @@ func (rt *Runtime) builtinTest(_ *starlark.Thread, _ *starlark.Builtin, args sta
 		"expect?", &expectArg,
 		"timeout?", &timeoutStr,
 		"terminate_when?", &twArg,
+		"assume?", &assumeArg,
 		"clock?", &clockStr,
 	); err != nil {
 		return nil, err
@@ -514,6 +520,23 @@ func (rt *Runtime) builtinTest(_ *starlark.Thread, _ *starlark.Builtin, args sta
 			return nil, fmt.Errorf("test(%q): bad timeout=%q: %w", name, timeoutStr, err)
 		}
 		cfg.Timeout = d
+	}
+	// RFC-043 §5.4 — per-test assume predicates. Accepts a list of
+	// callables (preferred) or bare booleans (constant). RunTest
+	// evaluates them at body entry against the current choices dict;
+	// the first failure halts the test.
+	if assumeArg != starlark.None {
+		list, ok := assumeArg.(*starlark.List)
+		if !ok {
+			return nil, fmt.Errorf("test(%q): assume= must be a list of predicates, got %s", name, assumeArg.Type())
+		}
+		for i := 0; i < list.Len(); i++ {
+			pred, err := assumeFromArg(list.Index(i))
+			if err != nil {
+				return nil, fmt.Errorf("test(%q): assume[%d]: %w", name, i, err)
+			}
+			cfg.Assumes = append(cfg.Assumes, pred)
+		}
 	}
 
 	fullName := "test_" + name


### PR DESCRIPTION
## Summary

Ships rc1 of **RFC-043 — Non-deterministic Spec Operators**. Four
small Starlark primitives that give Faultbox specs the vocabulary
P-lang and TLA+ have used for decades to describe a *space of
behaviors*: \`choose()\`, \`nondet()\`, \`halt()\`, \`assume()\`.

rc1 is the **language surface + single-leaf runtime**: every operator
parses, validates, and runs against the current (first-option /
first-leaf) snapshot. The plan-tree fan-out — actually producing
N test runs per \`choose([opts])\` — lands with rc2 alongside
RFC-042 §8.8's body re-execution machinery.

## Commits

| # | Commit | Scope |
|---|---|---|
| 1 | \`2df88c1\` | ChoiceVal + \`choose()\` + \`nondet()\` boolean (§5.1, §5.2) |
| 2 | \`358b113\` | \`halt()\` builtin + \`"halted"\` outcome through SuiteResult/manifest/report (§5.3) |
| 3 | \`aa0569f\` | \`assume(predicate)\` + \`test(assume=[...])\` + sandboxed evaluation thread (§5.4) |
| 4 | \`0b3c05b\` | \`halt()\` outside test body rejected (§5.8 #3) |
| 5 | \`83822b9\` | \`docs/nondeterministic-operators.md\`, spec-language, manifest, RFC flip (§8.8) |

5 PRs, 12 files (excluding two stray docs picked up by \`git add docs/\` —
benign, unchanged from prior epics).

## What ships

### \`choose([opts])\` / \`choose("name", [opts])\` (§5.2)
Non-deterministic finite choice. rc1 returns the first option; the
\`ChoiceVal\` is recorded on \`rt.choices\` so the plan-tree fan-out
in rc2 can read the option set without re-parsing. Empty lists, non-
list args, non-string names, and wrong arities all error at spec load.

### \`nondet()\` (§5.1)
Sugar for \`choose([True, False])\`. **Overloaded** against the
pre-existing \`nondet(svc, ...)\` variant by argument count — the
service-exclusion form keeps working unchanged. RFC-044 may unify
later.

### \`halt(reason="")\` (§5.3)
Prune the current plan-tree branch. \`RunTest\` catches the \`ErrHalt\`
sentinel before the generic fail path and returns
\`Result="halted"\`. New \`SuiteResult.Halted\` counter +
\`bundle.Summary.Halted\` + HTML report \`"halted"\` outcome (grey pill,
distinct from pass/fail/inconclusive).

\`halt()\` at module top-level or inside \`setup=\` errors at spec
load — guarded via \`rt.inTest\` (atomic.Bool).

### \`assume(predicate)\` + \`test(assume=[...])\` (§5.4)
Plan-tree filter. Top-level form evaluates at spec load (violation
errors the load); per-test form evaluates at body entry (violation
halts the test). Predicates receive a \`choices\` dict mapping each
named \`choose("name", opts)\` call to its currently-selected option.
Predicates run in a sandbox \`starlark.Thread\` tagged \`"assume:<name>"\`;
Starlark errors inside the predicate fail the test instead of halting.

Bare booleans are accepted as a convenience (wrapped in a constant
closure).

## Deferred to rc2 (per the split agreed upstream)

- **§8.5 plan-tree fan-out** — body re-execution / per-leaf
  selection vectors. Lands with RFC-042 §8.8.
- **§8.6 cost-guard + choose-options static check** — no-op in rc1
  (single-leaf means cartesian = 1; Starlark's eager evaluation
  already rejects runtime-computed elements).
- **§8.7 assume predicate AST sandbox** — predicates run in a tagged
  sandbox thread today; the spec-load AST walk that rejects service
  / fault references lands with rc2.
- **§8.9 testops goldens** — unit + CLI tests in rc1; end-to-end
  goldens share the same corpus as the interleaving work.

## Compatibility

- **Specs**: \`fault_matrix\`, \`fault_scenario\`, \`scenario\`,
  \`test()\`, \`def test_*()\` all behave exactly as before. New
  operators are additive; existing specs that never call them see no
  change.
- **\`nondet(svc, ...)\`**: pre-RFC-043 variadic form preserved.
  Zero-arg \`nondet()\` is the new RFC-043 boolean.
- **Bundles**: \`summary.halted\` is omitempty — pre-RFC-043 bundle
  readers see the same fields as before. \`Result="halted"\` is a
  new value alongside \`pass\` / \`fail\` / \`error\` / \`inconclusive\`.

## Test plan

- [x] \`go test ./...\` — green
- [x] \`go vet ./...\` — clean
- [x] choose / nondet arity + type + recording: \`internal/star/choose_test.go\`
- [x] halt sentinel + reason + RunTest path + top-level rejection +
  setup rejection: \`internal/star/halt_test.go\`
- [x] assume top-level + per-test + predicate raise + unnamed-choice
  skip: \`internal/star/assume_test.go\`
- [x] Existing temporal / determinism / plan tests still green
- [x] Manual smoke against a small choose+halt+assume spec