### PR TITLE
fix(runtime): drain alwaysFired/twFired on bodyDone arm (#119)

### DIFF
--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1199,6 +1199,20 @@ func (rt *Runtime) RunTest(ctx context.Context, name string) TestResult {
 		// Body completed under its own power. cause stays Natural
 		// unless the body raised; that's classified after we examine
 		// the error below.
+		//
+		// Drain alwaysFired / twFired non-blockingly to disambiguate
+		// the simultaneous-ready case: if both bodyDone and one of the
+		// signals were ready at the same scheduling tick, Go's select
+		// chooses uniformly at random — losing the violation/terminate
+		// signal would silently drop an invariant failure (issue #119).
+		// Mirrors the disambiguation in the bodyCtx.Done() arm.
+		select {
+		case <-alwaysFired:
+			cause = TerminationImmediateFail
+		case <-twFired:
+			cause = TerminationTerminateWhen
+		default:
+		}
 	case <-alwaysFired:
 		// always() invariant violated mid-run. RFC-041 §5.2 — fail
 		// immediately, rolling pending eventually's into the verdict.


### PR DESCRIPTION
## Summary

- Closes #119 — RunTest's `select` had no secondary drain on the `bodyDone` arm. When both `bodyDone` and `alwaysFired` (or `twFired`) were ready in the same scheduling tick, Go's select chose uniformly at random, silently dropping invariant violations / terminate_when signals when `bodyDone` won.
- Fix: non-blocking drain of `alwaysFired` and `twFired` right after `bo = <-bodyDone`. Mirrors the disambiguation already present in the `bodyCtx.Done()` arm.

## Why no test

Reproducing a Go-select race deterministically requires either (a) stress-looping 100+ times and asserting zero flakiness, which is slow and probabilistic, or (b) injecting test-only channel pre-arming, which would alter the code under test. The fix is structurally identical to the `bodyCtx.Done()` drain that's been correctness-checked since RFC-041 landed — copying its pattern is the proof.

## Test plan

- [x] `go test ./... && go vet ./...` clean
- [x] No behavioral change to any of the existing always()/terminate_when test paths (drain only fires when signal is already ready, which the existing tests don't construct)