### PR TITLE
feat(report): per-leaf axis surfacing in TestResult, manifest, and tests table (A3, RFC-042 §8.10)

### DIFF
--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -2289,6 +2289,12 @@ func testRowsFromResult(result *star.SuiteResult) []bundle.TestRow {
 			})
 		}
 
+		// Copy the per-leaf axis maps rather than aliasing TestResult's
+		// references. RunTestLeaf already deep-copies them off the
+		// PlanLeaf; we copy here too so a future refactor of
+		// TestResult lifecycle can't introduce a shared-mutation bug
+		// across the manifest row and the suite-result row (review
+		// N2 on PR #124).
 		rows = append(rows, bundle.TestRow{
 			Name:                    tr.Name,
 			Outcome:                 outcome,
@@ -2297,12 +2303,45 @@ func testRowsFromResult(result *star.SuiteResult) []bundle.TestRow {
 			Expectation:             tr.ExpectationName,
 			BypassedRules:           bypassed,
 			LeafID:                  tr.LeafID,
-			LeafChoices:             tr.LeafChoices,
-			LeafProbabilityOutcomes: tr.LeafProbabilityOutcomes,
-			LeafInterleavingIDs:     tr.LeafInterleavingIDs,
+			LeafChoices:             copyIntMapForRow(tr.LeafChoices),
+			LeafProbabilityOutcomes: copyBoolVecMapForRow(tr.LeafProbabilityOutcomes),
+			LeafInterleavingIDs:     copyIntMapForRow(tr.LeafInterleavingIDs),
 		})
 	}
 	return rows
+}
+
+// copyIntMapForRow returns nil for an empty or nil source so the
+// omitempty JSON contract on TestRow.LeafChoices /
+// LeafInterleavingIDs is preserved. Otherwise allocates a fresh map
+// — testRowsFromResult avoids aliasing the SuiteResult's maps so a
+// downstream mutator can't drift both row sets in lockstep (review
+// N2 on PR #124).
+func copyIntMapForRow(m map[string]int) map[string]int {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// copyBoolVecMapForRow mirrors copyIntMapForRow for the per-leaf
+// probability outcomes map. The bool vectors are also deep-copied
+// since they're the load-bearing structure for engine consultation.
+func copyBoolVecMapForRow(m map[string][]bool) map[string][]bool {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string][]bool, len(m))
+	for k, v := range m {
+		cp := make([]bool, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }
 
 // printReplayHints emits a `Replay: faultbox replay …` line per failed

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -2290,13 +2290,16 @@ func testRowsFromResult(result *star.SuiteResult) []bundle.TestRow {
 		}
 
 		rows = append(rows, bundle.TestRow{
-			Name:          tr.Name,
-			Outcome:       outcome,
-			DurationMs:    tr.DurationMs,
-			Seed:          tr.Seed,
-			Expectation:   tr.ExpectationName,
-			BypassedRules: bypassed,
-			LeafID:        tr.LeafID,
+			Name:                    tr.Name,
+			Outcome:                 outcome,
+			DurationMs:              tr.DurationMs,
+			Seed:                    tr.Seed,
+			Expectation:             tr.ExpectationName,
+			BypassedRules:           bypassed,
+			LeafID:                  tr.LeafID,
+			LeafChoices:             tr.LeafChoices,
+			LeafProbabilityOutcomes: tr.LeafProbabilityOutcomes,
+			LeafInterleavingIDs:     tr.LeafInterleavingIDs,
 		})
 	}
 	return rows

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -1400,6 +1400,26 @@ fault never fired. The predicate name (e.g. `expect_success`,
 `manifest.tests[].expectation` and surfaces alongside the pill in the
 report's tests table and drill-down header.
 
+#### Per-leaf axis attribution (v0.13.0 rc2)
+
+Multi-leaf rows from `choose()` / `probability=`/ `interleavings=`
+fan-out carry their axis assignments on the manifest row:
+
+- `leaf_choices` — map of named choose() axes to the **option index**
+  (zero-based) the leaf selected. The HTML report's tests table
+  renders this as `retries=2`, which means *"option at index 2"* —
+  NOT the literal value. For `choose("retries", [0, 1, 3])`, leaf 2
+  observes the value `3`; the display shows `retries=2`. The full
+  spec (axis values) lives in `plan.json`'s recorded choices.
+- `leaf_probability_outcomes` — per-rule fire/no-fire bit vector
+  (`wal[10]` = first occurrence fires, second does not).
+- `leaf_interleavings` — per `parallel()` call site, the
+  ordering-index the leaf executed (`spec.star:7#3` = site at
+  spec.star:7, ordering index 3).
+
+The omitempty contract holds: single-leaf rows omit all three fields,
+preserving the rc1 manifest shape.
+
 #### `require_faults_fire=True` on `fault_matrix()` (v0.11.1)
 
 Opt-in gate that demotes rows where at least one installed fault rule

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -111,6 +111,18 @@ type TestRow struct {
 	// have distinct LeafID values; consumers can group on Name and
 	// disambiguate by LeafID.
 	LeafID string `json:"leaf_id,omitempty"`
+
+	// LeafChoices snapshots the named choose() option indices this
+	// leaf observed (RFC-043 §5.2). nil for single-leaf rows.
+	LeafChoices map[string]int `json:"leaf_choices,omitempty"`
+	// LeafProbabilityOutcomes records the per-rule fired/not-fired
+	// vector the engine drove for this leaf (RFC-042 §8.9). nil for
+	// single-leaf and stochastic-mode rules.
+	LeafProbabilityOutcomes map[string][]bool `json:"leaf_probability_outcomes,omitempty"`
+	// LeafInterleavingIDs records the per-parallel-site ordering
+	// index this leaf executed (RFC-042 §8.8). nil for single-leaf
+	// and single-policy sites.
+	LeafInterleavingIDs map[string]int `json:"leaf_interleavings,omitempty"`
 }
 
 // BypassedRule mirrors star.BypassedRule for the manifest — we don't

--- a/internal/report/app.js
+++ b/internal/report/app.js
@@ -159,6 +159,34 @@
   // place so the drill-down header, the tests table, and the matrix
   // stay in lockstep. Precedence mirrors cmd/faultbox/main.go:
   // failed/errored > expectation_violated > fault_bypassed > passed.
+  // formatLeafAxes turns a TestRow's leaf_choices / leaf_probability_outcomes
+  // / leaf_interleavings maps into a compact display string for the
+  // tests table (RFC-042 §8.10 Plan-tab integration). Returns "" when
+  // the row has no leaf-axis data, so the caller can fall back to the
+  // bare LeafID display. Output is intentionally terse — the
+  // drill-down panel surfaces the full structure for deeper inspection.
+  function formatLeafAxes(row) {
+    var parts = [];
+    var ch = row.leaf_choices || {};
+    Object.keys(ch).sort().forEach(function (k) {
+      parts.push(k + "=" + ch[k]);
+    });
+    var prob = row.leaf_probability_outcomes || {};
+    Object.keys(prob).sort().forEach(function (k) {
+      var vec = prob[k] || [];
+      var bits = vec.map(function (b) { return b ? "1" : "0"; }).join("");
+      parts.push(k + "[" + bits + "]");
+    });
+    var inter = row.leaf_interleavings || {};
+    Object.keys(inter).sort().forEach(function (k) {
+      // Show only the file:line basename to keep the chip short —
+      // full path is in the JSON for tooling.
+      var short = k.split("/").pop();
+      parts.push(short + "#" + inter[k]);
+    });
+    return parts.join(", ");
+  }
+
   function outcomeFromTrace(test) {
     if (!test) return "";
     if (test.result === "pass") {
@@ -489,11 +517,16 @@
       var pillClass = outcomeClass(r.outcome);
       var fa = (r.fault_assumptions || []).join(", ");
       // RFC-042 §8.8 / RFC-043 §5.2 multi-leaf rendering: when a test
-      // fans out across choose() / probability axes, every leaf shares
-      // the test name. Suffix the display name with the leaf ordinal
-      // so the table doesn't read as N duplicates. Single-leaf rows
-      // (LeafID empty) keep the rc1 shape.
-      var displayName = r.leaf_id ? r.name + " [leaf " + r.leaf_id + "]" : r.name;
+      // fans out across choose() / probability / interleaving axes,
+      // every leaf shares the test name. Suffix the display name with
+      // the leaf ordinal + the leaf's axis assignments so the table
+      // shows what each leaf actually saw. Single-leaf rows (LeafID
+      // empty) keep the rc1 shape.
+      var displayName = r.name;
+      if (r.leaf_id) {
+        var axes = formatLeafAxes(r);
+        displayName = r.name + " [leaf " + r.leaf_id + (axes ? " — " + axes : "") + "]";
+      }
       var tr = el("tr", {
         "data-test": r.name,
         onclick: (function (n) { return function () { openDrillDown(n); }; })(r.name),

--- a/internal/star/choose_test.go
+++ b/internal/star/choose_test.go
@@ -294,6 +294,54 @@ def test_cross():
 	}
 }
 
+// TestRunAll_LeafChoicesSurfaceOnTestResult — each leaf's TestResult
+// carries the actual per-leaf choose() axis assignment in
+// LeafChoices, so the bundle manifest and HTML report can render
+// what every leaf actually saw (RFC-042 §8.10 Plan-tab integration,
+// A3).
+func TestRunAll_LeafChoicesSurfaceOnTestResult(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def test_axis():
+    _ = choose("retries", [0, 1, 3])
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	res, err := rt.RunAll(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if len(res.Tests) != 3 {
+		t.Fatalf("expected 3 leaves, got %d", len(res.Tests))
+	}
+	seen := map[int]bool{}
+	for _, tr := range res.Tests {
+		if tr.LeafChoices == nil {
+			t.Errorf("leaf %s: LeafChoices missing", tr.LeafID)
+			continue
+		}
+		idx, ok := tr.LeafChoices["retries"]
+		if !ok {
+			t.Errorf("leaf %s: missing retries axis; have %v", tr.LeafID, tr.LeafChoices)
+			continue
+		}
+		seen[idx] = true
+	}
+	for _, want := range []int{0, 1, 2} {
+		if !seen[want] {
+			t.Errorf("missing retries option index %d in leaves; got %v", want, seen)
+		}
+	}
+	// Single-leaf rows omit LeafChoices entirely.
+	rt2 := New(testLogger())
+	_ = rt2.LoadString("spec.star", `def test_plain(): pass`)
+	res2, _ := rt2.RunAll(context.Background(), RunConfig{})
+	if res2.Tests[0].LeafChoices != nil {
+		t.Errorf("single-leaf result must omit LeafChoices; got %v", res2.Tests[0].LeafChoices)
+	}
+}
+
 // TestRunAll_NoChoiceStaysSingleLeaf — a test that doesn't call
 // choose() at all keeps the rc1 shape: one TestResult per test, no
 // LeafID set. This guards backwards-compatibility for the entire

--- a/internal/star/interleavings_test.go
+++ b/internal/star/interleavings_test.go
@@ -586,6 +586,35 @@ func TestParallelWithLeaf_SkipsOutOfRangeIndex(t *testing.T) {
 	}
 }
 
+// TestRunAll_LeafInterleavingsSurfaceOnTestResult — interleaving
+// axes flow into TestResult.LeafInterleavingIDs (A3 / RFC-042 §8.10).
+// The HTML report's formatLeafAxes() consumes this through the
+// bundle's leaf_interleavings field to render per-leaf labels.
+func TestRunAll_LeafInterleavingsSurfaceOnTestResult(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def a(): pass
+def b(): pass
+def test_par_axis():
+    parallel(a, b, interleavings="all")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	res, err := rt.RunAll(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if len(res.Tests) != 2 {
+		t.Fatalf("expected 2 leaves, got %d", len(res.Tests))
+	}
+	for _, tr := range res.Tests {
+		if len(tr.LeafInterleavingIDs) != 1 {
+			t.Errorf("leaf %s: expected 1 interleaving entry, got %v", tr.LeafID, tr.LeafInterleavingIDs)
+		}
+	}
+}
+
 // TestInterleavings_ParallelRejectsBadKwarg — bad value surfaces at
 // runtime (parallel() is body-time, not load-time).
 func TestInterleavings_ParallelRejectsBadKwarg(t *testing.T) {

--- a/internal/star/interleavings_test.go
+++ b/internal/star/interleavings_test.go
@@ -590,6 +590,10 @@ func TestParallelWithLeaf_SkipsOutOfRangeIndex(t *testing.T) {
 // axes flow into TestResult.LeafInterleavingIDs (A3 / RFC-042 §8.10).
 // The HTML report's formatLeafAxes() consumes this through the
 // bundle's leaf_interleavings field to render per-leaf labels.
+//
+// Review N3 on PR #124: assert the two leaves carry DISTINCT
+// interleaving indices, not just that each has an entry. A
+// regression to always-index-0 would pass the bare count check.
 func TestRunAll_LeafInterleavingsSurfaceOnTestResult(t *testing.T) {
 	rt := New(testLogger())
 	src := `
@@ -608,9 +612,25 @@ def test_par_axis():
 	if len(res.Tests) != 2 {
 		t.Fatalf("expected 2 leaves, got %d", len(res.Tests))
 	}
+	seenIdx := map[int]bool{}
+	var seenKey string
 	for _, tr := range res.Tests {
 		if len(tr.LeafInterleavingIDs) != 1 {
 			t.Errorf("leaf %s: expected 1 interleaving entry, got %v", tr.LeafID, tr.LeafInterleavingIDs)
+			continue
+		}
+		for k, idx := range tr.LeafInterleavingIDs {
+			if seenKey == "" {
+				seenKey = k
+			} else if k != seenKey {
+				t.Errorf("leaves disagree on parallel site key: %q vs %q", seenKey, k)
+			}
+			seenIdx[idx] = true
+		}
+	}
+	for _, want := range []int{0, 1} {
+		if !seenIdx[want] {
+			t.Errorf("missing interleaving index %d across leaves; got %v", want, seenIdx)
 		}
 	}
 }

--- a/internal/star/probability_fanout_test.go
+++ b/internal/star/probability_fanout_test.go
@@ -128,6 +128,100 @@ dn = deny("EIO", probability=0.3, max_fires=2)
 	}
 }
 
+// TestRunAll_LeafProbabilityOutcomesSurfaceOnTestResult — review
+// B1 on PR #124: prove every leaf of a probability fan-out carries
+// its actual fire/no-fire vector through to TestResult. The
+// copyBoolVecMap deep-copy path was untested at the TestResult
+// level before this regression guard.
+func TestRunAll_LeafProbabilityOutcomesSurfaceOnTestResult(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+svc = service("svc", image="busybox", cmd=["sh","-c","sleep 1"])
+dn = deny("EIO", probability=0.3, max_fires=2, mode="exhaustive", label="wal")
+def test_prob():
+    fault(svc, write=dn, run=lambda: None)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	res, err := rt.RunAll(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if len(res.Tests) != 4 {
+		t.Fatalf("expected 4 leaves (2^max_fires), got %d", len(res.Tests))
+	}
+	seen := map[string]bool{}
+	for _, tr := range res.Tests {
+		if tr.LeafProbabilityOutcomes == nil {
+			t.Errorf("leaf %s: LeafProbabilityOutcomes missing", tr.LeafID)
+			continue
+		}
+		vec, ok := tr.LeafProbabilityOutcomes["wal"]
+		if !ok {
+			t.Errorf("leaf %s: missing wal key; have %v", tr.LeafID, tr.LeafProbabilityOutcomes)
+			continue
+		}
+		if len(vec) != 2 {
+			t.Errorf("leaf %s: vector len = %d, want 2", tr.LeafID, len(vec))
+			continue
+		}
+		key := ""
+		for _, b := range vec {
+			if b {
+				key += "1"
+			} else {
+				key += "0"
+			}
+		}
+		seen[key] = true
+	}
+	for _, want := range []string{"00", "01", "10", "11"} {
+		if !seen[want] {
+			t.Errorf("missing vector %q in leaves; got %v", want, seen)
+		}
+	}
+	// Single-leaf rows must omit the field entirely.
+	rt2 := New(testLogger())
+	_ = rt2.LoadString("spec.star", `def test_plain(): pass`)
+	res2, _ := rt2.RunAll(context.Background(), RunConfig{})
+	if res2.Tests[0].LeafProbabilityOutcomes != nil {
+		t.Errorf("single-leaf result must omit LeafProbabilityOutcomes; got %v", res2.Tests[0].LeafProbabilityOutcomes)
+	}
+}
+
+// TestRunAll_CombinedChooseAndProbCarryBothMaps — composite leaf
+// (choose() × probability) must carry both maps. Guards against a
+// future refactor that copies one kind but not the other.
+func TestRunAll_CombinedChooseAndProbCarryBothMaps(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+svc = service("svc", image="busybox", cmd=["sh","-c","sleep 1"])
+dn = deny("EIO", probability=0.3, max_fires=1, mode="exhaustive", label="wal")
+def test_combo():
+    _ = choose("retries", [0, 1])
+    fault(svc, write=dn, run=lambda: None)
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	res, err := rt.RunAll(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if len(res.Tests) != 4 {
+		t.Fatalf("expected 4 leaves (2 × 2), got %d", len(res.Tests))
+	}
+	for _, tr := range res.Tests {
+		if _, ok := tr.LeafChoices["retries"]; !ok {
+			t.Errorf("leaf %s missing retries in LeafChoices: %v", tr.LeafID, tr.LeafChoices)
+		}
+		if _, ok := tr.LeafProbabilityOutcomes["wal"]; !ok {
+			t.Errorf("leaf %s missing wal in LeafProbabilityOutcomes: %v", tr.LeafID, tr.LeafProbabilityOutcomes)
+		}
+	}
+}
+
 // TestProbabilityDecider_ConsultsLeaf — the runtime's decider
 // closure pulls the current leaf's outcomes vector and returns
 // (fire, pinned) matching ProbabilityFire's contract. Falls back to

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -87,6 +87,25 @@ type TestResult struct {
 	// callers — today it's the leaf's ordinal index ("1", "2", ...);
 	// the plan-tree enumerator may grow a richer naming scheme later.
 	LeafID string `json:"leaf_id,omitempty"`
+
+	// LeafChoices snapshots the leaf's named choose() axis assignments
+	// (RFC-043 §5.2). Key is the axis name; value is the selected
+	// option index into ChoiceVal.Options. nil for single-leaf
+	// executions.
+	LeafChoices map[string]int `json:"leaf_choices,omitempty"`
+
+	// LeafProbabilityOutcomes mirrors PlanLeaf.ProbabilityOutcomes for
+	// the bundle / report (RFC-042 §8.9). Key is the fault rule's
+	// label or "<service>:<syscall>"; vector is the per-occurrence
+	// fired/not-fired sequence consulted by the engine. nil for
+	// single-leaf and stochastic-mode rules.
+	LeafProbabilityOutcomes map[string][]bool `json:"leaf_probability_outcomes,omitempty"`
+
+	// LeafInterleavingIDs mirrors PlanLeaf.InterleavingIDs (RFC-042 §8.8).
+	// Key is the parallel() call site (file:line); value is the
+	// zero-based ordering index. nil for single-leaf and
+	// single-policy sites.
+	LeafInterleavingIDs map[string]int `json:"leaf_interleavings,omitempty"`
 }
 
 // BypassedRule describes one fault rule that was installed for this
@@ -1104,6 +1123,22 @@ func (rt *Runtime) runTestFanout(ctx context.Context, name string) []TestResult 
 		leaf := leaves[0]
 		results = append(results, rt.runTestSafelyLeaf(ctx, name, &leaf))
 	} else {
+		// Reuse the discovery run as leaf 0, but stamp the leaf's
+		// actual axis assignments onto the result so the bundle
+		// manifest and HTML report can render the per-leaf data
+		// (A3 / RFC-042 §8.10). The discovery run used leaf0 with
+		// an empty Choices map; the enumerated leaf 0 has the
+		// all-option-0 assignment for every named axis, which is
+		// semantically what the discovery run observed.
+		if len(leaves[0].Choices) > 0 {
+			tr0.LeafChoices = copyIntMap(leaves[0].Choices)
+		}
+		if len(leaves[0].ProbabilityOutcomes) > 0 {
+			tr0.LeafProbabilityOutcomes = copyBoolVecMap(leaves[0].ProbabilityOutcomes)
+		}
+		if len(leaves[0].InterleavingIDs) > 0 {
+			tr0.LeafInterleavingIDs = copyIntMap(leaves[0].InterleavingIDs)
+		}
 		results = append(results, tr0)
 	}
 	for i := 1; i < len(leaves); i++ {
@@ -1150,8 +1185,40 @@ func (rt *Runtime) RunTestLeaf(ctx context.Context, name string, leaf *PlanLeaf)
 	tr := rt.runTestImpl(ctx, name)
 	if leaf != nil {
 		tr.LeafID = fmt.Sprintf("%d", leaf.Index)
+		// Snapshot per-leaf axis assignments so the bundle manifest
+		// and HTML report can render exactly what each leaf saw
+		// (RFC-042 §8.10 Plan-tab integration). Maps are passed by
+		// reference into the leaf at construction time; copy them
+		// here so a later mutation can't drift the recorded result.
+		if len(leaf.Choices) > 0 {
+			tr.LeafChoices = copyIntMap(leaf.Choices)
+		}
+		if len(leaf.ProbabilityOutcomes) > 0 {
+			tr.LeafProbabilityOutcomes = copyBoolVecMap(leaf.ProbabilityOutcomes)
+		}
+		if len(leaf.InterleavingIDs) > 0 {
+			tr.LeafInterleavingIDs = copyIntMap(leaf.InterleavingIDs)
+		}
 	}
 	return tr
+}
+
+func copyIntMap(m map[string]int) map[string]int {
+	out := make(map[string]int, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func copyBoolVecMap(m map[string][]bool) map[string][]bool {
+	out := make(map[string][]bool, len(m))
+	for k, v := range m {
+		cp := make([]bool, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }
 
 // runTestImpl is the original RunTest body, kept private so the


### PR DESCRIPTION
## Summary

Closes A3 — the v0.13.0 Plan-tab integration slice for rc2 fan-out data. Each multi-leaf `TestResult` now carries the leaf's actual axis assignments through to the bundle manifest and the HTML report's tests table.

Before this PR, multi-leaf rows in the tests table read as `test_foo [leaf 0]`, `test_foo [leaf 1]`, ... — you knew leaves existed but couldn't see what each leaf observed without cross-referencing `plan.json`. After: `test_foo [leaf 3 — retries=1, fault=2]` or `test_foo [leaf 5 — wal[10]]` or `test_foo [leaf 1 — spec.star:7#3]`.

## What landed

- **`TestResult`** gains `LeafChoices map[string]int`, `LeafProbabilityOutcomes map[string][]bool`, `LeafInterleavingIDs map[string]int`. Populated by `RunTestLeaf` from the attached PlanLeaf; defensive deep-copy so later mutations don't drift the recorded result.
- **`runTestFanout`** stamps the enumerated leaf 0 axes onto the reused discovery-run result so single-leaf-reuse rows carry the same data as re-executed leaves. Closes the gap where leaf 0 of a choose-only fan-out had nil `LeafChoices`.
- **`bundle.TestRow`** gains `leaf_choices`, `leaf_probability_outcomes`, `leaf_interleavings` (all `omitempty`). `cmd/faultbox`'s `testRowsFromResult` propagates from TestResult.
- **`internal/report/app.js`** gains a `formatLeafAxes(row)` helper returning a compact display string. Tests table's display name now suffixes with axis details when present.

## Scope limit

Per-leaf axes are runtime-observed data and live in **manifest.tests**, not `plan.json`. The Plan tab itself (static analysis, no body run) still renders fault_matrix compositions only. Surfacing rc2 axes in plan.json would require running the body during plan generation; tracked as a follow-up.

## Test plan

- [x] `go test -race ./...` clean
- [x] 2 new tests:
  - `TestRunAll_LeafChoicesSurfaceOnTestResult` — 3 leaves of `choose("retries", [0,1,3])` each carry their option index; single-leaf rows omit the field
  - `TestRunAll_LeafInterleavingsSurfaceOnTestResult` — 2 leaves of `parallel(a, b, interleavings="all")` each carry one interleaving entry
- [x] Pre-existing tests unchanged: single-leaf rows still omit the new fields (rc1 manifest shape preserved byte-identically)

## Migration

Additive: existing manifest consumers see the new fields only when they're populated (omitempty). The `leaf_id` shape from rc2 PR #121 is unchanged.