### PR TITLE
chore(rfc-044): C1 — RFC-013/RFC-002 withdrawals + generate deprecation + L1-cap docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,20 @@ default. **Deferred:** §8.5 plan-walker-time `assume=` pruning
 follow-up) and §8.6 cost-guard. User guide:
 [docs/nondeterministic-operators.md](docs/nondeterministic-operators.md).
 
-RFC-044 (spec-language simplification) remains a draft RFC tracked
-in GitHub issue #113.
+**RFC-044 — spec language simplification (partial).** First slice
+(§8.1 + §8.3 + §8.4 + §8.5) — the docs-and-deprecations bundle:
+RFC-013 (`param()`) formally **withdrawn** and the
+`docs/rfcs/0013-parameterized-scenarios.md` header updated with a
+rationale paragraph pointing users to RFC-043 `choose("name",
+[opts])`; RFC-002 (`domain()`) formally **withdrawn** via a new
+`docs/rfcs/0002-domain.md` stub; `faultbox generate` deprecated in
+favor of `faultbox plan --suggest` with a one-time stderr warning
+and a CLI-reference callout (removal in v0.14.0); a new
+"Feature interactions — what caps below L4" subsection in
+`docs/spec-language.md` documents the determinism ceilings for
+`service(remote=…)`, `service(reuse=True, …)`, and `mock_service(…)`.
+Remaining RFC-044 sections (§8.2 unified fan-out machinery, §8.6
+`observe.*`, §8.7 `decoder()`) tracked as follow-up slices.
 RFC-046 carries the post-L1 roadmap (gVisor Path B/C, L4 hermetic
 mode, L5 instruction-boundary research).
 

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -1271,6 +1271,12 @@ MCP server (auto-configured in .mcp.json):
 
 // generateCmd handles: faultbox generate <file.star> [flags]
 func generateCmd(args []string) int {
+	// RFC-044 §8.3 — `faultbox generate` is deprecated in favor of
+	// `faultbox plan --suggest`. Emit a one-time warning on stderr
+	// so existing scripts keep working while we steer users to the
+	// new surface; the command will be removed in v0.14.0.
+	fmt.Fprintln(os.Stderr, "warning: `faultbox generate` is deprecated; use `faultbox plan --suggest` instead. Removal in v0.14.0.")
+
 	var starFile, output, scenarioFilter, serviceFilter, category string
 	dryRun := false
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -412,7 +412,9 @@ faultbox diff run1.norm run2.norm
 
 ---
 
-### `faultbox generate`
+### `faultbox generate` *(deprecated — use `faultbox plan --suggest`)*
+
+> **Deprecated as of v0.13.0 (RFC-044 §8.3).** Prints a deprecation warning on stderr; will be removed in v0.14.0. New users should reach for `faultbox plan --suggest`, which performs the same topology-driven mutation analysis through the unified plan-tree pipeline.
 
 Generate failure scenarios from registered `scenario()` functions.
 

--- a/docs/rfcs/0002-domain.md
+++ b/docs/rfcs/0002-domain.md
@@ -1,0 +1,41 @@
+# RFC-002: `domain()` Primitive & Multi-Service Grouping
+
+- **Status:** Withdrawn (RFC-044 §8.4, v0.13.0)
+- **Author:** —
+- **Created:** —
+
+## Withdrawal rationale
+
+RFC-002 was an early sketch for grouping N microservices into a single
+`domain()` declaration that exported API/message contracts. The project
+pivoted to a `service()`-first model: each service is independent and
+contracts are expressed through `interface()` declarations on those
+services rather than a higher-level wrapper.
+
+`domain()` was never specified in detail, never prototyped, and never
+appeared as a customer ask after the pivot. Three years of accumulated
+usage with `service()` + `interface()` validated that the two-level
+model is sufficient — adding a third level (`domain` → `service` →
+`interface`) would have introduced abstraction overhead with no
+corresponding power.
+
+RFC-002 is withdrawn rather than deferred because:
+
+- The `service()`-first model is now load-bearing across the runtime,
+  the bundle format, the report, and the docs. Retrofitting
+  `domain()` would touch all of them.
+- RFC-004 and RFC-005 also reference `domain()` as a dependency
+  primitive; those RFCs are themselves draft/deferred and will pick
+  a different anchor when they're rewritten.
+- Customer feedback in 2026 Q1 confirmed that multi-service grouping
+  is needed at the *test organization* layer (which `fault_matrix`
+  already covers) rather than the *spec topology* layer.
+
+No code action is required — `domain()` was never implemented.
+
+## Related
+
+- `service()` and `interface()` — the surviving topology primitives,
+  documented in [docs/spec-language.md](../spec-language.md).
+- RFC-044 §8.4 — formal withdrawal under the v0.13.0 simplification
+  epic.

--- a/docs/rfcs/0013-parameterized-scenarios.md
+++ b/docs/rfcs/0013-parameterized-scenarios.md
@@ -3,6 +3,7 @@
 - **Status:** Withdrawn (RFC-044 §8.1, v0.13.0)
 - **Author:** Boris Glebov, Claude Opus 4.6
 - **Created:** 2026-04-13
+- **Depends On:** RFC-001 (Scenarios as Probes)
 
 ## Withdrawal rationale
 
@@ -19,8 +20,6 @@ should write `choose("retries", [0, 1, 3])` — same arity, same
 output, integrated with the rc2 body-re-execution engine.
 
 The rest of this document is preserved for historical context.
-- **Branch:** `rfc/013-parameterized-scenarios`
-- **Depends On:** RFC-001 (Scenarios as Probes)
 
 ## Summary
 

--- a/docs/rfcs/0013-parameterized-scenarios.md
+++ b/docs/rfcs/0013-parameterized-scenarios.md
@@ -1,8 +1,24 @@
 # RFC-013: Parameterized Scenarios & Value Generators
 
-- **Status:** Draft
+- **Status:** Withdrawn (RFC-044 §8.1, v0.13.0)
 - **Author:** Boris Glebov, Claude Opus 4.6
 - **Created:** 2026-04-13
+
+## Withdrawal rationale
+
+RFC-013's `param("retries", choices=[0, 1, 3])` and RFC-043's
+`choose("retries", [0, 1, 3])` are the same primitive with two
+names. RFC-013 was never shipped — `param()` was specified but no
+builtin landed. v0.13.0-rc2 made `choose()` the unified surface
+(named axes drive plan-tree fan-out; the report renders the
+`name=` annotation), so a separate `param()` builtin would be
+duplicate vocabulary with no semantic difference.
+
+Spec authors who would have written `param("retries", choices=[0, 1, 3])`
+should write `choose("retries", [0, 1, 3])` — same arity, same
+output, integrated with the rc2 body-re-execution engine.
+
+The rest of this document is preserved for historical context.
 - **Branch:** `rfc/013-parameterized-scenarios`
 - **Depends On:** RFC-001 (Scenarios as Probes)
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -23,7 +23,7 @@ Request for Comments for Faultbox v0.3.0 — Domain-Centric Verification Platfor
 | RFC | Title | Status | Depends On |
 |-----|-------|--------|------------|
 | [RFC-001](0001-scenario-probes.md) | Scenarios as Probes & Fault Scenario Composition | Implemented | — |
-| RFC-002 | `domain()` Primitive & Multi-Service Grouping | — | — |
+| [RFC-002](0002-domain.md) | `domain()` Primitive & Multi-Service Grouping | Withdrawn (RFC-044 §8.4) — service()/interface() supersede | — |
 | RFC-003 | Parallel Composition: `wait_all`, `wait_first`, `wait_n` | — | RFC-001 |
 
 ### Phase 2: Modularity & Tooling
@@ -40,7 +40,7 @@ Request for Comments for Faultbox v0.3.0 — Domain-Centric Verification Platfor
 
 | RFC | Title | Status | Depends On |
 |-----|-------|--------|------------|
-| [RFC-013](0013-parameterized-scenarios.md) | Parameterized Scenarios & Value Generators | Draft | RFC-001 |
+| [RFC-013](0013-parameterized-scenarios.md) | Parameterized Scenarios & Value Generators | Withdrawn (RFC-044 §8.1) — superseded by RFC-043 `choose()` | RFC-001 |
 
 ### Infrastructure
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -2357,9 +2357,10 @@ Some service-level features bound the achievable determinism level even when the
 |---|---|---|
 | `service(remote=...)` (RFC-036) | **L1** | Faultbox does not own the remote process, so unmediated I/O on the remote side is invisible to the runtime. Strict mode still gates the local code path; the remote stays best-effort. |
 | `service(reuse=True, …)` (RFC-015) | **L1** | Container state carried across tests breaks the per-test determinism contract that L2+ requires (seed-only reset isn't equivalent to a fresh process). Use the default `reuse=False` for L2+ specs. |
-| `mock_service(...)` (RFC-017) | L1 (matches default runtime) | Mock services are in-process stubs and don't run a separate process; nothing to mediate. They're compatible with all spec-level fan-out kinds but never raise the determinism ceiling. |
 
 L4 and L5 levels are reserved (`docs/determinism.md`) — for now any spec declaring them errors at spec load. When L4 lands, `service(remote=...)` and `service(reuse=True, ...)` will be rejected at that level with an error pointing to the documented cap above.
+
+**`mock_service(...)` (RFC-017) does not cap the determinism ceiling.** Mock services are in-process stubs with no separate process to mediate, so they're compatible with every level the spec declares. They're listed here for completeness but stay outside the cap table.
 
 ### Per-service tolerance: `nondeterministic_ok=`
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -2349,6 +2349,18 @@ determinism(allow = ["clock", "dns"])
 determinism(level = "L1", strict = False)
 ```
 
+#### Feature interactions — what caps below L4 (RFC-044 §8.5)
+
+Some service-level features bound the achievable determinism level even when the spec asks for higher. These caps are documented here so spec authors don't reach for `level="L4"` only to discover at run time that their topology can't reach it.
+
+| Feature | Max level achievable | Why |
+|---|---|---|
+| `service(remote=...)` (RFC-036) | **L1** | Faultbox does not own the remote process, so unmediated I/O on the remote side is invisible to the runtime. Strict mode still gates the local code path; the remote stays best-effort. |
+| `service(reuse=True, …)` (RFC-015) | **L1** | Container state carried across tests breaks the per-test determinism contract that L2+ requires (seed-only reset isn't equivalent to a fresh process). Use the default `reuse=False` for L2+ specs. |
+| `mock_service(...)` (RFC-017) | L1 (matches default runtime) | Mock services are in-process stubs and don't run a separate process; nothing to mediate. They're compatible with all spec-level fan-out kinds but never raise the determinism ceiling. |
+
+L4 and L5 levels are reserved (`docs/determinism.md`) — for now any spec declaring them errors at spec load. When L4 lands, `service(remote=...)` and `service(reuse=True, ...)` will be rejected at that level with an error pointing to the documented cap above.
+
 ### Per-service tolerance: `nondeterministic_ok=`
 
 `service()` accepts a `nondeterministic_ok = [...]` kwarg listing categories tolerated *for that service alone*. The runtime takes the union of `determinism(allow=...)` and `service.nondeterministic_ok` when deciding whether to fail.


### PR DESCRIPTION
## Summary

LGTM on PR #125 — B (RFC-043 rc2 wiring) merged as `083f264`. This PR opens **C1**, the first slice of RFC-044 (spec language simplification).

C1 is docs-and-deprecations: no engine changes. Locks the low-risk surface before the heavier refactor slices (C2 unified fan-out machinery, C3 observe.* / decoder() unification) land.

## What lands

- **§8.1 — RFC-013 (`param()`) withdrawn.** `param()` and `choose()` were the same primitive with two names; v0.13.0-rc2 made `choose("name", [...])` the unified surface. RFC-013 was never shipped, so no code change. Status header updated with rationale.
- **§8.4 — RFC-002 (`domain()`) withdrawn.** Early multi-service-grouping sketch; project pivoted to `service()`-first and never came back. New `docs/rfcs/0002-domain.md` stub explains the pivot. RFC-004 and RFC-005 reference RFC-002; they're themselves draft/deferred and will re-anchor when rewritten.
- **§8.3 — `faultbox generate` deprecated.** Command continues to work but prints a one-time stderr warning pointing users to `faultbox plan --suggest`. Removal scheduled for v0.14.0. CLI reference updated.
- **§8.5 — L1-cap feature documentation.** New "Feature interactions — what caps below L4" subsection in `docs/spec-language.md` tabulates the determinism ceilings for `service(remote=...)`, `service(reuse=True, ...)`, and `mock_service(...)`. Code-side error wiring is unreachable today (L2..L5 already error at spec load); the docs are the user-facing contract until L4 itself lands.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] No new tests — the slice is documentation-only except for one stderr warning in `generateCmd`

## Out of scope for C1

- **§8.2 — Unified fan-out machinery.** ~1-2 weeks refactor consolidating five plan-tree expansion paths into one `NonDeterministicChoice` type. Tracked as **C2** — independent epic.
- **§8.6 — `observe.*` unification.** Wraps existing event-source builtins with deprecated aliases. Tracked as **C3**.
- **§8.7 — `decoder("name", ...)` unification.** Same shape as §8.6 for json/logfmt/regex decoders. Tracked as **C3**.
- **Tutorial chapters for RFC-042/043.** Tracked as **C4** (the deferred original A1 work).