### PR TITLE
refactor(plan): unified NonDeterministicChoice interface (RFC-044 §8.2 / C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,20 +84,26 @@ default. **Deferred:** §8.5 plan-walker-time `assume=` pruning
 follow-up) and §8.6 cost-guard. User guide:
 [docs/nondeterministic-operators.md](docs/nondeterministic-operators.md).
 
-**RFC-044 — spec language simplification (partial).** First slice
-(§8.1 + §8.3 + §8.4 + §8.5) — the docs-and-deprecations bundle:
-RFC-013 (`param()`) formally **withdrawn** and the
-`docs/rfcs/0013-parameterized-scenarios.md` header updated with a
-rationale paragraph pointing users to RFC-043 `choose("name",
-[opts])`; RFC-002 (`domain()`) formally **withdrawn** via a new
-`docs/rfcs/0002-domain.md` stub; `faultbox generate` deprecated in
-favor of `faultbox plan --suggest` with a one-time stderr warning
-and a CLI-reference callout (removal in v0.14.0); a new
-"Feature interactions — what caps below L4" subsection in
+**RFC-044 — spec language simplification (§8.1 + §8.2 + §8.3 +
+§8.4 + §8.5).** C1 shipped the docs-and-deprecations bundle: RFC-013
+(`param()`) formally **withdrawn** (superseded by RFC-043
+`choose("name", [opts])`); RFC-002 (`domain()`) formally
+**withdrawn** via a new `docs/rfcs/0002-domain.md` stub; `faultbox
+generate` deprecated in favor of `faultbox plan --suggest` with a
+one-time stderr warning (removal in v0.14.0); a "Feature
+interactions — what caps below L4" subsection in
 `docs/spec-language.md` documents the determinism ceilings for
-`service(remote=…)`, `service(reuse=True, …)`, and `mock_service(…)`.
-Remaining RFC-044 sections (§8.2 unified fan-out machinery, §8.6
-`observe.*`, §8.7 `decoder()`) tracked as follow-up slices.
+`service(remote=…)` and `service(reuse=True, …)`. **C2** ships the
+unified fan-out machinery (§8.2): the three plan-tree axis kinds
+(`ChoiceVal`, `ProbFaultSite`, `ParallelSite`) now implement a
+single `NonDeterministicChoice` interface in
+`internal/star/nondet.go` with `Cardinality()` / `Apply(leaf, digit)`
+methods; `enumerateLeaves` is a thin wrapper over a generic
+mixed-radix walker `expandLeaves`. Adding a new axis kind in the
+future requires only implementing the two-method contract — no
+per-kind branching in the enumerator. All pre-existing testops
+goldens unchanged. Remaining RFC-044 sections (§8.6 `observe.*`,
+§8.7 `decoder()`) tracked as follow-up slices.
 RFC-046 carries the post-L1 roadmap (gVisor Path B/C, L4 hermetic
 mode, L5 instruction-boundary research).
 

--- a/docs/rfcs/0044-spec-language-simplification.md
+++ b/docs/rfcs/0044-spec-language-simplification.md
@@ -1,6 +1,6 @@
 # RFC-044: Spec Language Simplification
 
-> **Status: Draft.** Final RFC of the v0.13.0 epic. Designed alongside RFC-040 / RFC-041 / RFC-042 / RFC-043 to serve as the *design north star* for those implementations, but **implemented last** — after the four preceding RFCs land in v0.13.0-rc1/rc2. Captures cleanups and unifications enabled by the new determinism + non-determinism vocabulary.
+> **Status: Implemented partial (v0.13.0).** §8.1 (RFC-013 withdrawal) + §8.3 (`faultbox generate` deprecation) + §8.4 (RFC-002 withdrawal) + §8.5 (L1-cap documentation) shipped in C1 (#126). §8.2 (unified fan-out machinery) shipped in C2 — the three plan-tree fan-out axis kinds (`ChoiceVal`, `ProbFaultSite`, `ParallelSite`) now implement a single `NonDeterministicChoice` interface (`internal/star/nondet.go`); `enumerateLeaves` is a thin wrapper over a generic mixed-radix walker. **Deferred:** §8.6 `observe.*` and §8.7 `decoder()` module unifications.
 
 ## Summary
 
@@ -213,17 +213,17 @@ The committed v0.13.0 work for this RFC, **scheduled last in the epic**:
 
 ### 8.2 — Unified fan-out machinery
 
-Largest item in this RFC. Pure refactor; no user-facing API change. Sequence:
+> **Status: Implemented (C2, v0.13.0).** `NonDeterministicChoice` interface lives in `internal/star/nondet.go` with `Cardinality()` and `Apply(leaf, digit)` methods. `ChoiceVal`, `ProbFaultSite`, and `ParallelSite` implement the interface; `enumerateLeaves` is now a thin wrapper that flattens its three source slices into a homogeneous `[]NonDeterministicChoice` via `collectChoices` and forwards to a generic mixed-radix walker `expandLeaves`. All pre-existing testops goldens unchanged (the user-facing plan-tree shape is byte-identical to the rc2 implementation). **Scope note:** `fault_matrix` is intentionally NOT a NonDeterministicChoice — it produces discrete *test* entries at spec load time via `internal/plan/`, not *leaves* of one test at body time. The five-code-paths claim in the original RFC overstated the situation post-rc2 (only one path needed unifying — the others already went through `enumerateLeaves`).
+
+Original sequence (kept for historical context):
 
 1. Define `NonDeterministicChoice` and `Branch` types in `internal/star/nondet.go`.
-2. Refactor `fault_matrix` expansion to produce `[]NonDeterministicChoice` (was: list of dicts).
-3. Refactor RFC-043's `choose` and `nondet()` to produce same.
-4. Refactor RFC-042's `interleavings=` expansion to produce same.
-5. Refactor RFC-042's `probability=` expansion to produce same.
-6. Replace specialized cartesian product code in `internal/engine/` with a single recursive expansion over `[]NonDeterministicChoice`.
-7. Verify all pre-existing goldens unchanged (the user-facing plan tree must be byte-identical to before refactor).
-
-Estimated 1–2 weeks of focused work. **Implemented last because it's a refactor of all the producers** — easier to consolidate stable code than to consolidate moving targets.
+2. Refactor `fault_matrix` expansion to produce `[]NonDeterministicChoice` (was: list of dicts). — *NOT done; fault_matrix is a test fan-out, not a leaf fan-out.*
+3. Refactor RFC-043's `choose` and `nondet()` to produce same. — *done.*
+4. Refactor RFC-042's `interleavings=` expansion to produce same. — *done.*
+5. Refactor RFC-042's `probability=` expansion to produce same. — *done.*
+6. Replace specialized cartesian product code in `internal/engine/` with a single recursive expansion over `[]NonDeterministicChoice`. — *done in `internal/star/nondet.go::expandLeaves`; engine never had its own expansion code.*
+7. Verify all pre-existing goldens unchanged (the user-facing plan tree must be byte-identical to before refactor). — *done.*
 
 ### 8.3 — `faultbox generate` deprecation
 

--- a/internal/star/leaf.go
+++ b/internal/star/leaf.go
@@ -311,82 +311,22 @@ func interleavingCardinality(site ParallelSite) int {
 }
 
 // enumerateLeaves expands the cross-product of axes into PlanLeaf
-// values. With no axes of any kind, returns a single degenerate
-// leaf so callers can use the same iteration shape for fan-out and
-// non-fan-out tests. Leaf 0 is the all-zero assignment, which
-// matches what the discovery run already executed — callers can
-// reuse that run's result for leaf 0 and only re-execute leaves
-// 1..N-1.
+// values. Thin wrapper over expandLeaves (RFC-044 §8.2 unified
+// fan-out machinery) that flattens the three axis-kind slices
+// into a homogeneous []NonDeterministicChoice and forwards to the
+// generic walker.
 //
-// Index assignment uses mixed-radix counting across (choice axes,
-// probability fault sites, parallel interleaving sites). Each
-// probability site contributes a 2^MaxFires factor; each parallel
-// site with Policy.Kind != "single" contributes
-// interleavingCardinality(site). Stable across runs given the same
-// axes input.
+// The signature stays as (axes, probAxes, parAxes) so the dozen
+// existing callers (runTime, tests) don't churn — the unification
+// is an internal contract. New axis kinds added in the future
+// just implement NonDeterministicChoice and join the slice; no
+// per-kind branching in the enumerator.
 //
-// Leaf 0's all-zero ProbabilityOutcomes vector encodes "no
-// occurrence fires" — bit 0 of digit=0 is `(0>>0)&1 == 0`. Leaf 0's
-// InterleavingIDs map is empty for "single" sites and pins index 0
-// for fan-out sites. Callers shouldn't depend on the exact
-// discovery-vs-leaf-0 equivalence at this level; instead they treat
-// leaf 0 as a fresh re-execution like any other leaf.
+// With no fan-out-eligible axes, returns a single degenerate leaf
+// so callers can iterate uniformly regardless of fan-out status.
+// Leaf 0 is the all-zero assignment which matches the discovery
+// run's behavior — see runTestFanout for the re-execution
+// contract.
 func enumerateLeaves(axes []*ChoiceVal, probAxes []ProbFaultSite, parAxes []ParallelSite) []PlanLeaf {
-	// Filter parallel axes to fan-out-eligible only. Single-policy
-	// sites stay recorded for plan output but don't multiply leaves.
-	var activeParAxes []ParallelSite
-	for _, p := range parAxes {
-		if interleavingCardinality(p) > 0 {
-			activeParAxes = append(activeParAxes, p)
-		}
-	}
-	if len(axes) == 0 && len(probAxes) == 0 && len(activeParAxes) == 0 {
-		return []PlanLeaf{{Index: 0, Choices: map[string]int{}}}
-	}
-	total := 1
-	for _, a := range axes {
-		total *= len(a.Options)
-	}
-	for _, p := range probAxes {
-		total *= 1 << p.MaxFires
-	}
-	for _, p := range activeParAxes {
-		total *= interleavingCardinality(p)
-	}
-	leaves := make([]PlanLeaf, 0, total)
-	for i := 0; i < total; i++ {
-		choices := make(map[string]int, len(axes))
-		probs := make(map[string][]bool, len(probAxes))
-		interleavings := make(map[string]int, len(activeParAxes))
-		rem := i
-		for _, a := range axes {
-			n := len(a.Options)
-			choices[a.Name] = rem % n
-			rem /= n
-		}
-		for _, p := range probAxes {
-			card := 1 << p.MaxFires
-			digit := rem % card
-			rem /= card
-			vec := make([]bool, p.MaxFires)
-			for b := 0; b < p.MaxFires; b++ {
-				vec[b] = (digit>>b)&1 == 1
-			}
-			probs[p.Key] = vec
-		}
-		for _, p := range activeParAxes {
-			card := interleavingCardinality(p)
-			interleavings[p.Key] = rem % card
-			rem /= card
-		}
-		leaf := PlanLeaf{Index: i, Choices: choices}
-		if len(probs) > 0 {
-			leaf.ProbabilityOutcomes = probs
-		}
-		if len(interleavings) > 0 {
-			leaf.InterleavingIDs = interleavings
-		}
-		leaves = append(leaves, leaf)
-	}
-	return leaves
+	return expandLeaves(collectChoices(axes, probAxes, parAxes))
 }

--- a/internal/star/nondet.go
+++ b/internal/star/nondet.go
@@ -1,0 +1,171 @@
+package star
+
+// NonDeterministicChoice is the unified plan-tree fan-out axis
+// (RFC-044 §8.2). Every axis kind — named `choose()` axes,
+// probability fault sites, parallel() interleavings — implements
+// this interface so enumerateLeaves can walk a homogeneous slice
+// instead of branching by type.
+//
+// Implementations must be pure: Cardinality() is read once before
+// the cross-product is sized, and Apply() is called exactly once
+// per (leaf, axis) pair with digit ∈ [0, Cardinality()-1]. Neither
+// method may mutate the receiver across calls — the same axis is
+// applied to every leaf with a different digit.
+//
+// Why an interface rather than a sum type: rc2's three axis kinds
+// (ChoiceVal, ProbFaultSite, ParallelSite) live in three files and
+// each carries kind-specific metadata (option lists, max-fires
+// counts, ordering keys). Forcing them into one struct would
+// duplicate fields; an interface keeps each kind in its own file
+// and only requires the two-method contract for fan-out
+// participation.
+//
+// Scope note: fault_matrix and fault_scenario are NOT
+// NonDeterministicChoices — they produce discrete *test* entries
+// at spec load time, not *leaves* of one test at body time. The
+// plan walker in internal/plan/ handles those separately.
+type NonDeterministicChoice interface {
+	// Cardinality returns the number of leaves this axis contributes
+	// to the cross-product. Must return ≥ 1 for the axis to
+	// participate; returning 0 means "no fan-out" (the axis is
+	// recorded for plan output but doesn't multiply leaves).
+	Cardinality() int
+
+	// Apply stamps the per-leaf assignment for this axis onto leaf,
+	// using the supplied digit (0-based, < Cardinality()). The
+	// implementation decides which PlanLeaf field gets updated.
+	Apply(leaf *PlanLeaf, digit int)
+}
+
+// Cardinality / Apply implementations for the three axis kinds
+// follow. Kept here rather than in choose.go / leaf.go /
+// interleavings.go so the interface contract sits next to its
+// implementations and a reviewer can verify all three implement it
+// identically.
+
+// Cardinality on ChoiceVal — number of options for a named axis.
+// Anonymous axes (Name=="") and single-option axes return 0; the
+// caller filters those out before building the enumeration list.
+func (c *ChoiceVal) Cardinality() int {
+	if c == nil || c.Name == "" || len(c.Options) < 2 {
+		return 0
+	}
+	return len(c.Options)
+}
+
+// Apply on ChoiceVal — pin leaf.Choices[Name] to the digit.
+// Lazily allocates the map so a leaf with no axes stays nil.
+func (c *ChoiceVal) Apply(leaf *PlanLeaf, digit int) {
+	if c == nil || c.Name == "" || leaf == nil {
+		return
+	}
+	if leaf.Choices == nil {
+		leaf.Choices = make(map[string]int)
+	}
+	leaf.Choices[c.Name] = digit
+}
+
+// Cardinality on ProbFaultSite — 2^MaxFires (one leaf per
+// per-occurrence fire/no-fire combination). Returns 0 for sites
+// without max_fires set; those don't fan out (stochastic mode).
+func (p ProbFaultSite) Cardinality() int {
+	if p.MaxFires <= 0 {
+		return 0
+	}
+	return 1 << p.MaxFires
+}
+
+// Apply on ProbFaultSite — decode digit as a binary vector and
+// stamp onto leaf.ProbabilityOutcomes[Key].
+func (p ProbFaultSite) Apply(leaf *PlanLeaf, digit int) {
+	if p.Key == "" || p.MaxFires <= 0 || leaf == nil {
+		return
+	}
+	vec := make([]bool, p.MaxFires)
+	for b := 0; b < p.MaxFires; b++ {
+		vec[b] = (digit>>b)&1 == 1
+	}
+	if leaf.ProbabilityOutcomes == nil {
+		leaf.ProbabilityOutcomes = make(map[string][]bool)
+	}
+	leaf.ProbabilityOutcomes[p.Key] = vec
+}
+
+// Cardinality on ParallelSite — delegates to the policy-aware
+// helper interleavingCardinality (already capped at min(2N-1, N!)
+// for "critical" and min(N, N!) for "n").
+func (p ParallelSite) Cardinality() int {
+	return interleavingCardinality(p)
+}
+
+// Apply on ParallelSite — pin leaf.InterleavingIDs[Key] to the
+// digit. The digit is the index into the policy's ordering
+// enumeration; interleavingOrdering decodes it to a concrete
+// branch permutation at execution time.
+func (p ParallelSite) Apply(leaf *PlanLeaf, digit int) {
+	if p.Key == "" || leaf == nil {
+		return
+	}
+	if leaf.InterleavingIDs == nil {
+		leaf.InterleavingIDs = make(map[string]int)
+	}
+	leaf.InterleavingIDs[p.Key] = digit
+}
+
+// collectChoices flattens the three recorded discovery slices into
+// a single []NonDeterministicChoice, filtering out axes whose
+// cardinality is 0 (anonymous choose() calls, single-option axes,
+// single-policy parallel sites, no-max-fires probability rules).
+// The result preserves the source order: named choose() axes
+// first, then probability sites, then parallel sites. Stable
+// ordering matters for the plan tree to stay byte-identical across
+// runs given the same recordings.
+func collectChoices(
+	axes []*ChoiceVal,
+	probAxes []ProbFaultSite,
+	parAxes []ParallelSite,
+) []NonDeterministicChoice {
+	var out []NonDeterministicChoice
+	for _, a := range axes {
+		if a.Cardinality() > 0 {
+			out = append(out, a)
+		}
+	}
+	for _, p := range probAxes {
+		if p.Cardinality() > 0 {
+			out = append(out, p)
+		}
+	}
+	for _, p := range parAxes {
+		if p.Cardinality() > 0 {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// expandLeaves runs the mixed-radix walk over a flat
+// []NonDeterministicChoice. Returns one PlanLeaf per cross-product
+// cell. The empty-axes case returns one degenerate leaf so
+// callers can iterate uniformly regardless of fan-out status.
+func expandLeaves(choices []NonDeterministicChoice) []PlanLeaf {
+	if len(choices) == 0 {
+		return []PlanLeaf{{Index: 0, Choices: map[string]int{}}}
+	}
+	total := 1
+	for _, c := range choices {
+		total *= c.Cardinality()
+	}
+	leaves := make([]PlanLeaf, total)
+	for i := 0; i < total; i++ {
+		leaf := PlanLeaf{Index: i, Choices: map[string]int{}}
+		rem := i
+		for _, c := range choices {
+			card := c.Cardinality()
+			c.Apply(&leaf, rem%card)
+			rem /= card
+		}
+		leaves[i] = leaf
+	}
+	return leaves
+}

--- a/internal/star/nondet.go
+++ b/internal/star/nondet.go
@@ -148,6 +148,15 @@ func collectChoices(
 // []NonDeterministicChoice. Returns one PlanLeaf per cross-product
 // cell. The empty-axes case returns one degenerate leaf so
 // callers can iterate uniformly regardless of fan-out status.
+//
+// **Precondition:** every element of `choices` must have
+// Cardinality() ≥ 1. A zero-cardinality entry would fold `total`
+// to 0 and yield an empty slice — semantically wrong (callers
+// expect at least the degenerate leaf). The canonical entry point
+// `collectChoices` filters zero-cardinality axes out, so the
+// normal call path is safe; this precondition pins the contract
+// for any future caller that builds the slice by hand (review N1
+// on PR #127).
 func expandLeaves(choices []NonDeterministicChoice) []PlanLeaf {
 	if len(choices) == 0 {
 		return []PlanLeaf{{Index: 0, Choices: map[string]int{}}}

--- a/internal/star/nondet_test.go
+++ b/internal/star/nondet_test.go
@@ -151,6 +151,16 @@ func TestNonDet_ExpandLeavesIdenticalToEnumerateLeaves(t *testing.T) {
 	if got[wantLen-1].InterleavingIDs["spec:5"] != 5 {
 		t.Errorf("leaf %d interleaving = %v, want 5", wantLen-1, got[wantLen-1].InterleavingIDs)
 	}
+	// Review N2 on PR #127 — complete the byte-identical claim by
+	// also asserting on ProbabilityOutcomes. Leaf 0 has digit=0 →
+	// [false, false]; leaf wantLen-1 has digit=3 → [true, true]
+	// (binary 11 across 2 max_fires).
+	if got := got[0].ProbabilityOutcomes["wal"]; !reflect.DeepEqual(got, []bool{false, false}) {
+		t.Errorf("leaf 0 wal vector = %v, want [false, false]", got)
+	}
+	if got := got[wantLen-1].ProbabilityOutcomes["wal"]; !reflect.DeepEqual(got, []bool{true, true}) {
+		t.Errorf("leaf %d wal vector = %v, want [true, true]", wantLen-1, got)
+	}
 	// Leaf indices must be 0..wantLen-1 with no gaps.
 	indices := make([]int, len(got))
 	for i, l := range got {

--- a/internal/star/nondet_test.go
+++ b/internal/star/nondet_test.go
@@ -1,0 +1,179 @@
+package star
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+// TestNonDet_ChoiceValInterface — ChoiceVal implements
+// NonDeterministicChoice with the rc2 cardinality / apply
+// semantics: anonymous axes and single-option axes contribute 0
+// leaves; named multi-option axes contribute len(Options).
+func TestNonDet_ChoiceValInterface(t *testing.T) {
+	var _ NonDeterministicChoice = (*ChoiceVal)(nil) // compile-time witness
+
+	anon := &ChoiceVal{Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1)}}
+	if anon.Cardinality() != 0 {
+		t.Errorf("anonymous Choice: Cardinality = %d, want 0", anon.Cardinality())
+	}
+
+	single := &ChoiceVal{Name: "k", Options: []starlark.Value{starlark.MakeInt(42)}}
+	if single.Cardinality() != 0 {
+		t.Errorf("single-option Choice: Cardinality = %d, want 0", single.Cardinality())
+	}
+
+	named := &ChoiceVal{Name: "retries", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1), starlark.MakeInt(3)}}
+	if got, want := named.Cardinality(), 3; got != want {
+		t.Errorf("named Choice: Cardinality = %d, want %d", got, want)
+	}
+
+	leaf := &PlanLeaf{}
+	named.Apply(leaf, 2)
+	if leaf.Choices["retries"] != 2 {
+		t.Errorf("Apply did not pin axis: got %v", leaf.Choices)
+	}
+}
+
+// TestNonDet_ProbFaultSiteInterface — ProbFaultSite implements
+// NonDeterministicChoice. Cardinality = 2^MaxFires, Apply stamps
+// a bit-vector decoded from digit.
+func TestNonDet_ProbFaultSiteInterface(t *testing.T) {
+	var _ NonDeterministicChoice = ProbFaultSite{} // compile-time witness
+
+	zero := ProbFaultSite{Key: "wal", MaxFires: 0}
+	if zero.Cardinality() != 0 {
+		t.Errorf("MaxFires=0: Cardinality = %d, want 0", zero.Cardinality())
+	}
+
+	site := ProbFaultSite{Key: "wal", MaxFires: 3}
+	if got, want := site.Cardinality(), 8; got != want {
+		t.Errorf("MaxFires=3: Cardinality = %d, want %d", got, want)
+	}
+
+	leaf := &PlanLeaf{}
+	site.Apply(leaf, 5) // 101 → [true, false, true]
+	want := []bool{true, false, true}
+	if !reflect.DeepEqual(leaf.ProbabilityOutcomes["wal"], want) {
+		t.Errorf("digit=5: got %v, want %v", leaf.ProbabilityOutcomes["wal"], want)
+	}
+}
+
+// TestNonDet_ParallelSiteInterface — ParallelSite implements
+// NonDeterministicChoice. Cardinality delegates to
+// interleavingCardinality (already policy-aware); Apply stamps
+// the ordering index.
+func TestNonDet_ParallelSiteInterface(t *testing.T) {
+	var _ NonDeterministicChoice = ParallelSite{} // compile-time witness
+
+	single := ParallelSite{Key: "spec:1", Branches: 3, Policy: InterleavingPolicy{Kind: "single"}}
+	if single.Cardinality() != 0 {
+		t.Errorf("single policy: Cardinality = %d, want 0 (no fan-out)", single.Cardinality())
+	}
+
+	all := ParallelSite{Key: "spec:1", Branches: 3, Policy: InterleavingPolicy{Kind: "all"}}
+	if got, want := all.Cardinality(), 6; got != want {
+		t.Errorf("3! all: Cardinality = %d, want %d", got, want)
+	}
+
+	leaf := &PlanLeaf{}
+	all.Apply(leaf, 4)
+	if leaf.InterleavingIDs["spec:1"] != 4 {
+		t.Errorf("Apply did not pin index: got %v", leaf.InterleavingIDs)
+	}
+}
+
+// TestNonDet_CollectChoicesPreservesOrder — collectChoices flattens
+// the three source slices in (axes, probAxes, parAxes) order and
+// filters out zero-cardinality axes. Stable order is what keeps
+// plan-tree output byte-identical across runs.
+func TestNonDet_CollectChoicesPreservesOrder(t *testing.T) {
+	axes := []*ChoiceVal{
+		{Name: "a", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1)}},
+		{Name: "", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1)}}, // anonymous — filtered
+		{Name: "b", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1)}},
+	}
+	probAxes := []ProbFaultSite{
+		{Key: "wal", MaxFires: 1},
+		{Key: "noop", MaxFires: 0}, // filtered
+	}
+	parAxes := []ParallelSite{
+		{Key: "spec:1", Branches: 2, Policy: InterleavingPolicy{Kind: "all"}},
+		{Key: "spec:2", Branches: 2, Policy: InterleavingPolicy{Kind: "single"}}, // filtered
+	}
+	got := collectChoices(axes, probAxes, parAxes)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 active axes, got %d", len(got))
+	}
+	// Type-check the ordering: choose axes first, then prob, then par.
+	if _, ok := got[0].(*ChoiceVal); !ok {
+		t.Errorf("got[0] = %T, want *ChoiceVal", got[0])
+	}
+	if _, ok := got[1].(*ChoiceVal); !ok {
+		t.Errorf("got[1] = %T, want *ChoiceVal", got[1])
+	}
+	if _, ok := got[2].(ProbFaultSite); !ok {
+		t.Errorf("got[2] = %T, want ProbFaultSite", got[2])
+	}
+	if _, ok := got[3].(ParallelSite); !ok {
+		t.Errorf("got[3] = %T, want ParallelSite", got[3])
+	}
+}
+
+// TestNonDet_ExpandLeavesIdenticalToEnumerateLeaves — RFC-044 §8.2
+// safety net: expandLeaves(collectChoices(...)) must produce
+// byte-identical PlanLeaf slices to the pre-refactor
+// enumerateLeaves call. This is the user-facing plan-tree
+// invariant the RFC explicitly promises.
+func TestNonDet_ExpandLeavesIdenticalToEnumerateLeaves(t *testing.T) {
+	axes := []*ChoiceVal{
+		{Name: "a", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1)}},
+		{Name: "b", Options: []starlark.Value{starlark.MakeInt(0), starlark.MakeInt(1), starlark.MakeInt(2)}},
+	}
+	probAxes := []ProbFaultSite{{Key: "wal", MaxFires: 2}}
+	parAxes := []ParallelSite{{Key: "spec:5", Branches: 3, Policy: InterleavingPolicy{Kind: "all"}}}
+
+	got := enumerateLeaves(axes, probAxes, parAxes)
+	wantLen := 2 * 3 * 4 * 6 // 144
+	if len(got) != wantLen {
+		t.Fatalf("expected %d leaves (2 * 3 * 2^2 * 3!), got %d", wantLen, len(got))
+	}
+	// Spot check: leaf 0 carries all-zero assignments; leaf wantLen-1
+	// carries the max-index assignment for every axis.
+	if got[0].Choices["a"] != 0 || got[0].Choices["b"] != 0 {
+		t.Errorf("leaf 0 choices = %v, want all-zero", got[0].Choices)
+	}
+	if got[wantLen-1].Choices["a"] != 1 || got[wantLen-1].Choices["b"] != 2 {
+		t.Errorf("leaf %d choices = %v, want a=1,b=2", wantLen-1, got[wantLen-1].Choices)
+	}
+	if got[wantLen-1].InterleavingIDs["spec:5"] != 5 {
+		t.Errorf("leaf %d interleaving = %v, want 5", wantLen-1, got[wantLen-1].InterleavingIDs)
+	}
+	// Leaf indices must be 0..wantLen-1 with no gaps.
+	indices := make([]int, len(got))
+	for i, l := range got {
+		indices[i] = l.Index
+	}
+	sort.Ints(indices)
+	for i := range indices {
+		if indices[i] != i {
+			t.Errorf("indices missing %d; got %v", i, indices)
+			break
+		}
+	}
+}
+
+// TestNonDet_NoAxesProducesDegenerate — the empty input must still
+// produce one leaf so callers iterate uniformly. This is what
+// makes runTestFanout's "no fan-out" short-circuit valid.
+func TestNonDet_NoAxesProducesDegenerate(t *testing.T) {
+	got := expandLeaves(nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 degenerate leaf, got %d", len(got))
+	}
+	if got[0].Index != 0 {
+		t.Errorf("Index = %d, want 0", got[0].Index)
+	}
+}


### PR DESCRIPTION
## Summary

C2 — unified fan-out machinery (RFC-044 §8.2). The three plan-tree axis kinds (`ChoiceVal`, `ProbFaultSite`, `ParallelSite`) now implement a single `NonDeterministicChoice` interface; `enumerateLeaves` is a thin wrapper over a generic mixed-radix walker.

Pure refactor — no user-facing API change, all pre-existing testops goldens byte-identical.

## What lands

- **`NonDeterministicChoice` interface** (`internal/star/nondet.go`, new):
  ```go
  type NonDeterministicChoice interface {
      Cardinality() int
      Apply(leaf *PlanLeaf, digit int)
  }
  ```
- **Three impls.** `*ChoiceVal`, `ProbFaultSite`, `ParallelSite` each get a 5-10 line `Cardinality()` + `Apply()` pair. Compile-time witnesses pinned in tests.
- **`collectChoices(axes, probAxes, parAxes)`** flattens the three source slices into a homogeneous `[]NonDeterministicChoice` in source order, filtering zero-cardinality axes (anonymous choose(), single-option axes, no-max_fires prob sites, single-policy parallel sites).
- **`expandLeaves(choices)`** is the generic mixed-radix walker. One pass over the slice, calls `Cardinality()` once per axis to size the total, then `Apply(digit)` per (leaf, axis) pair.
- **`enumerateLeaves`** keeps its (axes, probAxes, parAxes) signature — now a one-liner: `return expandLeaves(collectChoices(...))`. The dozen existing callers don't churn.

## Scope honesty

The original RFC said "five separate code paths" but the post-rc2 reality was only one (`enumerateLeaves`) — choose / probability / interleaving all already went through it. `fault_matrix` is intentionally NOT a `NonDeterministicChoice`: it produces discrete *test* entries at spec load time via `internal/plan/`, not *leaves* of one test at body time. The RFC §8.2 status header now documents this scope correction.

## Test plan

- [x] `go test -race ./...` clean
- [x] Testops goldens (`TestGoldens/*`) unchanged — plan-tree output byte-identical
- [x] 6 new unit tests:
  - Per-interface contract for each of the three impls
  - `collectChoices` preserves source order + filters zero-cardinality
  - End-to-end cross-product (2 × 3 × 4 × 6 = 144 leaves) with index/assignment invariants
  - Empty input produces one degenerate leaf

## Out of scope

- §8.6 `observe.*` and §8.7 `decoder()` unifications — tracked as C3, independent slice
- Tutorial chapters for RFC-042/043 — C4