### PR TITLE
refactor(spec-lang): observe.* + decoder("name") unifications (RFC-044 §8.6/§8.7 / C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,17 @@ methods; `enumerateLeaves` is a thin wrapper over a generic
 mixed-radix walker `expandLeaves`. Adding a new axis kind in the
 future requires only implementing the two-method contract — no
 per-kind branching in the enumerator. All pre-existing testops
-goldens unchanged. Remaining RFC-044 sections (§8.6 `observe.*`,
-§8.7 `decoder()`) tracked as follow-up slices.
+goldens unchanged. **C3** ships the namespace unifications
+(§8.6 + §8.7): a new `observe` Starlark struct exposes
+`observe.stdout` and `observe.stderr` as attributes; a unified
+`decoder("name", ...)` dispatcher handles `"json"`, `"logfmt"`,
+and `"regex"`. The pre-rc2 top-level `stdout()` / `stderr()` /
+`json_decoder()` / `logfmt_decoder()` / `regex_decoder()` builtins
+remain registered as deprecated aliases that emit a one-time
+stderr warning per process and route through the canonical
+implementation — DecoderVal construction has a single source of
+truth, so a future decoder bug fix lands in one place. Removal
+of the aliases is scheduled for v0.14.0.
 RFC-046 carries the post-L1 roadmap (gVisor Path B/C, L4 hermetic
 mode, L5 instruction-boundary research).
 

--- a/docs/feature-manifest.md
+++ b/docs/feature-manifest.md
@@ -128,8 +128,8 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 
 | Feature | Tier | Mechanism | Status | Notes |
 |---|---|---|---|---|
-| Event sources (stdout, wal_stream, topic, tail, poll) | 2 | `internal/eventsource/*_test.go` | 🟢 | |
-| Decoders (json, logfmt, regex) | 2 | `internal/eventsource/decoder` unit tests | 🟢 | |
+| Event sources (stdout, wal_stream, topic, tail, poll) | 2 | `internal/eventsource/*_test.go` + `internal/star/observe_decoder_test.go` (RFC-044 `observe.*` namespace + deprecated aliases) | 🟢 | RFC-044 §8.6: top-level `stdout()` / `stderr()` deprecated → `observe.stdout` / `observe.stderr`; one-time stderr warning per process, removal v0.14.0. |
+| Decoders (json, logfmt, regex) | 2 | `internal/eventsource/decoder` unit tests + `internal/star/observe_decoder_test.go` (unified dispatcher + deprecated aliases) | 🟢 | RFC-044 §8.7: unified `decoder("name", ...)` dispatcher; `json_decoder()` / `logfmt_decoder()` / `regex_decoder()` deprecated, removal v0.14.0. |
 | Container reuse (`reuse=True`) | 2 | No coverage | 🔴 | |
 | Lima VM dev environment | 3 | Manual (`make env-verify`) | 🟡 | |
 

--- a/docs/rfcs/0044-spec-language-simplification.md
+++ b/docs/rfcs/0044-spec-language-simplification.md
@@ -1,6 +1,6 @@
 # RFC-044: Spec Language Simplification
 
-> **Status: Implemented partial (v0.13.0).** §8.1 (RFC-013 withdrawal) + §8.3 (`faultbox generate` deprecation) + §8.4 (RFC-002 withdrawal) + §8.5 (L1-cap documentation) shipped in C1 (#126). §8.2 (unified fan-out machinery) shipped in C2 — the three plan-tree fan-out axis kinds (`ChoiceVal`, `ProbFaultSite`, `ParallelSite`) now implement a single `NonDeterministicChoice` interface (`internal/star/nondet.go`); `enumerateLeaves` is a thin wrapper over a generic mixed-radix walker. **Deferred:** §8.6 `observe.*` and §8.7 `decoder()` module unifications.
+> **Status: Implemented (v0.13.0).** All eight sub-sections shipped: §8.1 (RFC-013 withdrawal) + §8.3 (`faultbox generate` deprecation) + §8.4 (RFC-002 withdrawal) + §8.5 (L1-cap documentation) in C1 (#126); §8.2 (unified fan-out machinery — `NonDeterministicChoice` interface in `internal/star/nondet.go`) in C2 (#127); §8.6 (`observe.*` namespace) + §8.7 (`decoder("name", ...)` dispatcher) in C3, with deprecated aliases for the pre-rc2 surface that emit a one-time stderr warning and route through the canonical implementation. Removal of the deprecated aliases is scheduled for v0.14.0.
 
 ## Summary
 
@@ -246,17 +246,11 @@ Original sequence (kept for historical context):
 
 ### 8.6 — `observe.*` unification
 
-- New Starlark module `observe` in `internal/star/builtins.go` exposing factories as attributes.
-- Existing `stdout()`, `stderr()`, `topic()`, `tail()`, `wal_stream()`, `poll()` stay registered as deprecated aliases that emit a one-time warning.
-- Update tutorials and example specs to the new form.
-- Update `docs/spec-language.md`.
+> **Status: Implemented (C3, v0.13.0).** New Starlark module `observe` (a `starlarkstruct.Struct`) exposes `observe.stdout` and `observe.stderr` as attributes (`internal/star/observe_decoder.go::makeObserveModule`). Top-level `stdout()` / `stderr()` remain registered as deprecated aliases (`builtinStdoutDeprecated` / `builtinStderrDeprecated`) that emit a one-time stderr warning per process and delegate to the canonical implementation. **Scope correction:** the RFC originally listed `topic()`, `tail()`, `wal_stream()`, `poll()` as additional factories to unify, but those were never top-level builtins — only the event source plugins ship under those names (loaded via `observe=` lists on `service()`). Future Starlark-level factories plug into `makeObserveModule()` as additional attributes.
 
 ### 8.7 — `decoder("name", ...)` unification
 
-- New `decoder()` Starlark builtin dispatching by registered name.
-- Existing `json_decoder()`, `logfmt_decoder()`, `regex_decoder()` stay registered as deprecated aliases.
-- RFC-045 (Protobuf decoder) ships directly under the new form (no alias needed since it's new).
-- Update `docs/spec-language.md`.
+> **Status: Implemented (C3, v0.13.0).** Unified `decoder(name, ...)` dispatcher in `internal/star/observe_decoder.go::builtinDecoder` handles `"json"`, `"logfmt"`, and `"regex"`. Legacy `json_decoder()` / `logfmt_decoder()` / `regex_decoder()` remain registered as deprecated aliases that emit a one-time stderr warning and route through the new dispatcher — DecoderVal construction has a single source of truth. RFC-045 (Protobuf decoder) will plug in as `case "proto":` in the dispatcher.
 
 ### 8.8 — Tests
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -1140,7 +1140,7 @@ observe=[observe.stdout(decoder=decoder("logfmt"))]
 observe=[observe.stdout(decoder=decoder("regex", pattern=r"WAL: (?P<action>\w+) (?P<path>.+)"))]
 ```
 
-> **RFC-044 §8.6 + §8.7 migration:** v0.13.0 introduces the `observe` namespace (`observe.stdout`, `observe.stderr`) and the unified `decoder("name", ...)` dispatcher. The pre-rc2 top-level `stdout()` / `stderr()` and the three `*_decoder()` builtins remain registered as deprecated aliases that emit a one-time stderr warning per spec load; they will be removed in **v0.14.0**. New specs should use the namespaced form; existing specs migrate by mechanical substitution.
+> **RFC-044 §8.6 + §8.7 migration:** v0.13.0 introduces the `observe` namespace (`observe.stdout`, `observe.stderr`) and the unified `decoder("name", ...)` dispatcher. The pre-rc2 top-level `stdout()` / `stderr()` and the three `*_decoder()` builtins remain registered as deprecated aliases that emit a one-time stderr warning **per process** (not per spec — a test harness that loads multiple specs sequentially sees the warning once total); they will be removed in **v0.14.0**. New specs should use the namespaced form; existing specs migrate by mechanical substitution.
 
 ### Querying Event Source Events
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -1123,22 +1123,24 @@ Decoders parse raw bytes (a line of output, a message payload) into
 structured event fields. The `"data"` field is auto-decoded on
 `StarlarkEvent.data` — no `json.decode()` needed.
 
-| Decoder | Constructor | Parses |
-|---------|------------|--------|
-| json | `json_decoder()` | JSON objects — top-level keys become fields |
-| logfmt | `logfmt_decoder()` | `key=value key2="value 2"` pairs |
-| regex | `regex_decoder(pattern=)` | Named capture groups from regex |
+| Decoder | Constructor (RFC-044) | Legacy alias (deprecated, removed in v0.14.0) | Parses |
+|---------|----------------------|-----------------------------------------------|--------|
+| json | `decoder("json")` | `json_decoder()` | JSON objects — top-level keys become fields |
+| logfmt | `decoder("logfmt")` | `logfmt_decoder()` | `key=value key2="value 2"` pairs |
+| regex | `decoder("regex", pattern=...)` | `regex_decoder(pattern=...)` | Named capture groups from regex |
 
 ```python
 # JSON: {"level":"INFO","msg":"started"} → e.data["level"] == "INFO"
-observe=[stdout(decoder=json_decoder())]
+observe=[observe.stdout(decoder=decoder("json"))]
 
 # Logfmt: level=INFO msg="started" → e.data["msg"] == "started"
-observe=[stdout(decoder=logfmt_decoder())]
+observe=[observe.stdout(decoder=decoder("logfmt"))]
 
 # Regex: WAL: fsync /data/wal/001 → e.data["action"] == "fsync"
-observe=[stdout(decoder=regex_decoder(pattern=r"WAL: (?P<action>\w+) (?P<path>.+)"))]
+observe=[observe.stdout(decoder=decoder("regex", pattern=r"WAL: (?P<action>\w+) (?P<path>.+)"))]
 ```
+
+> **RFC-044 §8.6 + §8.7 migration:** v0.13.0 introduces the `observe` namespace (`observe.stdout`, `observe.stderr`) and the unified `decoder("name", ...)` dispatcher. The pre-rc2 top-level `stdout()` / `stderr()` and the three `*_decoder()` builtins remain registered as deprecated aliases that emit a one-time stderr warning per spec load; they will be removed in **v0.14.0**. New specs should use the namespaced form; existing specs migrate by mechanical substitution.
 
 ### Querying Event Source Events
 

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -74,11 +74,22 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		"error":             starlark.NewBuiltin("error", builtinProxyError),
 		"drop":              starlark.NewBuiltin("drop", builtinProxyDrop),
 		"duplicate":         starlark.NewBuiltin("duplicate", builtinProxyDuplicate),
-		"stdout":            starlark.NewBuiltin("stdout", builtinStdoutSource),
-		"stderr":            starlark.NewBuiltin("stderr", builtinStderrSource),
-		"json_decoder":      starlark.NewBuiltin("json_decoder", builtinJSONDecoder),
-		"logfmt_decoder":    starlark.NewBuiltin("logfmt_decoder", builtinLogfmtDecoder),
-		"regex_decoder":     starlark.NewBuiltin("regex_decoder", builtinRegexDecoder),
+		// RFC-044 §8.6 — `observe` module is the canonical surface for
+		// event-source factories. Legacy top-level stdout/stderr remain
+		// registered as deprecated aliases that emit a one-time stderr
+		// warning before producing the same value the new form does.
+		// Removal in v0.14.0.
+		"observe":           makeObserveModule(),
+		"stdout":            starlark.NewBuiltin("stdout", builtinStdoutDeprecated),
+		"stderr":            starlark.NewBuiltin("stderr", builtinStderrDeprecated),
+		// RFC-044 §8.7 — `decoder("name", ...)` is the unified
+		// dispatcher; the three legacy names are deprecated aliases.
+		// All four routes converge in builtinDecoder so DecoderVal
+		// construction has a single source of truth.
+		"decoder":           starlark.NewBuiltin("decoder", builtinDecoder),
+		"json_decoder":      starlark.NewBuiltin("json_decoder", builtinJSONDecoderDeprecated),
+		"logfmt_decoder":    starlark.NewBuiltin("logfmt_decoder", builtinLogfmtDecoderDeprecated),
+		"regex_decoder":     starlark.NewBuiltin("regex_decoder", builtinRegexDecoderDeprecated),
 		// struct(**kwargs) — namespace objects. Used by recipe modules so
 		// protocol-specific helpers don't collide on common names (e.g.
 		// mongodb.disk_full vs postgres.disk_full).
@@ -2751,29 +2762,11 @@ func builtinStderrSource(thread *starlark.Thread, fn *starlark.Builtin, args sta
 	return &ObserveSourceVal{Config: cfg}, nil
 }
 
-// json_decoder() — creates a JSON decoder config.
-func builtinJSONDecoder(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	return &DecoderVal{Name: "json"}, nil
-}
-
-// logfmt_decoder() — creates a logfmt decoder config.
-func builtinLogfmtDecoder(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	return &DecoderVal{Name: "logfmt"}, nil
-}
-
-// regex_decoder(pattern=) — creates a regex decoder config.
-func builtinRegexDecoder(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	params := make(map[string]string)
-	for _, kv := range kwargs {
-		key, _ := starlark.AsString(kv[0])
-		val, _ := starlark.AsString(kv[1])
-		params[key] = val
-	}
-	if _, ok := params["pattern"]; !ok {
-		return nil, fmt.Errorf("regex_decoder() requires pattern= argument")
-	}
-	return &DecoderVal{Name: "regex", Params: params}, nil
-}
+// (Pre-RFC-044 decoder builtins lived here. They were folded into
+// the unified builtinDecoder dispatcher in observe_decoder.go;
+// the three legacy names — json_decoder, logfmt_decoder,
+// regex_decoder — are still registered above as deprecated
+// aliases that route through the new dispatcher.)
 
 // isFaultableSyscall returns true if the given name is a known faultable syscall.
 func isFaultableSyscall(name string) bool {

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -2762,12 +2762,6 @@ func builtinStderrSource(thread *starlark.Thread, fn *starlark.Builtin, args sta
 	return &ObserveSourceVal{Config: cfg}, nil
 }
 
-// (Pre-RFC-044 decoder builtins lived here. They were folded into
-// the unified builtinDecoder dispatcher in observe_decoder.go;
-// the three legacy names — json_decoder, logfmt_decoder,
-// regex_decoder — are still registered above as deprecated
-// aliases that route through the new dispatcher.)
-
 // isFaultableSyscall returns true if the given name is a known faultable syscall.
 func isFaultableSyscall(name string) bool {
 	for _, sc := range faultableSyscalls {

--- a/internal/star/observe_decoder.go
+++ b/internal/star/observe_decoder.go
@@ -1,0 +1,158 @@
+package star
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// RFC-044 §8.6 / §8.7 — unify event-source and decoder builtins
+// under namespace surfaces:
+//
+//   - observe.stdout / observe.stderr  (was: stdout, stderr)
+//   - decoder("json", ...) / decoder("logfmt", ...) /
+//     decoder("regex", pattern=...)
+//     (was: json_decoder, logfmt_decoder, regex_decoder)
+//
+// Old names stay registered as deprecated aliases that emit a
+// one-time-per-spec stderr warning. Removal is scheduled for
+// v0.14.0 — same migration cadence as faultbox generate (§8.3).
+
+// deprecationWarnings tracks which deprecated builtins have
+// already warned in this process, so a spec that calls
+// `stdout()` ten times surfaces the migration hint once instead
+// of ten times.
+//
+// Per-process (not per-spec) is intentional: most CI runs load
+// exactly one spec, so per-process matches the user mental model.
+// A test harness that LoadStrings multiple specs in sequence sees
+// one warning total — which is fine because the migration message
+// is the same regardless of which spec triggered it.
+var (
+	deprecationWarningsMu sync.Mutex
+	deprecationWarnings   = map[string]bool{}
+)
+
+// warnDeprecated emits a one-time stderr line for an old builtin
+// name, naming the replacement. Returns nil so callers can chain
+// it before the actual builtin work.
+func warnDeprecated(oldName, replacement string) {
+	deprecationWarningsMu.Lock()
+	already := deprecationWarnings[oldName]
+	if !already {
+		deprecationWarnings[oldName] = true
+	}
+	deprecationWarningsMu.Unlock()
+	if already {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: %s() is deprecated (RFC-044); use %s instead. Removal in v0.14.0.\n", oldName, replacement)
+}
+
+// resetDeprecationWarnings is exposed for tests so each test can
+// observe the first-warn behavior without process-level state
+// bleeding across runs.
+func resetDeprecationWarnings() {
+	deprecationWarningsMu.Lock()
+	deprecationWarnings = map[string]bool{}
+	deprecationWarningsMu.Unlock()
+}
+
+// makeObserveModule constructs the `observe` Starlark value
+// (`starlarkstruct.Struct`) exposing event-source factories as
+// attributes. Today: observe.stdout, observe.stderr. Future
+// factories (topic, tail, wal_stream, poll) plug in here as
+// they're implemented.
+//
+// The struct constructor name is "observe" so error messages
+// reading `<observe.stdout>` are clear about the namespace.
+func makeObserveModule() *starlarkstruct.Struct {
+	return starlarkstruct.FromStringDict(
+		starlarkstruct.Default,
+		starlark.StringDict{
+			"stdout": starlark.NewBuiltin("observe.stdout", builtinStdoutSource),
+			"stderr": starlark.NewBuiltin("observe.stderr", builtinStderrSource),
+		},
+	)
+}
+
+// builtinStdoutDeprecated is the legacy top-level `stdout()` —
+// behaves identically to observe.stdout but emits the deprecation
+// warning on first call.
+func builtinStdoutDeprecated(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	warnDeprecated("stdout", "observe.stdout")
+	return builtinStdoutSource(thread, fn, args, kwargs)
+}
+
+// builtinStderrDeprecated mirrors builtinStdoutDeprecated for
+// stderr.
+func builtinStderrDeprecated(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	warnDeprecated("stderr", "observe.stderr")
+	return builtinStderrSource(thread, fn, args, kwargs)
+}
+
+// builtinDecoder is RFC-044 §8.7's unified dispatcher.
+// `decoder("json")` / `decoder("logfmt")` / `decoder("regex",
+// pattern=...)` route to the same DecoderVal-producing logic the
+// three legacy builtins used.
+//
+// Why dispatch by name rather than separate builtins: the three
+// decoders share an identical surface modulo one kwarg
+// (`pattern=` for regex). A single `decoder(name, ...)` builtin
+// reads better in specs (`decoder("regex", pattern="...")`) and
+// keeps RFC-045 (Protobuf decoder) one-line to add.
+func builtinDecoder(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("decoder(name, ...): takes exactly one positional argument (the decoder name)")
+	}
+	name, ok := starlark.AsString(args[0])
+	if !ok {
+		return nil, fmt.Errorf("decoder(name, ...): name must be a string, got %s", args[0].Type())
+	}
+	switch name {
+	case "json":
+		if len(kwargs) > 0 {
+			return nil, fmt.Errorf("decoder(\"json\"): takes no kwargs")
+		}
+		return &DecoderVal{Name: "json"}, nil
+	case "logfmt":
+		if len(kwargs) > 0 {
+			return nil, fmt.Errorf("decoder(\"logfmt\"): takes no kwargs")
+		}
+		return &DecoderVal{Name: "logfmt"}, nil
+	case "regex":
+		params := make(map[string]string)
+		for _, kv := range kwargs {
+			k, _ := starlark.AsString(kv[0])
+			v, _ := starlark.AsString(kv[1])
+			params[k] = v
+		}
+		if _, ok := params["pattern"]; !ok {
+			return nil, fmt.Errorf("decoder(\"regex\", pattern=...): requires pattern= kwarg")
+		}
+		return &DecoderVal{Name: "regex", Params: params}, nil
+	}
+	return nil, fmt.Errorf("decoder(%q): unknown decoder; known names: \"json\", \"logfmt\", \"regex\"", name)
+}
+
+// builtinJSONDecoderDeprecated etc. — legacy decoder builtins.
+// Each emits the deprecation warning and delegates to the unified
+// decoder() dispatcher (so the migration path is also the
+// reference implementation — only one place to fix decoder bugs).
+func builtinJSONDecoderDeprecated(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	warnDeprecated("json_decoder", `decoder("json")`)
+	return builtinDecoder(thread, fn, starlark.Tuple{starlark.String("json")}, kwargs)
+}
+
+func builtinLogfmtDecoderDeprecated(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	warnDeprecated("logfmt_decoder", `decoder("logfmt")`)
+	return builtinDecoder(thread, fn, starlark.Tuple{starlark.String("logfmt")}, kwargs)
+}
+
+func builtinRegexDecoderDeprecated(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	warnDeprecated("regex_decoder", `decoder("regex", pattern=...)`)
+	return builtinDecoder(thread, fn, starlark.Tuple{starlark.String("regex")}, kwargs)
+}

--- a/internal/star/observe_decoder.go
+++ b/internal/star/observe_decoder.go
@@ -67,11 +67,14 @@ func resetDeprecationWarnings() {
 // factories (topic, tail, wal_stream, poll) plug in here as
 // they're implemented.
 //
-// The struct constructor name is "observe" so error messages
-// reading `<observe.stdout>` are clear about the namespace.
+// The constructor identifier is `starlark.String("observe")` so the
+// value prints as `observe(...)` rather than the default `struct(...)`
+// (the starlarkstruct.Default sentinel) — keeps the namespace
+// identity visible in error messages and `print()` output (review
+// N2 on PR #128).
 func makeObserveModule() *starlarkstruct.Struct {
 	return starlarkstruct.FromStringDict(
-		starlarkstruct.Default,
+		starlark.String("observe"),
 		starlark.StringDict{
 			"stdout": starlark.NewBuiltin("observe.stdout", builtinStdoutSource),
 			"stderr": starlark.NewBuiltin("observe.stderr", builtinStderrSource),

--- a/internal/star/observe_decoder_test.go
+++ b/internal/star/observe_decoder_test.go
@@ -122,6 +122,38 @@ r = regex_decoder(pattern="x")
 	}
 }
 
+// TestDecoder_LegacyAliasesRejectUnknownKwargs — review N3 on PR
+// #128: this is an intentional behavior change. Pre-rc2,
+// json_decoder(foo="bar") silently accepted (and ignored) the
+// extra kwarg because the old implementation didn't iterate
+// kwargs at all. After C3, all three legacy builtins delegate
+// to the unified builtinDecoder, which rejects unknown kwargs
+// to match the new dispatcher's contract — json/logfmt take no
+// kwargs at all, and regex accepts only `pattern=`. This test
+// pins the new strictness so a future "compatibility" patch
+// can't loosen it back without an explicit decision.
+func TestDecoder_LegacyAliasesRejectUnknownKwargs(t *testing.T) {
+	cases := []struct {
+		src      string
+		wantSubs string
+	}{
+		{`d = json_decoder(foo="bar")`, "no kwargs"},
+		{`d = logfmt_decoder(pattern="x")`, "no kwargs"},
+		{`d = regex_decoder()`, "requires pattern"},
+	}
+	for _, tc := range cases {
+		rt := New(testLogger())
+		err := rt.LoadString("spec.star", tc.src)
+		if err == nil {
+			t.Errorf("expected error for %q (rc2 contract: legacy aliases route through builtinDecoder)", tc.src)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSubs) {
+			t.Errorf("for %q, want error containing %q, got %v", tc.src, tc.wantSubs, err)
+		}
+	}
+}
+
 // TestObserve_DeprecationWarning — calling a deprecated builtin
 // emits a one-time stderr line naming the replacement. A second
 // call doesn't re-warn.

--- a/internal/star/observe_decoder_test.go
+++ b/internal/star/observe_decoder_test.go
@@ -1,0 +1,203 @@
+package star
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestObserve_ModuleExposesStdoutAndStderr — RFC-044 §8.6: the
+// `observe` Starlark struct exposes stdout/stderr as attributes;
+// `observe.stdout()` produces a value of the same type as the
+// legacy `stdout()` builtin.
+func TestObserve_ModuleExposesStdoutAndStderr(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+out = observe.stdout()
+err = observe.stderr()
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if _, ok := rt.globals["out"].(*ObserveSourceVal); !ok {
+		t.Errorf("observe.stdout() returned %T, want *ObserveSourceVal", rt.globals["out"])
+	}
+	if _, ok := rt.globals["err"].(*ObserveSourceVal); !ok {
+		t.Errorf("observe.stderr() returned %T, want *ObserveSourceVal", rt.globals["err"])
+	}
+}
+
+// TestObserve_StdoutDeprecatedAliasStillWorks — legacy
+// `stdout()` keeps working and produces the same value type as
+// `observe.stdout()`. The deprecation warning is asserted
+// separately in TestObserve_DeprecationWarning.
+func TestObserve_StdoutDeprecatedAliasStillWorks(t *testing.T) {
+	resetDeprecationWarnings()
+	rt := New(testLogger())
+	src := `legacy = stdout()`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if _, ok := rt.globals["legacy"].(*ObserveSourceVal); !ok {
+		t.Errorf("legacy stdout() returned %T, want *ObserveSourceVal", rt.globals["legacy"])
+	}
+}
+
+// TestDecoder_UnifiedDispatcher — RFC-044 §8.7: `decoder("json")`,
+// `decoder("logfmt")`, and `decoder("regex", pattern=...)` produce
+// DecoderVal values matching the legacy builtins.
+func TestDecoder_UnifiedDispatcher(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+j = decoder("json")
+l = decoder("logfmt")
+r = decoder("regex", pattern="^foo (?P<bar>.+)$")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if got := rt.globals["j"].(*DecoderVal); got.Name != "json" {
+		t.Errorf("decoder(\"json\") name = %q, want json", got.Name)
+	}
+	if got := rt.globals["l"].(*DecoderVal); got.Name != "logfmt" {
+		t.Errorf("decoder(\"logfmt\") name = %q, want logfmt", got.Name)
+	}
+	r := rt.globals["r"].(*DecoderVal)
+	if r.Name != "regex" {
+		t.Errorf("decoder(\"regex\") name = %q, want regex", r.Name)
+	}
+	if r.Params["pattern"] != "^foo (?P<bar>.+)$" {
+		t.Errorf("decoder(\"regex\") pattern = %q, want ^foo …", r.Params["pattern"])
+	}
+}
+
+// TestDecoder_Rejections — bad inputs surface clear errors at
+// spec load.
+func TestDecoder_Rejections(t *testing.T) {
+	cases := []struct {
+		src      string
+		wantSubs string
+	}{
+		{`d = decoder()`, "exactly one positional argument"},
+		{`d = decoder("json", "extra")`, "exactly one positional argument"},
+		{`d = decoder(42)`, "must be a string"},
+		{`d = decoder("unknown")`, "unknown decoder"},
+		{`d = decoder("regex")`, "requires pattern="},
+		{`d = decoder("json", pattern="x")`, "no kwargs"},
+		{`d = decoder("logfmt", pattern="x")`, "no kwargs"},
+	}
+	for _, tc := range cases {
+		rt := New(testLogger())
+		err := rt.LoadString("spec.star", tc.src)
+		if err == nil {
+			t.Errorf("expected error for %q", tc.src)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSubs) {
+			t.Errorf("for %q, want error containing %q, got %v", tc.src, tc.wantSubs, err)
+		}
+	}
+}
+
+// TestDecoder_LegacyAliasesStillWork — the three legacy
+// builtins (json_decoder/logfmt_decoder/regex_decoder) keep
+// working and produce identical values to the new dispatcher.
+func TestDecoder_LegacyAliasesStillWork(t *testing.T) {
+	resetDeprecationWarnings()
+	rt := New(testLogger())
+	src := `
+j = json_decoder()
+l = logfmt_decoder()
+r = regex_decoder(pattern="x")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	for _, name := range []string{"j", "l", "r"} {
+		if _, ok := rt.globals[name].(*DecoderVal); !ok {
+			t.Errorf("%s returned %T, want *DecoderVal", name, rt.globals[name])
+		}
+	}
+}
+
+// TestObserve_DeprecationWarning — calling a deprecated builtin
+// emits a one-time stderr line naming the replacement. A second
+// call doesn't re-warn.
+func TestObserve_DeprecationWarning(t *testing.T) {
+	resetDeprecationWarnings()
+	captured := captureStderr(t, func() {
+		rt := New(testLogger())
+		src := `
+a = stdout()
+b = stdout()  # second call must not re-warn
+c = stderr()
+`
+		if err := rt.LoadString("spec.star", src); err != nil {
+			t.Fatalf("LoadString: %v", err)
+		}
+	})
+	// Expect exactly one warning for stdout and one for stderr.
+	if got := strings.Count(captured, "stdout() is deprecated"); got != 1 {
+		t.Errorf("stdout deprecation warnings = %d, want 1; stderr capture:\n%s", got, captured)
+	}
+	if got := strings.Count(captured, "stderr() is deprecated"); got != 1 {
+		t.Errorf("stderr deprecation warnings = %d, want 1; stderr capture:\n%s", got, captured)
+	}
+	if !strings.Contains(captured, "observe.stdout") {
+		t.Errorf("warning should name the replacement (observe.stdout); got:\n%s", captured)
+	}
+}
+
+// TestDecoder_DeprecationWarning — same one-time semantics for
+// the three legacy decoder builtins.
+func TestDecoder_DeprecationWarning(t *testing.T) {
+	resetDeprecationWarnings()
+	captured := captureStderr(t, func() {
+		rt := New(testLogger())
+		src := `
+a = json_decoder()
+b = logfmt_decoder()
+c = regex_decoder(pattern="x")
+`
+		if err := rt.LoadString("spec.star", src); err != nil {
+			t.Fatalf("LoadString: %v", err)
+		}
+	})
+	for _, name := range []string{"json_decoder", "logfmt_decoder", "regex_decoder"} {
+		if got := strings.Count(captured, name+"() is deprecated"); got != 1 {
+			t.Errorf("%s warnings = %d, want 1; capture:\n%s", name, got, captured)
+		}
+	}
+	if !strings.Contains(captured, `decoder("json")`) {
+		t.Errorf("warning should name replacement decoder(\"json\"); got:\n%s", captured)
+	}
+}
+
+// captureStderr redirects os.Stderr around fn and returns
+// everything written during the call. The actual logger output
+// from the runtime is unaffected because testLogger() writes via
+// slog to io.Discard.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	defer func() {
+		os.Stderr = old
+	}()
+	fn()
+	_ = w.Close()
+	<-done
+	return buf.String()
+}


### PR DESCRIPTION
## Summary

C3 — namespace unifications, the final RFC-044 slice. v0.13.0 introduces the `observe` Starlark struct (§8.6) and the unified `decoder("name", ...)` dispatcher (§8.7). Pre-rc2 top-level builtins remain as deprecated aliases that emit a one-time stderr warning per process and route through the canonical implementation. Removal of the aliases is scheduled for v0.14.0.

## What lands

**§8.6 — `observe.*`** (`internal/star/observe_decoder.go::makeObserveModule`)
- `observe.stdout` / `observe.stderr` attributes on a `starlarkstruct.Struct`.
- Legacy `stdout()` / `stderr()` route through `builtinStdoutDeprecated` / `builtinStderrDeprecated` — one-time warning + delegate to the same value-producing source as the namespace.
- **Scope correction:** the RFC originally listed `topic()`, `tail()`, `wal_stream()`, `poll()` as additional factories. Those were never top-level builtins (they ship only as event-source plugins consumed via `observe=` lists on `service()`); only `stdout` / `stderr` needed unifying. RFC §8.6 status note records the correction.

**§8.7 — `decoder("name", ...)`** (`builtinDecoder`)
- Dispatches `"json"` / `"logfmt"` / `"regex"` (with `pattern=` kwarg). All four routes converge in `builtinDecoder` so `DecoderVal` construction has a single source of truth.
- Legacy `json_decoder()` / `logfmt_decoder()` / `regex_decoder()` keep working with one-time warnings; old implementations removed (no callers).

**Deprecation warning infrastructure**
- `warnDeprecated(oldName, replacement)` emits one stderr line per (process, name). Suppression is per-name so ten `stdout()` calls produce one warning. Per-process rather than per-spec — CI runs typically load one spec; the user mental model is "the migration is the same regardless of which spec triggered it."
- `resetDeprecationWarnings()` exposed for tests.

## Test plan

- [x] `go test -race ./...` clean
- [x] 7 new tests:
  - `TestObserve_ModuleExposesStdoutAndStderr` — `observe.stdout()` produces `*ObserveSourceVal`
  - `TestObserve_StdoutDeprecatedAliasStillWorks` — legacy form keeps type identity
  - `TestDecoder_UnifiedDispatcher` — three names + regex's `pattern=` kwarg
  - `TestDecoder_Rejections` — bad arity / wrong type / unknown name / missing pattern / disallowed kwargs (7 cases)
  - `TestDecoder_LegacyAliasesStillWork` — three legacy builtins still produce `DecoderVal`
  - `TestObserve_DeprecationWarning` — captures stderr; asserts one warning per legacy builtin even when called multiple times; warning names the replacement
  - `TestDecoder_DeprecationWarning` — same for the three legacy decoder builtins

## Docs

- `spec-language.md` decoder table gains a "Legacy alias (deprecated, removed in v0.14.0)" column; example code switches to `observe.stdout(decoder=decoder("json"))` form; migration callout below.
- RFC-044 status header flipped to fully Implemented; §8.6 and §8.7 status notes with the scope correction.
- CHANGELOG paragraph extended.
- Feature-manifest rows updated.

## v0.13.0 epic close-out

This completes RFC-044. With C3 in, all five v0.13.0 RFCs (040, 041, 042, 043, 044) have landed end-to-end:
- **RFC-040** Determinism levels — L1 contract with `unmediated_io` events
- **RFC-041** Temporal properties — `eventually` / `always` / `await_*` / `monitor` / `test()`
- **RFC-042** Exploration plan + body re-execution engine + interleaving execution
- **RFC-043** Non-deterministic operators — `choose` / `nondet` / `halt` / `assume` with per-leaf fan-out
- **RFC-044** Spec language simplification — withdrawals + unified fan-out machinery + namespace unifications