### PR TITLE
docs(tutorial): RFC-042/043 chapters in Part 4 (C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,20 @@ stderr warning per process and route through the canonical
 implementation — DecoderVal construction has a single source of
 truth, so a future decoder bug fix lands in one place. Removal
 of the aliases is scheduled for v0.14.0.
+
+**Tutorial — RFC-042/043 chapters.** Part 4 (Safety & Verification)
+gains two new chapters covering the v0.13.0-rc2 fan-out vocabulary:
+**Ch 25 — Non-deterministic Operators (`choose` / `assume` /
+`halt` / `nondet`)** walks the four RFC-043 operators end-to-end
+from the "one test, 18 leaves" motivating problem through the
+sandbox semantics and the discovery-run mental model; **Ch 26 —
+Plan-Tree Fan-Out** covers the RFC-042 plan tree, probability
+fan-out with `max_fires=`/`mode=`, `parallel(interleavings=)`, the
+`faultbox plan --check-cost` gate, and the cross-product
+composition rules. Both chapters include exercises and the
+`Result="error"` vs `"fail"` distinction for predicate Starlark
+errors.
+
 RFC-046 carries the post-L1 roadmap (gVisor Path B/C, L4 hermetic
 mode, L5 instruction-boundary research).
 

--- a/docs/tutorial/04-safety/25-choose-and-assume.md
+++ b/docs/tutorial/04-safety/25-choose-and-assume.md
@@ -102,7 +102,7 @@ test("checkout",
 )
 ```
 
-The `assume=` kwarg on `test()` takes a list of predicates. Each predicate receives a `choices` dict mapping axis names to the leaf's selected option index. Leaves where any predicate returns False are recorded as **halted** — they don't contribute to pass/fail.
+The `assume=` kwarg on `test()` takes a list of predicates. Each predicate receives a `choices` dict mapping axis names to the leaf's selected option **value** (not the index — the dict carries what the body would observe from `choose()`, so a predicate that reads `choices["retries"]` against `choose("retries", [0, 1, 3])` sees one of `0`, `1`, `3` directly). Leaves where any predicate returns False are recorded as **halted** — they don't contribute to pass/fail.
 
 > **Visibility:** Per-test `assume=` predicates evaluate at body entry. They see the leaf's axis assignment for any `choose()` call recorded during the discovery run (the first body execution; see below). Conditional choose() calls — axes that only appear in some branches — may not show up in `choices` for every leaf. Best practice: declare all axes unconditionally at the start of the body.
 

--- a/docs/tutorial/04-safety/25-choose-and-assume.md
+++ b/docs/tutorial/04-safety/25-choose-and-assume.md
@@ -1,0 +1,228 @@
+# Chapter 25: Non-deterministic Operators — `choose`, `assume`, `halt`
+
+**Duration:** 30 minutes
+**Prerequisites:** [Chapter 14 (Invariants & Safety Properties)](14-invariants.md) completed, RFC-043 operators landed in v0.13.0
+
+## Goals & Purpose
+
+Chapter 14 taught you to write invariants that hold across every test. But you still wrote one test per scenario. When the scenario space is large — three retry strategies × four fault kinds × two timeout values — you'd write 24 separate tests and copy-paste the body across all of them.
+
+The four operators in this chapter let you describe the *space* of scenarios as one test, and Faultbox produces 24 leaves at run time. Each leaf is its own deterministic execution with a unique `LeafID` and full bundle attribution. The plan tree shows exactly what was explored.
+
+This chapter teaches you to:
+- **`choose("name", [opts])`** — declare a finite N-way axis the plan tree fans out over
+- **`assume(predicate)`** — filter the plan tree to only the leaves you care about
+- **`halt(reason)`** — prune the current branch from inside the body
+- **`nondet()`** — the non-deterministic boolean shorthand
+- **The discovery run** — why your body runs once "for free" before fan-out
+
+By the end you'll write one test that explores hundreds of scenarios without copy-paste.
+
+## The motivating problem
+
+You're testing a checkout service. Three things vary across your test matrix:
+
+- **`retries`** — how many times the client retries on failure (0, 1, 3)
+- **`fault`** — what the downstream returns (503, 504, timeout)
+- **`backoff_ms`** — the delay between retries (10ms, 100ms)
+
+In Chapter 14's style you'd write 3 × 3 × 2 = 18 tests. With RFC-043 operators you write one:
+
+```python
+def test_checkout_robustness():
+    retries  = choose("retries", [0, 1, 3])
+    fault    = choose("fault",   ["503", "504", "timeout"])
+    backoff  = choose("backoff_ms", [10, 100])
+
+    # Some combinations don't make sense — retries=0 with timeout
+    # is uninteresting because there's nothing to retry.
+    if retries == 0 and fault == "timeout":
+        halt("nothing to retry — uninteresting branch")
+
+    api.checkout(retries=retries, expected_fault=fault, backoff_ms=backoff)
+```
+
+That's 18 leaves minus the halted ones. Each leaf runs as its own test execution, gets its own bundle row, and shows up in the report with its axis values: `test_checkout_robustness [leaf 7 — retries=1, fault=2, backoff_ms=0]`.
+
+## `choose("name", [opts])` — finite N-way axis
+
+`choose()` is a Starlark builtin that returns one of the options. The first argument is the axis name (visible in the report); the second is the option list. The plan walker fans the test out across every option.
+
+```python
+def test_retries():
+    n = choose("retries", [0, 1, 3])
+    api.post("/order", retries=n)
+```
+
+Running this with `faultbox test spec.star` produces three leaves:
+- `test_retries [leaf 0 — retries=0]` — body sees `n == 0`
+- `test_retries [leaf 1 — retries=1]` — body sees `n == 1`
+- `test_retries [leaf 2 — retries=2]` — body sees `n == 3`
+
+> **Leaf-ID convention.** The display shows the *option index*, not the option *value*. For `choose("retries", [0, 1, 3])`, leaf 2 carries option index 2 — which decodes to the value 3. The full axis-value mapping is in the bundle's `plan.json`.
+
+### Anonymous form
+
+`choose([opts])` without a name still returns the first option, but doesn't fan out — there's no key for the plan tree to address the axis by:
+
+```python
+n = choose([10, 20, 30])    # always returns 10; no fan-out
+n = choose("k", [10, 20, 30])  # 3 leaves
+```
+
+Use the named form whenever you want the axis exercised.
+
+### Cross-product
+
+Multiple `choose()` calls in one body produce the Cartesian product:
+
+```python
+def test_matrix():
+    a = choose("a", [True, False])
+    b = choose("b", [1, 2, 3])
+    # 2 × 3 = 6 leaves
+```
+
+Mix freely with the other rc2 axes (`probability=` on faults, `interleavings=` on `parallel()` — see Chapter 26): cardinality multiplies.
+
+## `assume(predicate)` — filter the plan tree
+
+Sometimes the cross-product contains leaves you don't want to run. The classic case: a configuration constraint that only makes sense for some axis combinations.
+
+```python
+def test_checkout():
+    retries  = choose("retries", [0, 1, 3, 5, 10])
+    backoff  = choose("backoff_ms", [10, 100, 1000])
+    api.checkout(retries=retries, backoff_ms=backoff)
+
+# Only run the leaves where total wait time is sane.
+test("checkout",
+    body = test_checkout,
+    assume = [lambda choices: choices["retries"] * choices["backoff_ms"] <= 3000],
+)
+```
+
+The `assume=` kwarg on `test()` takes a list of predicates. Each predicate receives a `choices` dict mapping axis names to the leaf's selected option index. Leaves where any predicate returns False are recorded as **halted** — they don't contribute to pass/fail.
+
+> **Visibility:** Per-test `assume=` predicates evaluate at body entry. They see the leaf's axis assignment for any `choose()` call recorded during the discovery run (the first body execution; see below). Conditional choose() calls — axes that only appear in some branches — may not show up in `choices` for every leaf. Best practice: declare all axes unconditionally at the start of the body.
+
+### Top-level `assume()`
+
+You can also declare spec-wide constraints at the top level:
+
+```python
+retries_axis = choose("retries", [0, 1, 3])
+fault_axis   = choose("fault", ["503", "504"])
+
+# Reject the (retries=0, fault=504) combination spec-wide.
+assume(lambda c: not (c.get("retries", 0) == 0 and c.get("fault", "") == "504"))
+
+def test_checkout():
+    api.checkout(retries=retries_axis, expected_fault=fault_axis)
+```
+
+Top-level `assume()` evaluates at spec load against the current axis snapshot. Use the per-test form (`test(..., assume=[...])`) when the constraint depends on per-leaf state.
+
+### Predicate sandbox
+
+`assume()` predicates are sandboxed at spec load: they can't call `fault()`, `service()`, `parallel()`, `halt()`, `eventually()`, `await_*`, or any other runtime-mutating builtin. The denylist mirrors RFC-041's monitor sandbox — predicates are pure functions of the `choices` argument.
+
+Predicate Starlark errors (e.g. indexing a missing key) map to `Result="error"` (not `"fail"`), distinguishing spec-authoring bugs from actual SUT behavioral failures.
+
+## `halt(reason="")` — prune from inside the body
+
+`halt()` lets the body itself decide a leaf is uninteresting and prune it. Same effect as a false `assume()` predicate, but lives at the call site:
+
+```python
+def test_checkout():
+    retries  = choose("retries", [0, 1, 3])
+    fault    = choose("fault", ["503", "504", "timeout"])
+
+    if retries == 0 and fault == "timeout":
+        halt("nothing to retry — uninteresting branch")
+
+    api.checkout(retries=retries, expected_fault=fault)
+```
+
+The halted leaf is recorded with `Result="halted"` — counted separately from pass/fail/inconclusive in the suite summary. Halt is not a verdict; CI gates that ignore halted runs see a clean exit.
+
+### Where halt is rejected
+
+- **Module top-level** — errors at spec load (`halt("…")` outside a function body).
+- **Inside `setup=`** — runtime error before the body runs.
+- **Inside a monitor `check=` / `update=` lambda** — produces an opaque "monitor violation: halt" message; use `assume()` to filter branches instead.
+
+### halt() vs assume()
+
+| | `halt()` | `assume()` |
+|---|---|---|
+| Where it lives | Body code | Spec preamble or `test(assume=[...])` |
+| When it fires | At the call site during body execution | At body entry (per-test) or spec load (top-level) |
+| Visibility | Can use any body-time state | Sees axis assignments only |
+| Use for | "This combo doesn't make sense given runtime state I just computed" | "This combo is structurally uninteresting" |
+
+## `nondet()` — non-deterministic boolean
+
+`nondet()` is sugar for `choose([True, False])`. Like anonymous `choose()`, it doesn't fan out (no name), so it always returns `True`. Use the named form for fan-out:
+
+```python
+flaky = choose("flaky", [True, False])  # 2 leaves
+if flaky:
+    api.set_flaky_mode()
+api.run()
+```
+
+> **Naming note:** the pre-RFC-043 `nondet(svc1, svc2, …)` form still works (it marks services as exempt from interleaving control during `parallel()`). The two arities are distinguished by argument count.
+
+## The discovery run
+
+Faultbox can't enumerate leaves without knowing what axes exist. So it runs your body **once** in *discovery* mode — a synthetic "leaf 0" that records every `choose()` call but skips `assume=` evaluation (the choices dict is empty at this point — predicates indexing a body-time key would spuriously error).
+
+After discovery, the plan walker enumerates the real leaves and re-executes the body once per leaf with the explicit axis assignment pinned. Each re-execution sees the same `choose()` calls return their leaf-specific value.
+
+What this means in practice:
+
+- **The body runs N+1 times for N leaves**, not N. Discovery is leaf 0's prep.
+- **`assume=` predicates fire only for the N real leaves**, not for discovery.
+- **Side effects in the body fire N+1 times.** If your body emits a side effect — writing to a Go-side counter, mutating a fixture — be aware. Faultbox state (services, faults, event log) resets between leaves so the body sees a fresh environment each time.
+
+## Putting it together — a real-world matrix
+
+```python
+api = service("api", binary="./api", interface("http", "http", 8080))
+db  = service("db",  image="postgres:16-alpine")
+
+# Module-level axes — visible to assume= predicates.
+retries_axis = choose("retries", [0, 1, 3])
+fault_axis   = choose("fault",   ["503", "504", "timeout"])
+
+def checkout():
+    if retries_axis == 0 and fault_axis == "timeout":
+        halt("uninteresting: no retry budget for a timeout")
+    api.http.post("/checkout", body='{"item":"widget"}')
+
+test("checkout_matrix",
+    body = checkout,
+    assume = [
+        lambda c: c.get("retries", 0) < 10,  # sanity cap
+    ],
+)
+```
+
+Running this produces 3 × 3 = 9 leaves; the halted branch (`retries=0, fault="timeout"`) is recorded as halted and skipped. The remaining 8 leaves run as 8 separate test executions, each with its own bundle row and trace.
+
+The bundle's `plan.json` lists every axis and option set; the HTML report's tests table shows the per-leaf assignment in the row name. `faultbox plan spec.star` prints the tree without launching services — useful when you want to know "how many leaves will this produce?" before committing CI time.
+
+## Exercises
+
+1. **Halt the uninteresting half.** Add a third axis `protocol = choose("protocol", ["http", "https"])`. Use `halt()` to skip every `protocol="http"` leaf when `fault="timeout"`. Verify with `faultbox plan` that only the right leaves remain.
+
+2. **Filter by predicate.** Rewrite Exercise 1 using a top-level `assume()` instead of `halt()`. Which approach reads better?
+
+3. **Trigger a predicate error.** Write an `assume=` predicate that indexes `choices["nonexistent_key"]`. Run the test and verify `Result="error"` (not `"fail"`).
+
+4. **Anonymous vs named.** Replace `choose("retries", [0, 1, 3])` with the anonymous form `choose([0, 1, 3])`. How many leaves does the test produce now? Why?
+
+## What's next
+
+[Chapter 26](26-plan-fanout.md) covers the RFC-042 plan-tree machinery these operators ride on: `faultbox plan`, probability fan-out, parallel-interleaving fan-out, and how to read the cross-product cost before CI runs it.

--- a/docs/tutorial/04-safety/26-plan-fanout.md
+++ b/docs/tutorial/04-safety/26-plan-fanout.md
@@ -1,0 +1,203 @@
+# Chapter 26: Plan-Tree Fan-Out — `faultbox plan`, probability, interleavings
+
+**Duration:** 30 minutes
+**Prerequisites:** [Chapter 25 (Non-deterministic Operators)](25-choose-and-assume.md) completed, [Chapter 5 (Exploring Concurrency)](../02-syscall-level/05-concurrency.md) reviewed
+
+## Goals & Purpose
+
+Chapter 25's `choose()` taught you to declare a finite axis the plan tree fans out over. This chapter shows the rest of the rc2 fan-out machinery: **probability fan-out** on faults (every fired/not-fired combination), **interleaving fan-out** on `parallel()` (every branch ordering), and the `faultbox plan` command that prints the cross-product cost *before* you commit CI minutes to it.
+
+The three axis kinds compose. A spec with two `choose()` axes, one probabilistic fault with `max_fires=3`, and one `parallel(interleavings="all")` with 3 branches produces `2 × 2 × 2³ × 3! = 192` leaves. Reading that number out of `faultbox plan` is cheaper than discovering it from a 20-minute CI run.
+
+This chapter teaches you to:
+- **Probability fan-out** — turn stochastic fault firing into exhaustive coverage
+- **Interleaving fan-out** — explore every branch ordering of `parallel()`
+- **`faultbox plan`** — preview the plan tree without launching services
+- **Reading the report** — find a specific leaf's trace in a bundle
+
+## Probability fan-out — `max_fires` + `mode="exhaustive"`
+
+Pre-rc2 Faultbox treated `probability=p` stochastically: at each trigger point the seeded RNG decided whether the rule fired this time. A single test run produced one realization. Reproducing a rare bug required hunting for the right seed.
+
+rc2 adds `max_fires=N` and `mode="exhaustive"` to `delay()` and `deny()`. Together they turn probability into a fan-out axis: every fired/not-fired combination across the first N occurrences becomes its own plan-tree leaf with a deterministic per-occurrence vector.
+
+```python
+fault(db,
+    write = deny("EIO",
+        probability = 0.3,
+        max_fires   = 2,
+        mode        = "exhaustive",
+        label       = "wal",
+    ),
+    run = lambda: api.checkout(),
+)
+```
+
+This produces `2² = 4` leaves:
+
+| Leaf | Occurrence 1 | Occurrence 2 |
+|------|--------------|--------------|
+| 0 | not fired | not fired |
+| 1 | fired | not fired |
+| 2 | not fired | fired |
+| 3 | fired | fired |
+
+Each leaf is a deterministic execution. The bundle records the per-occurrence vector under `leaf_probability_outcomes["wal"]`; the report's tests table shows `wal[10]` (bit string) on each row.
+
+### Mode rules
+
+| Combination | Behavior |
+|-------------|----------|
+| `probability=1.0` | Always fires. No fan-out. `max_fires=` rejected. |
+| `probability<1, max_fires=` unset | Stochastic — legacy RNG path. |
+| `probability<1, max_fires=N` | Exhaustive — `2^N` leaves with deterministic vector. Default mode. |
+| `probability<1, max_fires=N, mode="stochastic"` | Rejected at spec load — `max_fires=` is incompatible with stochastic. |
+| `probability<1, mode="exhaustive"` (no `max_fires`) | Rejected at spec load — would silently degrade to stochastic. |
+
+### Bare `probability=p` is unaffected
+
+This is the migration story. Existing specs that use `probability=0.3` *without* `max_fires=` keep the stochastic RNG path verbatim — no behavior change, no surprise extra leaves in CI. Opting into exhaustive fan-out is an explicit `max_fires=N` add.
+
+> **Scope note:** rc2 probability fan-out is syscall-level (`delay()` / `deny()`). Protocol-level (`response()` / `error()` / `drop()`) still uses the stochastic path; the `max_fires=` surface threads through `internal/proxy` in a follow-up.
+
+## Interleaving fan-out — `parallel(..., interleavings=)`
+
+`parallel(fn1, fn2, …)` (Chapter 5) runs branches concurrently. rc2 adds an `interleavings=` kwarg that turns each ordering into a leaf:
+
+```python
+def step_a(): api.post("/order")
+def step_b(): api.post("/inventory_adjust")
+def step_c(): api.post("/audit_log")
+
+def test_concurrent():
+    parallel(step_a, step_b, step_c, interleavings = "all")
+```
+
+Policies:
+
+| Value | Leaves produced |
+|-------|-----------------|
+| `1` (default) | One — runs once, branches concurrently as in rc1 |
+| `"all"` | `factorial(N)` — every distinct ordering |
+| `"critical"` | `min(2N-1, N!)` — head-to-head + sequential pairs heuristic |
+| Integer N | `min(N, factorial(branches))` — capped subset, first N in plan order |
+
+For 3 branches with `"all"`, that's 3! = 6 leaves with launch orderings `[a,b,c]`, `[a,c,b]`, `[b,a,c]`, …
+
+### Reserved values — locked for future RFCs
+
+```python
+parallel(a, b, interleavings = "dpor")          # → spec-load error, RFC-009
+parallel(a, b, interleavings = "sut-internal")  # → spec-load error, L5 / RFC-040 Appendix A
+```
+
+These are explicit "future release" rejections so CI integrations gating on the value don't drift when the corresponding RFC lands.
+
+### Scope limit (rc2)
+
+Today's interleaving is **launch ordering** — branches launch sequentially in the per-leaf order. Mediated-event-level interleaving (two branches running concurrently while the engine releases their syscalls in a specific sequence) is a follow-up. The kwarg surface and plan-tree leaf descriptors are in place for that work to plug into; specs you write today stay valid when the engine refines.
+
+## `faultbox plan` — preview the cross-product
+
+Before committing CI time to a test, ask Faultbox what it will run:
+
+```bash
+$ faultbox plan checkout.star
+Plan tree:
+  test_checkout_matrix [27 instances]
+      ├── choose: retries = [0, 1, 3]
+      ├── choose: fault = [503, 504, timeout]
+      └── choose: backoff = [10, 100, 1000]
+  test_concurrent_orders [6 instances]
+      └── parallel: 3 branches, interleavings = "all" → 6 leaves
+  test_wal_robustness [4 instances]
+      └── probability: wal (max_fires=2) → 4 leaves
+Totals: 37 instances
+```
+
+The command runs *only* spec loading + static analysis — no services launched, no Docker pulls, no Lima VM start. Sub-100ms even for large specs.
+
+### `--check-cost --max-instances N`
+
+Use the cost gate in CI / pre-commit hooks to block accidental explosions:
+
+```bash
+$ faultbox plan checkout.star --check-cost --max-instances 100
+ok: 37 instances within budget of 100
+```
+
+```bash
+$ faultbox plan checkout.star --check-cost --max-instances 30
+error: plan has 37 instances, exceeds budget of 30
+exit code: 2
+```
+
+Wire into a pre-commit hook on the spec directory and your team gets a hard stop before someone accidentally adds a `choose([0..1000])` axis.
+
+### `--format=json` for tooling
+
+Pipe the plan into `jq` or a dashboard:
+
+```bash
+$ faultbox plan checkout.star --format=json | jq '.totals.instances'
+37
+```
+
+The JSON schema is versioned (`schema_version: 1`); the same shape lives in every bundle's `plan.json` so tooling that reads one reads both.
+
+## Composition — the cross-product
+
+The three axis kinds — `choose`, probability, interleaving — multiply:
+
+```python
+def test_everything():
+    retries = choose("retries", [0, 1, 3])          # 3
+    parallel(a, b, c, interleavings = "all")        # 3! = 6
+    fault(db, write = deny("EIO",
+        probability = 0.3, max_fires = 2,           # 2² = 4
+        label = "wal"))
+    api.run()
+
+# Total: 3 × 6 × 4 = 72 leaves
+```
+
+The plan walker enumerates the cross-product in mixed-radix order so leaf indices are stable across runs. The bundle's `plan.json` records every axis; the HTML report's tests table shows the per-leaf assignment in the row label:
+
+```
+test_everything [leaf 17 — retries=2, parallel#3, wal[01]]
+```
+
+## Reading a specific leaf's trace
+
+Each leaf gets its own trace event log. To find leaf 17's events:
+
+1. Open the HTML report (`faultbox report run.fb` produces `report.html`).
+2. The tests table shows every leaf as a separate row — sort/filter by name to find your test.
+3. Click the leaf row to open the drill-down: per-leaf trace, swim-lane visualization, replay command.
+
+For CLI inspection: `cat run.fb/manifest.json | jq '.tests[] | select(.leaf_id=="17")'` gets the row metadata; `faultbox replay run.fb --test test_everything --leaf 17` (when leaf-selection lands — currently leaves share the test name in `--test`) reruns that specific configuration.
+
+## When to use which axis kind
+
+| Use case | Axis kind |
+|----------|-----------|
+| Configuration parameter (retry count, timeout value, mode flag) | `choose("name", [opts])` |
+| Rare failure mode you want exhaustive coverage of | `probability=p, max_fires=N` |
+| Two independent operations that might arrive in any order | `parallel(a, b, interleavings="all")` |
+| Combination that doesn't make sense | `halt()` inside body, or `assume=` predicate |
+
+For test design: pick the smallest axis count that exercises the failure modes you care about. `choose("retries", [0, 1])` + `probability=0.3, max_fires=1` is usually more informative than `choose("retries", [0, 1, 2, 3, 4, 5])` — diminishing returns set in fast and the plan grows multiplicatively.
+
+## Exercises
+
+1. **Count before you run.** Write a spec with three `choose()` axes (cardinalities 2, 3, 4) and one `parallel(interleavings="critical")` with 4 branches. Predict the leaf count, then run `faultbox plan --format=json | jq '.totals.instances'` to verify.
+
+2. **Cost gate.** Add the `faultbox plan --check-cost --max-instances 50` invocation to your repo's pre-commit hook. Add an axis that pushes the count over 50 and confirm the hook blocks the commit.
+
+3. **Exhaustive WAL coverage.** Take an existing spec that uses `probability=0.3` on a WAL write. Add `max_fires=3, mode="exhaustive"` and observe the four-times-larger plan tree in `faultbox plan`. Find the leaf where every WAL write fired — what does the trace look like compared to the all-passed leaf?
+
+4. **Interleaving identity.** Compare `parallel(a, b, interleavings=1)` and `parallel(a, b, interleavings="all")` plans. The first should produce 1 leaf, the second 2. Verify with `faultbox plan`.
+
+## What's next
+
+You've reached the end of Part 4. The full v0.13.0 verification toolkit is at your disposal: invariants (Ch 14), monitors (Ch 15), partitions (Ch 16), determinism (Ch 24), operators (Ch 25), and plan-tree fan-out (this chapter). Part 5 covers advanced operational features — containers, scenario generation, event sources, and LLM agent integration.

--- a/docs/tutorial/04-safety/26-plan-fanout.md
+++ b/docs/tutorial/04-safety/26-plan-fanout.md
@@ -194,7 +194,7 @@ For test design: pick the smallest axis count that exercises the failure modes y
 
 2. **Cost gate.** Add the `faultbox plan --check-cost --max-instances 50` invocation to your repo's pre-commit hook. Add an axis that pushes the count over 50 and confirm the hook blocks the commit.
 
-3. **Exhaustive WAL coverage.** Take an existing spec that uses `probability=0.3` on a WAL write. Add `max_fires=3, mode="exhaustive"` and observe the four-times-larger plan tree in `faultbox plan`. Find the leaf where every WAL write fired — what does the trace look like compared to the all-passed leaf?
+3. **Exhaustive WAL coverage.** Take an existing spec that uses `probability=0.3` on a WAL write. Add `max_fires=3, mode="exhaustive"` and observe the eight-leaf plan tree (2³) in `faultbox plan`. Find the leaf where every WAL write fired — what does the trace look like compared to the all-passed leaf?
 
 4. **Interleaving identity.** Compare `parallel(a, b, interleavings=1)` and `parallel(a, b, interleavings="all")` plans. The first should produce 1 leaf, the second 2. Verify with `faultbox plan`.
 

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -62,6 +62,8 @@ make lima-create && make lima-build                 # macOS (one-time)
 | 15 | [Monitors & Temporal Properties](04-safety/15-monitors.md) | 30 min |
 | 16 | [Network Partitions](04-safety/16-partitions.md) | 20 min |
 | 24 | [Determinism & the L1 Contract](04-safety/24-determinism.md) | 25 min |
+| 25 | [Non-deterministic Operators — `choose`, `assume`, `halt`](04-safety/25-choose-and-assume.md) | 30 min |
+| 26 | [Plan-Tree Fan-Out — `faultbox plan`, probability, interleavings](04-safety/26-plan-fanout.md) | 30 min |
 
 ## Part 5: Advanced Features
 


### PR DESCRIPTION
## Summary

C4 — the deferred A1 tutorial work. Two new chapters in Part 4 (Safety & Verification) cover the v0.13.0-rc2 fan-out vocabulary end-to-end. No code changes.

## What lands

**[Chapter 25 — Non-deterministic Operators (`choose` / `assume` / `halt` / `nondet`)](docs/tutorial/04-safety/25-choose-and-assume.md)**
- "One test, 18 leaves" motivating problem (3-axis matrix)
- `choose("name", [opts])` named vs anonymous; option-index-vs-value display caveat
- `assume()` per-test + top-level, sandbox semantics, predicate Starlark errors → `Result="error"` (Q3 polish)
- `halt(reason)` body-time pruning + rejection contexts + halt-vs-assume comparison
- `nondet()` shorthand + the `nondet(svc)` arity-disambiguation
- The discovery-run mental model — why body runs N+1 times for N leaves
- Worked composition example, 4 exercises

**[Chapter 26 — Plan-Tree Fan-Out](docs/tutorial/04-safety/26-plan-fanout.md)**
- Probability fan-out: 2^N leaf table, per-occurrence vector, full mode-rules matrix, migration story
- `parallel(interleavings=)` policy taxonomy, reserved values, launch-ordering scope limit
- `faultbox plan` CLI: text/JSON output, `--check-cost --max-instances N` gate
- Composition: 72-leaf cross-product example
- Per-leaf trace navigation in the HTML report
- "When to use which axis kind" decision table, 4 exercises

Tutorial README updated with both chapters slotted into Part 4 alongside Ch 24 (Determinism).

## Test plan

- [x] `go test ./...` clean — `docs/` package's markdown link checker covers the new files
- [x] All cross-references resolve (Ch 4, Ch 14, Ch 25→26, Ch 5)
- [x] Code examples typecheck mentally against the rc2 surface (named choose, assume= kwarg, max_fires, interleavings=)

## v0.13.0 epic close-out

With C4 in, the v0.13.0 epic is done:
- 5 RFCs end-to-end shipped (040, 041, 042, 043, 044)
- 9 PRs merged this session (#121 #123 #124 #125 #126 #127 #128 plus this one)
- 2 follow-up issues filed (#119 RunTest select race, #122 non-deterministic prob site order)
- Two new tutorial chapters teaching the rc2 operator + fan-out vocabulary