### PR TITLE
RFC-049: finite-trace verdict semantics (D4) — LTL₃/LTL_f

### DIFF
--- a/docs/rfcs/0049-finite-trace-verdict-semantics.md
+++ b/docs/rfcs/0049-finite-trace-verdict-semantics.md
@@ -1,0 +1,120 @@
+# RFC-049: Finite-Trace Verdict Semantics — Pinning the Monitor Table to LTL₃ / LTL_f
+
+> **Status: Draft.** Specification RFC (Direction 4 of [RFC-047](https://github.com/faultbox/Faultbox/issues/132)). Refines RFC-041 (Temporal Properties) — does not add surface, it *grounds* the existing verdict logic. **First in the agreed research-epic sequence (D4 → D3 → RFC-048 DPOR+LDFI):** despite the higher RFC number, this lands first because it gates the trustworthiness of every verdict the later epics emit.
+>
+> In-tree document: `docs/rfcs/0049-finite-trace-verdict-semantics.md`.
+
+## Summary
+
+RFC-041 ships a three-valued verdict — PASS / FAIL / **INCONCLUSIVE** — whose finite-prefix resolution is described by a **hand-written table** (`docs/temporal.md` §"Test completion"). The INCONCLUSIVE verdict means Faultbox is already, implicitly, doing three-valued runtime-verification LTL. This RFC makes that explicit: map the verdict to **LTL₃ / RV-LTL** (Bauer, Leucker & Schinz 2011) and the terminating-test evaluation to **finite-trace LTL_f** (De Giacomo & Vardi 2013), then **re-derive the table from the semantics and diff against the shipped behavior.** Every disagreement is either a documentation clarification or a latent bug to fix.
+
+This is a ~2-week specification task with no engine rebuild. Its value is twofold: (1) it reconciles the verdict semantics across docs, per-property `Finalize`, and the runtime aggregation — which, on inspection, disagreed in *opposite* directions (the docs table over-claimed PASS at timeout; the per-property `Finalize` over-claimed PASS for unbounded `always`; the runtime aggregation was already conservative-correct — see the findings); and (2) it gives users (and the RFC-048 coverage statements that sit on top of these verdicts) a citable, well-understood mental model instead of a bespoke table.
+
+## Motivation
+
+Two forces:
+
+1. **Two reduction algorithms are about to depend on this layer.** RFC-048's DPOR reports "violation found" and LDFI reasons over a "success outcome" — both are PASS/FAIL/INCONCLUSIVE verdicts. Building coverage *guarantees* on top of a hand-rolled verdict table is unsound by construction. The verdict semantics must be pinned to a named logic *before* the moat epic claims anything.
+2. **Hand-written finite-prefix tables get the boundary wrong.** The subtle cases — `eventually` that never fires, `always` truncated by timeout, an open `between=` interval, vacuous intervals — are exactly where infinite-trace intuition and finite-trace reality diverge. A table written by hand tends to encode the common case correctly and the boundary by accident.
+
+## Technical Details
+
+### The verdict ↔ logic mapping
+
+| Faultbox verdict | LTL₃ / RV-LTL value | Meaning |
+|---|---|---|
+| **PASS** (for a property) | ⊤ | definitively satisfied — no extension of the trace can change it |
+| **FAIL** | ⊥ | definitively violated — no extension can repair it |
+| **INCONCLUSIVE** | ? | the finite prefix does not decide it; a longer trace could go either way |
+
+A test's overall verdict is the conjunction over its properties, with FAIL dominating ? dominating ⊤ (any ⊥ → FAIL; else any ? → INCONCLUSIVE; else PASS).
+
+### Which logic applies depends on *why* the trace ended
+
+This is the crux the current table encodes informally and this RFC makes explicit. A finite trace is interpreted under **LTL_f** (the trace is *logically complete* — there is no "rest of the trace") **only** when termination signals genuine completion; otherwise it is an LTL₃ *truncated prefix* (the system was still running; "?" verdicts survive).
+
+| Termination cause (RFC-041) | Interpretation | Consequence |
+|---|---|---|
+| (a) Body returns | **LTL_f** end-of-trace | `eventually`/`always` get *definite* verdicts |
+| (b) `terminate_when=` fires | **LTL_f** end-of-trace | same — the user declared "final state reached" |
+| (c) `timeout=` elapses | **LTL₃** truncated prefix | unresolved `?` stays INCONCLUSIVE — we stopped watching, the system did not stop |
+| (d) Immediate failure | ⊥ directly | FAIL |
+
+### Per-operator semantics
+
+- **`eventually(p)` = F p — co-safety, monotone.** Once `p` holds, the verdict latches ⊤ for the rest of the trace. Before that it is `?`. On an LTL_f end-of-trace (a/b) with `p` never held → ⊥ (FAIL). On an LTL₃ truncation (c) with `p` never held → `?` (INCONCLUSIVE). *This matches the shipped table.*
+- **`always(p)` = G p — safety.** Violated the instant `p` is false → ⊥ (FAIL), any cause. Never violated: ⊤ only on an LTL_f end-of-trace (a/b); on truncation (c) it is **`?`, not ⊤** — a longer trace could still violate it. The shipped per-property `Finalize` did not distinguish this for the *unbounded* case (Finding B below).
+- **`always(p, between=(a,b))` — bounded safety / MTL.** Once the closing anchor `b` is observed, G p over [a,b] is *definitively* decided even mid-run → can be ⊤ before termination. If `b` is never observed before timeout, the interval is **open** → `?` (INCONCLUSIVE). **Already correct in the engine** — `AlwaysExpectation.Finalize` returns `Pending` for an unreached end-anchor under `TerminationTimeout`, and PASS under `terminate_when` (the window spans the whole test). This is the *precedent* the unbounded-`always` fix below should follow. If the opening anchor `a` never occurs, the interval is **empty** → classically vacuously ⊤ (the one remaining open question — vacuity is a known monitor footgun and should be a stated decision, ideally with a warning).
+- **`monitor(check=)` — per-event safety.** Equivalent to G over the check predicate. Same truncation rule as unbounded `always`: a never-violated monitor is ⊤ at LTL_f completion, `?` at timeout.
+- **`await_event` / `await_stable` — liveness-flavored, block the body.** Not reached before timeout → INCONCLUSIVE via the timeout cause. This is already correct LTL₃ (quiescence/await is a `?` until observed).
+
+### Long-living and `reuse=True` services (decided)
+
+A `reuse=True` service — or any service that never naturally returns — has no LTL_f *body-returns* terminal (cause a). For these, **the termination signal is the user's to define.** An explicit `terminate_when=` marks the logical end of the unit of work under verification, and Faultbox interprets the trace up to that point under LTL_f: if a declared `eventually(p)` has not held by the user's `terminate_when` signal, the test **FAILS** — "the service reached its declared completion and `p` never happened." Absent any `terminate_when`, the only terminal cause is `timeout` → **INCONCLUSIVE**: Faultbox will not invent an end-of-trace the user did not declare. `terminate_when=` is therefore strongly recommended (effectively required for a non-INCONCLUSIVE verdict) on long-living / `reuse=True` specs.
+
+The asymmetry is deliberate and matches how these systems are actually tested:
+
+- The **reused dependency** (a long-living Postgres, Redis, broker) is assumed *stable background infrastructure*, not the verification target. Its events appear in the trace, but its non-termination does **not** poison the verdict — we do not wait for the database to "finish."
+- The **service-under-test** is the target. The user-declared termination is about *its* unit of work, and the verdict is rendered against *its* behavior at that point.
+- Soundness of the long-living dependency's use across tests — state leakage, a missing `seed`/`reset` — is the **spec author's responsibility**, not something the verdict semantics can recover. Faultbox already warns on `reuse=True` without `seed`/`reset`; that warning is the contract boundary here.
+
+### The findings (after tracing the *aggregation*, not just the table)
+
+The initial hypothesis — "the engine over-PASSes at timeout" — was **half right, and the interesting half is the correction.** Tracing the actual test-level aggregation (`runtime.go`, not just `AlwaysExpectation.Finalize`) shows two distinct things:
+
+**Finding A — test-level timeout was already conservative-correct (the docs were wrong, not the engine).** The runtime termination path returns **INCONCLUSIVE for *any* timed-out test that did not FAIL** — including one whose every `eventually` was satisfied — because the body never reached a *declared* completion (natural return or `terminate_when`), so the run is a truncated prefix. The shipped docs table claimed `(c) timeout / all satisfied → PASS`; that cell is contradicted by the engine's catch-all. **Decision (kept): INCONCLUSIVE.** A hung or overrunning body is not a clean PASS just because its assertions happened to hold before the deadline; long-running / `reuse=True` specs that want a definite PASS must declare `terminate_when=` (cause b). The fix here is to the **docs table** and to making the catch-all's intent explicit in code — not to test outcomes.
+
+**Finding B — per-property over-claim (real, but dominated by A at the test level).** `AlwaysExpectation.Finalize` returned `VerdictPass` for a never-violated **unbounded** `always(p)` under *every* cause, including timeout: the `endPending` guard fires only for an unreached `between=` end-anchor, so the unbounded case fell through. Per LTL₃ that per-property verdict should be `?` at timeout. We fix it — the engine already did exactly this for *bounded* windows, so the change extends that truncation logic to the unbounded case — but note it does **not** change test outcomes (Finding A already made them INCONCLUSIVE); it corrects per-property *reporting* and aligns the engine with the oracle.
+
+**Non-finding — the `monitor` case.** Monitors aren't in the expectation set, so a never-violated `monitor` at timeout falls through to the same catch-all (Finding A) → INCONCLUSIVE. No separate change needed.
+
+The lesson is exactly why step 3 (diff the oracle against the *engine*, not the prose table) is in the plan: the docs table and the per-property `Finalize` both disagreed with the engine's already-conservative aggregation, in opposite directions.
+
+### The re-derived verdict table (proposed)
+
+Overall test verdict = worst property verdict, with safety/liveness resolved per cause:
+
+| Cause | `eventually` unsatisfied | unbounded `always`/`monitor` not violated | bounded `always` (interval closed) | bounded `always` (interval open) |
+|---|---|---|---|---|
+| (a) Natural / (b) terminate_when | **FAIL** (LTL_f ⊥) | **PASS** (LTL_f ⊤) | PASS/FAIL as decided | **INCONCLUSIVE** (open at end) |
+| (c) timeout | **INCONCLUSIVE** | **INCONCLUSIVE** (per-property fix, Finding B) | PASS/FAIL as decided | **INCONCLUSIVE** |
+| (d) immediate failure | **FAIL** | **FAIL** (the violation) | — | — |
+
+(`eventually` satisfied → that property is ⊤ everywhere; the table shows the *binding* property.) **At the test level, the entire `(c) timeout` row is INCONCLUSIVE regardless of per-property verdicts** — the runtime catch-all (Finding A) maps any non-FAIL timeout to INCONCLUSIVE, because the body never reached a declared completion. The per-property column for (c) matters for *reporting* (what the report shows for each property), not for flipping the test outcome.
+
+### Out of scope (noted)
+
+- **MTL/STL for timing predicates over `slow` faults** (Koymans 1990; Maler & Nickovic 2004). `always(between=)` is already metric; full MTL/STL for latency assertions is a later RFC.
+- **The recovery property** ("healthy within N seconds after a fault is removed") is a bounded-MTL property; D4 should confirm the verdict semantics match intent at the timeout boundary, but the `transient`/recovery *vocabulary* is RFC-047 Direction 3 (RFC-050).
+
+## Impact
+
+- **Breaking changes: none at the test-outcome level.** The conservative "any timeout → INCONCLUSIVE" behavior (Finding A) was already shipping; this RFC only corrects the docs table to match it and makes the catch-all's intent explicit. The per-property `always` fix (Finding B) changes a *reported* per-property verdict, not a test verdict. So no test that passed before now fails or flips outcome. Bounded-window and `monitor` cases needed no change. Vacuity is a doc/warning decision (the one open question), not a verdict change. The oracle (step 3) is now in the tree (`TestVerdictOracle_FinalizeMatrix`) and found no further per-property divergence.
+- **CLI exit codes:** unchanged (0/2/3); D4 only changes *which* verdict a borderline test produces, which then flows through the existing exit-code mapping.
+- **Downstream:** RFC-048's coverage statements become semantically grounded — DPOR's "violation" and LDFI's "success outcome" are now LTL₃/LTL_f verdicts with a citation.
+
+## Decisions (resolved)
+
+- **3-valued, not 4-valued (was OQ1).** Faultbox exposes exactly PASS / FAIL / INCONCLUSIVE. A never-violated safety property at `timeout` is **INCONCLUSIVE**, not a qualified PASS — we do not adopt RV-LTL's "presumably true." This is the honest, CI-actionable choice and aligns with the conservatism principle the RFC-048 guarantees rely on.
+- **Timeout is always INCONCLUSIVE, never PASS (Finding A).** A test that ends on its `timeout` deadline is INCONCLUSIVE even if every declared property was satisfied — the body did not reach a declared completion, so the run is a truncated prefix and a green verdict would over-claim. This was already the engine's behavior (a conservative catch-all); D4 corrects the docs table to match and documents the intent. It is the test-level corollary of the OQ2 decision: an un-terminated service run is not a clean PASS.
+- **User-defined termination for long-living / `reuse=True` services (was OQ2).** Faultbox does not auto-detect end-of-trace for a service that never naturally ends; the user declares it via `terminate_when=`, at which point LTL_f applies (unsatisfied `eventually` before the declared completion → FAIL). Absent `terminate_when=`, the only terminal is `timeout` → INCONCLUSIVE. The reused dependency is stable background infrastructure, not the verification target; soundness of its cross-test use is the spec author's responsibility. See "Long-living and `reuse=True` services" above.
+- **Vacuity: PASS + warning, not a verdict change (was the last OQ).** An `always(p, between=(a,b))` whose start anchor `a` never fires has a never-opened window → vacuously ⊤ → **PASS preserved.** Forcing INCONCLUSIVE was rejected: a window can be *legitimately* untriggered (e.g. `between=(error, recovery)` in a clean run), and demoting every such case to INCONCLUSIVE would flood normal runs with false alarms. Instead the runtime emits a **`vacuous_property` warning event** when a window never opened, so an accidentally-broken/typo'd anchor surfaces in the trace rather than hiding as a silent green — without changing the verdict. Implemented: `AlwaysExpectation.VacuousWindow()` + the emit in the Finalize loop, guarded so an unbounded always (opens immediately) and a violated always are never flagged.
+
+## Open Questions
+
+None remaining for the verdict semantics. Possible follow-up: a report-renderer treatment for `vacuous_property` (surface it as a soft warning chip), and extending the oracle to the test-outcome level once a no-service way to drive a *satisfied* `eventually` exists.
+
+## Implementation Plan
+
+This is a specification + test task, not an engine change:
+
+1. Write `docs/concepts/` + `docs/temporal.md` semantics section stating the LTL₃/LTL_f mapping and the per-cause interpretation (the tables above).
+2. Build a **verdict-derivation oracle** — a small reference function from (property kind, prefix, termination cause) → {⊤,?,⊥} — and a golden test matrix covering each operator × each cause × each boundary case.
+3. **Diff the oracle against shipped behavior.** Each disagreement is triaged: doc clarification (oracle matches intent, docs were vague) or bug (engine deviates) → fix with the regression test from step 2.
+4. Land the docs-table correction (Finding A), the per-property `always` fix (Finding B), and the vacuity warning behind the same release; update the RFC-041 verdict table in the docs and on the site.
+
+**Status:** steps 1–4 implemented on `epic/d4-verdict-semantics` (`TestVerdictOracle_FinalizeMatrix` is the step-2/3 oracle; it found no divergence beyond Finding B). The docs/site verdict-table sync (the site mirror) is the remaining piece.
+
+## References
+
+A. Bauer, M. Leucker, C. Schinz, "Runtime Verification for LTL and TLTL," *ACM TOSEM* 20(4), 2011 — LTL₃ / RV-LTL three-valued semantics. · G. De Giacomo, M. Vardi, "Linear Temporal Logic and Linear Dynamic Logic on Finite Traces," *IJCAI* 2013 — LTL_f. · A. Pnueli, "The Temporal Logic of Programs," *FOCS* 1977 — LTL. · R. Koymans, "Specifying Real-Time Properties with Metric Temporal Logic," *Real-Time Systems* 2(4), 1990 — MTL. · O. Maler, D. Nickovic, "Monitoring Temporal Properties of Continuous Signals," *FORMATS* 2004 — STL. · M. Leucker, C. Schallhart, "A Brief Account of Runtime Verification," *JLAP* 78(5), 2009 — survey.

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -239,12 +239,30 @@ Final verdict per cause:
 |-------|----------------------------|-------------------------------|
 | (a) Natural | PASS | **FAIL** (contradiction — natural completion requires every `eventually` already satisfied) |
 | (b) terminate_when | PASS | **FAIL** (system reached its declared final state without `p` ever holding) |
-| (c) timeout | PASS | **INCONCLUSIVE** (more time might have helped) |
+| (c) timeout | **INCONCLUSIVE** | **INCONCLUSIVE** (more time might have helped) |
 | (d) Immediate failure | n/a | **FAIL** |
 
 `always` violations and `monitor` errors are always FAIL regardless of
 cause. INCONCLUSIVE is a deliberate third state — CI integrations can
 choose to gate on it via [exit codes](#cli-exit-codes).
+
+**Timeout is always INCONCLUSIVE, never PASS (RFC-049).** A test that ends by
+hitting its `timeout` is INCONCLUSIVE even if every `eventually` it declared
+was already satisfied — the body did not reach a declared completion (natural
+return or `terminate_when`), so the run is a *truncated prefix* and a green
+verdict would over-claim. This is deliberate and conservative: a hung or
+overrunning body is not a clean PASS just because its assertions happened to
+hold before the deadline. To get a definitive PASS from a long-running or
+`reuse=True` service, declare a `terminate_when=` so the test has a real
+end-of-trace (cause b) rather than relying on the deadline.
+
+This rule is also why per-property verdicts at timeout surface as pending:
+a never-violated *unbounded* `always(p)` (no `between=` window) finalizes to
+INCONCLUSIVE under timeout — a safety property merely *not yet violated* on a
+truncated prefix is not established. At natural completion or `terminate_when`
+the same `always` is a definitive PASS. Bounded `always(p, between=(a,b))` is
+unaffected: once `b` is observed the window is decided, and an *unreached*
+end-anchor at timeout was already INCONCLUSIVE.
 
 ### Why declare `terminate_when=`?
 

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1768,11 +1768,19 @@ func (rt *Runtime) runTestImpl(ctx context.Context, name string) TestResult {
 		}
 	}
 
-	// Timeout with no temporal expectations to gate on — INCONCLUSIVE
-	// rather than PASS, because we couldn't observe the body's verdict.
-	// (Legacy synchronous tests never reach this branch because their
-	// only timeout is the 3-minute infrastructure ctx, and they'd have
-	// returned via err != nil instead.)
+	// A test that ended by TIMEOUT is INCONCLUSIVE — never PASS — and this
+	// is intentional for ALL timeouts, not just the no-expectations case
+	// (RFC-049). Reaching here means no expectation FAILed and none is still
+	// pending (a satisfied eventually finalized to Pass and fell through);
+	// even so, the body did not reach a declared completion (natural return
+	// or terminate_when), so the run is a truncated prefix and a green
+	// verdict would over-claim. Conservative by design: a hung or overrunning
+	// body is not a clean PASS just because its assertions happened to hold
+	// before the deadline. Long-running / reuse=True specs that want a
+	// definite PASS must declare terminate_when= (cause b) rather than lean
+	// on the deadline. (Legacy synchronous tests never reach this branch —
+	// their only timeout is the 3-minute infra ctx, and they'd have returned
+	// via err != nil instead.)
 	if cause == TerminationTimeout {
 		return TestResult{
 			Name: name, Result: "inconclusive",

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -1739,6 +1739,16 @@ func (rt *Runtime) runTestImpl(ctx context.Context, name string) TestResult {
 		anyPending := false
 		for _, exp := range expectations {
 			v, msg := exp.Finalize(finThread, rt.events, cause)
+			// RFC-049 vacuity resolution: an always() whose between= start
+			// anchor never fired is vacuously satisfied (verdict unchanged),
+			// but the predicate was never actually checked — emit a warning so
+			// a typo'd anchor surfaces in the trace instead of a silent green.
+			if vw, ok := exp.(interface{ VacuousWindow() bool }); ok && vw.VacuousWindow() {
+				rt.events.Emit("vacuous_property", "test", map[string]string{
+					"property": exp.Name(),
+					"reason":   "between= start anchor never fired; window never opened — verify the anchor",
+				})
+			}
 			switch v {
 			case VerdictFail:
 				return TestResult{

--- a/internal/star/temporal.go
+++ b/internal/star/temporal.go
@@ -331,6 +331,14 @@ func (a *AlwaysExpectation) Finalize(thread *starlark.Thread, log *EventLog, cau
 	// for always says INCONCLUSIVE; we surface pending and the caller maps.
 	a.mu.Lock()
 	endPending := !a.windowEnded && (a.betweenEnd.matcher != nil || a.hasNamedEndAnchorLocked())
+	// An always() with no closing anchor at all (unbounded `always(p)`, no
+	// between=) is a safety property over the whole trace. RFC-049
+	// Discrepancy 1: a timeout truncates the trace (LTL₃ prefix), so a
+	// never-violated unbounded safety property is INCONCLUSIVE, not PASS — a
+	// longer trace could still violate it. At natural completion /
+	// terminate_when (LTL_f end-of-trace) it stays a definitive PASS, which
+	// the fall-through below preserves.
+	unbounded := a.betweenEnd.matcher == nil && a.betweenEnd.name == ""
 	a.mu.Unlock()
 	if endPending {
 		switch cause {
@@ -341,6 +349,9 @@ func (a *AlwaysExpectation) Finalize(thread *starlark.Thread, log *EventLog, cau
 			// effectively spans the entire test, predicate held throughout → PASS.
 			return VerdictPass, ""
 		}
+	}
+	if unbounded && cause == TerminationTimeout {
+		return VerdictPending, "always(" + funcName(a.predicate) + ") held through a truncated (timed-out) prefix — safety not definitively established (RFC-049)"
 	}
 	return VerdictPass, ""
 }

--- a/internal/star/temporal.go
+++ b/internal/star/temporal.go
@@ -356,6 +356,24 @@ func (a *AlwaysExpectation) Finalize(thread *starlark.Thread, log *EventLog, cau
 	return VerdictPass, ""
 }
 
+// VacuousWindow reports whether this always() had a real start anchor that
+// never fired, so the window never opened and the predicate was never actually
+// evaluated. Such a property is vacuously satisfied (PASS is preserved — the
+// window may be legitimately untriggered, e.g. between=(error, recovery) in a
+// run with no error), but a never-firing start anchor is just as often a
+// typo'd / misnamed anchor that would otherwise hide as a silent green. The
+// runtime emits a `vacuous_property` warning when this is true so the case
+// surfaces in the trace (RFC-049 vacuity resolution). An always() that was
+// violated is not vacuous; an unbounded always (no anchor, opens immediately)
+// never is.
+func (a *AlwaysExpectation) VacuousWindow() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	hasStartAnchor := a.betweenStart.matcher != nil ||
+		(a.betweenStart.name != "" && a.betweenStart.name != "body_start")
+	return hasStartAnchor && !a.windowStarted && !a.violated
+}
+
 // hasNamedEndAnchorLocked is the lock-already-held variant of
 // hasNamedEndAnchor. The Finalize check above already holds a.mu.
 func (a *AlwaysExpectation) hasNamedEndAnchorLocked() bool {

--- a/internal/star/temporal_test.go
+++ b/internal/star/temporal_test.go
@@ -174,6 +174,211 @@ func TestAlways_NoViolation(t *testing.T) {
 	}
 }
 
+// TestVerdictOracle_FinalizeMatrix is the RFC-049 step-2/3 oracle: it encodes
+// the re-derived LTL₃/LTL_f per-property verdict table as the source of truth
+// and diffs every (property-state × termination-cause) cell against what the
+// engine's Finalize actually returns. A future divergence in any cell is
+// either a latent bug or a docs drift — this matrix is where it surfaces.
+//
+// Scope: per-property (Finalize-level) verdicts. The test-level aggregation —
+// notably "any timeout → INCONCLUSIVE" via the runtime catch-all — is guarded
+// at the RunTest level (see lifecycle_test.go TestLifecycle_*Timeout*).
+func TestVerdictOracle_FinalizeMatrix(t *testing.T) {
+	allCauses := []TerminationCause{
+		TerminationNatural, TerminationTerminateWhen, TerminationTimeout, TerminationImmediateFail,
+	}
+	P := VerdictPass
+	F := VerdictFail
+	I := VerdictPending // "?" at the property level; the runner maps to INCONCLUSIVE
+
+	// Each scenario builds a fresh expectation already driven into a known
+	// state, plus the log to Finalize against. The oracle is the expected
+	// verdict per cause.
+	type scenario struct {
+		name  string
+		build func() (ExpectationVal, *EventLog)
+		want  map[TerminationCause]Verdict
+	}
+
+	truePred := func() starlark.Callable { return makePredicate("p", func(*TraceVal) bool { return true }) }
+	falsePred := func() starlark.Callable { return makePredicate("p", func(*TraceVal) bool { return false }) }
+	thread := &starlark.Thread{Name: "oracle"}
+
+	scenarios := []scenario{
+		{
+			// eventually satisfied — co-safety ⊤ latches; PASS under every cause.
+			name: "eventually/satisfied",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				log.Emit("ok", "svc", nil)
+				e := &EventuallyExpectation{predicate: truePred()}
+				_, _, _ = e.Evaluate(thread, log) // latch satisfied
+				return e, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: P, TerminationTerminateWhen: P, TerminationTimeout: P, TerminationImmediateFail: P,
+			},
+		},
+		{
+			// eventually never satisfied — FAIL at a real end-of-trace
+			// (natural / terminate_when / immediate-fail), INCONCLUSIVE only
+			// under timeout (more time might have helped).
+			name: "eventually/unsatisfied",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				log.Emit("ok", "svc", nil)
+				return &EventuallyExpectation{predicate: falsePred()}, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: F, TerminationTerminateWhen: F, TerminationTimeout: I, TerminationImmediateFail: F,
+			},
+		},
+		{
+			// unbounded always, never violated — PASS at a real end-of-trace,
+			// INCONCLUSIVE under timeout (RFC-049 Discrepancy 1).
+			name: "always/unbounded/ok",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				log.Emit("ok", "svc", nil)
+				return &AlwaysExpectation{predicate: truePred()}, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: P, TerminationTerminateWhen: P, TerminationTimeout: I, TerminationImmediateFail: P,
+			},
+		},
+		{
+			// bounded always whose end-anchor closed before termination — the
+			// window is definitively decided; PASS under every cause.
+			name: "always/bounded/closed",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				end := &MatcherVal{matchFn: func(ev Event) bool { return ev.Type == "stop" }}
+				a := &AlwaysExpectation{predicate: truePred(), betweenEnd: betweenAnchor{matcher: end}}
+				log.Emit("normal", "svc", nil)
+				_, _, _ = a.Evaluate(thread, log)
+				log.Emit("stop", "svc", nil)
+				_, _, _ = a.Evaluate(thread, log) // closes window
+				return a, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: P, TerminationTerminateWhen: P, TerminationTimeout: P, TerminationImmediateFail: P,
+			},
+		},
+		{
+			// bounded always whose end-anchor never arrived — open interval;
+			// INCONCLUSIVE under timeout, PASS when a real end-of-trace closes
+			// the test around it.
+			name: "always/bounded/open",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				end := &MatcherVal{matchFn: func(ev Event) bool { return ev.Type == "stop" }}
+				a := &AlwaysExpectation{predicate: truePred(), betweenEnd: betweenAnchor{matcher: end}}
+				log.Emit("normal", "svc", nil)
+				_, _, _ = a.Evaluate(thread, log) // pending, window still open
+				return a, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: P, TerminationTerminateWhen: P, TerminationTimeout: I, TerminationImmediateFail: P,
+			},
+		},
+		{
+			// any violated always — FAIL under every cause.
+			name: "always/violated",
+			build: func() (ExpectationVal, *EventLog) {
+				log := NewEventLog()
+				log.Emit("bad", "svc", nil)
+				a := &AlwaysExpectation{predicate: falsePred()}
+				_, _, _ = a.Evaluate(thread, log) // latch violation
+				return a, log
+			},
+			want: map[TerminationCause]Verdict{
+				TerminationNatural: F, TerminationTerminateWhen: F, TerminationTimeout: F, TerminationImmediateFail: F,
+			},
+		},
+	}
+
+	for _, sc := range scenarios {
+		for _, cause := range allCauses {
+			exp, log := sc.build()
+			got, _ := exp.Finalize(thread, log, cause)
+			if want := sc.want[cause]; got != want {
+				t.Errorf("oracle mismatch [%s × %v]: got %v, want %v", sc.name, cause, got, want)
+			}
+		}
+	}
+}
+
+// TestAlways_Unbounded_TimeoutIsInconclusive is the RFC-049 Discrepancy 1
+// regression guard: an unbounded always(p) (no between=) that was never
+// violated must finalize to PENDING (→ INCONCLUSIVE) under a timeout — the
+// trace is a truncated LTL₃ prefix, so "never violated yet" is not a
+// definitive PASS. Before the fix this returned VerdictPass.
+func TestAlways_Unbounded_TimeoutIsInconclusive(t *testing.T) {
+	log := NewEventLog()
+	log.Emit("ok", "svc", nil)
+
+	exp := &AlwaysExpectation{
+		predicate: makePredicate("p", func(*TraceVal) bool { return true }),
+	}
+	thread := &starlark.Thread{Name: "test"}
+
+	if v, _, _ := exp.Evaluate(thread, log); v != VerdictPending {
+		t.Fatalf("precondition: expected pending pre-termination, got %v", v)
+	}
+
+	v, msg := exp.Finalize(thread, log, TerminationTimeout)
+	if v != VerdictPending {
+		t.Errorf("unbounded always at timeout must be PENDING (→INCONCLUSIVE), got %v", v)
+	}
+	if !strings.Contains(msg, "truncated") {
+		t.Errorf("message should explain the truncated-prefix reason, got %q", msg)
+	}
+}
+
+// TestAlways_Unbounded_DefiniteAtEndOfTrace guards the other side: at a real
+// end-of-trace (natural completion or terminate_when — both LTL_f), an
+// unbounded never-violated always stays a definitive PASS. Only timeout is
+// inconclusive.
+func TestAlways_Unbounded_DefiniteAtEndOfTrace(t *testing.T) {
+	thread := &starlark.Thread{Name: "test"}
+	for _, cause := range []TerminationCause{TerminationNatural, TerminationTerminateWhen} {
+		log := NewEventLog()
+		log.Emit("ok", "svc", nil)
+		exp := &AlwaysExpectation{
+			predicate: makePredicate("p", func(*TraceVal) bool { return true }),
+		}
+		_, _, _ = exp.Evaluate(thread, log)
+		if v, _ := exp.Finalize(thread, log, cause); v != VerdictPass {
+			t.Errorf("cause %v: unbounded never-violated always must be PASS at end-of-trace, got %v", cause, v)
+		}
+	}
+}
+
+// TestAlways_BoundedClosedWindow_TimeoutStaysPass guards that the Discrepancy 1
+// fix did not over-reach: a *bounded* always whose end-anchor closed before
+// the timeout has a definitively-decided window and stays PASS at timeout —
+// the unbounded-truncation rule must not apply to it.
+func TestAlways_BoundedClosedWindow_TimeoutStaysPass(t *testing.T) {
+	log := NewEventLog()
+	endMatcher := &MatcherVal{matchFn: func(ev Event) bool { return ev.Type == "stop" }}
+	exp := &AlwaysExpectation{
+		predicate:  makePredicate("p", func(*TraceVal) bool { return true }),
+		betweenEnd: betweenAnchor{matcher: endMatcher},
+	}
+	thread := &starlark.Thread{Name: "test"}
+
+	log.Emit("normal", "svc", nil)
+	_, _, _ = exp.Evaluate(thread, log)
+	log.Emit("stop", "svc", nil) // closes the window
+	if v, _, _ := exp.Evaluate(thread, log); v != VerdictPass {
+		t.Fatalf("precondition: window should close to PASS, got %v", v)
+	}
+
+	if v, _ := exp.Finalize(thread, log, TerminationTimeout); v != VerdictPass {
+		t.Errorf("bounded always with a closed window must stay PASS at timeout, got %v", v)
+	}
+}
+
 func TestAlways_ViolationIsImmediate(t *testing.T) {
 	log := NewEventLog()
 	log.Emit("bad", "svc", nil)

--- a/internal/star/temporal_test.go
+++ b/internal/star/temporal_test.go
@@ -174,6 +174,48 @@ func TestAlways_NoViolation(t *testing.T) {
 	}
 }
 
+// TestAlways_VacuousWindow is the RFC-049 vacuity guard: an always() whose
+// between= start anchor never fires never opened its window, so the predicate
+// was never checked. VacuousWindow() reports this (the runtime emits a
+// vacuous_property warning), while the verdict stays a vacuous PASS.
+func TestAlways_VacuousWindow(t *testing.T) {
+	thread := &starlark.Thread{Name: "test"}
+	truePred := makePredicate("p", func(*TraceVal) bool { return true })
+	startNever := &MatcherVal{matchFn: func(ev Event) bool { return ev.Type == "go" }}
+
+	// Start anchor never fires → vacuous.
+	log := NewEventLog()
+	log.Emit("other", "svc", nil) // not "go"
+	vac := &AlwaysExpectation{predicate: truePred, betweenStart: betweenAnchor{matcher: startNever}}
+	if v, _, _ := vac.Evaluate(thread, log); v != VerdictPending {
+		t.Fatalf("precondition: window should be closed (pending), got %v", v)
+	}
+	if !vac.VacuousWindow() {
+		t.Error("start anchor never fired → expected VacuousWindow() true")
+	}
+	if v, _ := vac.Finalize(thread, log, TerminationNatural); v != VerdictPass {
+		t.Errorf("vacuous always should still finalize PASS, got %v", v)
+	}
+
+	// Start anchor fires → window opens → not vacuous.
+	log2 := NewEventLog()
+	opened := &AlwaysExpectation{predicate: truePred, betweenStart: betweenAnchor{matcher: startNever}}
+	log2.Emit("go", "svc", nil)
+	_, _, _ = opened.Evaluate(thread, log2)
+	if opened.VacuousWindow() {
+		t.Error("start anchor fired → expected VacuousWindow() false")
+	}
+
+	// Unbounded always opens immediately → never vacuous.
+	log3 := NewEventLog()
+	unb := &AlwaysExpectation{predicate: truePred}
+	log3.Emit("x", "svc", nil)
+	_, _, _ = unb.Evaluate(thread, log3)
+	if unb.VacuousWindow() {
+		t.Error("unbounded always opens immediately → expected VacuousWindow() false")
+	}
+}
+
 // TestVerdictOracle_FinalizeMatrix is the RFC-049 step-2/3 oracle: it encodes
 // the re-derived LTL₃/LTL_f per-property verdict table as the source of truth
 // and diffs every (property-state × termination-cause) cell against what the


### PR DESCRIPTION
Implements **RFC-049 (Direction 4 of the RFC-047 research agenda)** — pins the RFC-041 finite-prefix verdict logic (PASS / FAIL / **INCONCLUSIVE**) to a named semantics (LTL₃ for "?", LTL_f for terminating-test evaluation) and reconciles the docs, the per-property `Finalize`, and the runtime aggregation, which on inspection disagreed in *opposite* directions.

This is the first step of the agreed research-epic sequence **D4 → D3 → RFC-048 (DPOR+LDFI)**: D4 grounds the verdicts those later epics will emit. The RFC doc is included (`docs/rfcs/0049-...`).

## Findings (from tracing the actual aggregation, not just the prose table)

- **Finding A — the engine was already conservative-correct; the docs were wrong.** A test that ends on its `timeout` is INCONCLUSIVE for *any* non-FAIL outcome — even with every `eventually` satisfied — because the body never reached a declared completion (natural return / `terminate_when`), so the run is a truncated prefix. The shipped docs table claimed `(c) timeout / all satisfied → PASS`. Decision (per maintainer): **keep INCONCLUSIVE** — a hung/overrunning body is not a clean PASS. Fixed the docs table + made the catch-all's intent explicit in code. *No test-outcome change.*
- **Finding B — per-property over-claim.** A never-violated **unbounded** `always(p)` finalized to PASS under every cause; at timeout it must be INCONCLUSIVE (LTL₃ truncated safety). The engine already did this for *bounded* windows, so the change extends that truncation logic to the unbounded case. Corrects per-property *reporting*; the test outcome was already INCONCLUSIVE via Finding A.
- **`monitor` — non-issue.** Monitors aren't in the expectation set → a never-violated monitor at timeout falls through to the same catch-all → INCONCLUSIVE.
- **Vacuity — PASS + warning.** An `always(p, between=(a,b))` whose start anchor never fires keeps its vacuous PASS (a window can be legitimately untriggered, e.g. `between=(error, recovery)` in a clean run), but the runtime now emits a `vacuous_property` warning so a typo'd anchor surfaces in the trace instead of hiding as a silent green.

## Changes

- `AlwaysExpectation.Finalize`: unbounded + timeout → `Pending` (→INCONCLUSIVE).
- `AlwaysExpectation.VacuousWindow()` + `vacuous_property` emit in the runtime Finalize loop (optional-interface pattern; `ExpectationVal` unchanged).
- `runtime.go` termination catch-all: comment clarified (all timeouts → INCONCLUSIVE, by design).
- `docs/temporal.md`: verdict table `(c)` row corrected; rationale + per-property note added.
- `TestVerdictOracle_FinalizeMatrix`: encodes the RFC-049 verdict table and diffs every (property-state × cause) cell against the engine — the step-2/3 oracle, zero divergence beyond Finding B. Plus regression guards for the unbounded-always and vacuity cases.

## Impact

**No breaking change at the test-outcome level.** The conservative timeout→INCONCLUSIVE behavior already shipped; this only corrects the docs to match and fixes a per-property reported verdict. No spec surface changes. CLI exit codes unchanged.

## Testing

Full `go test ./...` green (host), `GOOS=linux GOARCH=arm64 go build ./...` OK, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)