### PR TITLE
docs: bug-class positioning - tutorial reading order, guides, showcase spec

### DIFF
--- a/docs/guides/choosing-fault-levels.md
+++ b/docs/guides/choosing-fault-levels.md
@@ -1,7 +1,22 @@
-# Choosing Fault Levels: Syscall vs Protocol
+# Choosing Fault Levels: Start from the Bug Class
 
-Faultbox operates at two levels. This guide helps you decide which to use
-and when to combine them.
+You don't choose a mechanism - you choose a bug to close. Decide which
+of the six bug classes you're testing for, and the fault level follows.
+This guide gives the mapping first, then the mechanics of each level.
+
+## Which bug are you closing?
+
+| Bug class | Level | Typical fault |
+|---|---|---|
+| **Unhandled dependency failure** | Either - syscall for "the whole dependency is gone" (`connect=deny("ECONNREFUSED")`), protocol for "this operation is refused" (`error(query="INSERT*")`) | Start syscall-broad, refine protocol-precise |
+| **Missing timeout / runaway retry** | Protocol - slowness must hit one operation while the service stays healthy | `delay(path="/search*", delay="2s")` |
+| **Non-idempotent retry** | Syscall `hold()` + protocol `error()` - the failure must land *between* the side effect and the response | `write=hold("charge")`, then fail the reply |
+| **Partial failure / torn writes** | Syscall - the only level that can split a transaction mid-flight | `write=deny("EIO", trigger="after=1")`, `fsync=deny("EIO")` |
+| **Failed recovery** | Either level for the fault; the *assertion* is temporal | scoped `fault(...)`, then `eventually(recovered)` |
+| **Bad responses, not outages** | Protocol only - response rewriting | `response(path="/quote", status=200, body="<garbage>")` |
+
+The rest of this guide explains what each level can and cannot do, so
+you can refine these defaults.
 
 ## Two levels, one API
 
@@ -19,7 +34,7 @@ Same `fault()` builtin. The first argument determines the level:
 
 ## When to use syscall faults
 
-Syscall faults simulate **infrastructure failures** — the kind that affect
+Syscall faults simulate **infrastructure failures** - the kind that affect
 everything a service does, not just specific operations.
 
 | Scenario | Fault | What it simulates |
@@ -31,13 +46,13 @@ everything a service does, not just specific operations.
 | Total partition | `partition(svc_a, svc_b)` | Bidirectional network split |
 
 **Strengths:**
-- Works on ANY binary — no protocol support needed
+- Works on ANY binary - no protocol support needed
 - Catches unexpected write paths (logging, temp files, metrics)
 - Simulates real infrastructure failures accurately
 - Simple: one line tests a broad category
 
 **Weaknesses:**
-- Coarse: `write=deny("EIO")` blocks stdout, TCP, files — everything
+- Coarse: `write=deny("EIO")` blocks stdout, TCP, files - everything
 - Can't target specific queries, paths, or commands
 - May break service health (can't respond to healthchecks under write fault)
 
@@ -45,7 +60,7 @@ everything a service does, not just specific operations.
 
 ## When to use protocol faults
 
-Protocol faults simulate **application-level failures** — one operation
+Protocol faults simulate **application-level failures** - one operation
 fails while the rest of the service works normally.
 
 | Scenario | Fault | What it simulates |
@@ -59,7 +74,7 @@ fails while the rest of the service works normally.
 **Strengths:**
 - Precise: target specific queries, paths, commands, topics
 - Realistic: real services fail at the query level, not the disk level
-- Service stays healthy — healthchecks and other operations work normally
+- Service stays healthy - healthchecks and other operations work normally
 - Tests error handling for specific code paths
 
 **Weaknesses:**
@@ -116,10 +131,20 @@ def test_degraded_system():
 
 ## Progression for a new project
 
-1. **Start with syscall faults** — `connect=deny`, `write=deny`, `partition` for each dependency. Covers the broad "is X broken?" category.
+Work through the bug classes in order of incident frequency:
 
-2. **Add protocol faults** for critical paths — specific queries, endpoints, or commands where you need precise error handling verification.
+1. **Unhandled dependency failure first** - `connect=deny` +
+   `error()` for every dependency of your critical flow. This is the
+   class behind most production incidents, and one afternoon covers it.
 
-3. **Combine** for integration scenarios — realistic degradation that exercises multiple failure modes simultaneously.
+2. **Timeouts and retries next** - `delay()`/`slow()` on the same
+   dependencies. Assert latency bounds, not just status codes.
 
-Most projects get 80% of the value from step 1 alone.
+3. **Then the precision classes** for flows where correctness is money:
+   non-idempotent retries (`hold()`), torn writes
+   (`deny(trigger="after=N")`), recovery (`eventually()` after the
+   fault clears), bad responses (`response()` rewriting).
+
+Most projects get 80% of the value from step 1 alone - which is also
+why "which bug class has no spec yet?" is the right review question,
+not "which mechanism haven't we used?"

--- a/docs/guides/seeding-data.md
+++ b/docs/guides/seeding-data.md
@@ -1,7 +1,7 @@
 # Seeding Data & Initial State
 
 Real services do not boot into a vacuum. Before the first request they
-need a schema, reference data, accounts, topics — state that normally
+need a schema, reference data, accounts, topics - state that normally
 lives in init migrations, entrypoint scripts, or a migrations tool.
 This page maps each place that state lives today onto the Faultbox
 mechanism that provides it, and states the guarantees seeding gets
@@ -29,7 +29,7 @@ Three hooks, three jobs:
 
 | Hook | Runs | Use for |
 |------|------|---------|
-| Image entrypoint (`/docker-entrypoint-initdb.d`, baked-in scripts) | On first container boot, before the healthcheck | Schema, migrations — anything the image can do by itself |
+| Image entrypoint (`/docker-entrypoint-initdb.d`, baked-in scripts) | On first container boot, before the healthcheck | Schema, migrations - anything the image can do by itself |
 | `seed=` callback | Once, after the first healthcheck | Application-level fixtures: reference rows, accounts, topics, cache keys |
 | `reset=` callback | Before every test after the first, when `reuse=True` | Cheap cleanup back to the seeded state (`TRUNCATE`, `DEL`) |
 
@@ -41,9 +41,9 @@ state may leak between tests.
 
 | Today | In Faultbox |
 |-------|-------------|
-| Plain `.sql` init scripts | Mount them into the image's init directory: `volumes={"./init.sql": "/docker-entrypoint-initdb.d/init.sql"}` — the database image runs them on first boot, before your healthcheck can pass |
+| Plain `.sql` init scripts | Mount them into the image's init directory: `volumes={"./init.sql": "/docker-entrypoint-initdb.d/init.sql"}` - the database image runs them on first boot, before your healthcheck can pass |
 | The service runs its own migrations on startup | Nothing to do. The healthcheck gates the suite until the service is ready; make the healthcheck strict enough to imply "migrated" |
-| A migrations tool (Flyway, goose, Alembic, Liquibase) | Bake the migration step into the service image's entrypoint, or apply migrations when building the image. Faultbox has no one-shot job container and no exec-into-container — see the honest-limitations note below |
+| A migrations tool (Flyway, goose, Alembic, Liquibase) | Bake the migration step into the service image's entrypoint, or apply migrations when building the image. Faultbox has no one-shot job container and no exec-into-container - see the honest-limitations note below |
 | Test fixtures, reference rows | `seed=` with interface calls: `postgres.main.exec(sql=...)` |
 | Per-test cleanup | `reset=` with `TRUNCATE ... RESTART IDENTITY CASCADE` or key deletes |
 | Mock dependencies | Pre-seed state declaratively: `redis.server(state={...})`, `mongo.server(collections={...})`, `mock_service(..., openapi=...)` |
@@ -72,7 +72,7 @@ postgres = service(
 )
 ```
 
-Seeding is not SQL-only — any interface method works:
+Seeding is not SQL-only - any interface method works:
 
 ```python
 def seed_all():
@@ -87,7 +87,7 @@ def seed_all():
   is installed; `reset()` executes after the previous test's faults are
   cleared. Your fixtures can never be corrupted by an injected fault.
 - **Seeding stays out of the trace.** The event log gets single
-  `service_seed` / `service_reset` markers, not the seeding traffic —
+  `service_seed` / `service_reset` markers, not the seeding traffic -
   temporal properties and invariants never match against setup noise.
 - **Failure is loud.** A failed `seed()` aborts the suite; a failed
   `reset()` fails the test. There is no silent fall-through into tests
@@ -96,7 +96,7 @@ def seed_all():
 ## Pitfalls
 
 - **Keep `reset()` cheap and idempotent.** `TRUNCATE`, not
-  `DROP`/re-`CREATE` — reset runs before every test and its cost
+  `DROP`/re-`CREATE` - reset runs before every test and its cost
   multiplies across the fault matrix.
 - **Keep seed data deterministic.** Random names or timestamps in
   fixtures break trace comparison across replays. Fixed values, always.
@@ -115,12 +115,12 @@ There is currently no way to run a one-shot init container (a job that
 runs migrations and exits) and no `exec`-into-container primitive. If
 your migrations can only run via a tool against a live database, bake
 that step into the image entrypoint or apply it at image build time.
-If this blocks you, say so — it is exactly the kind of demand that
+If this blocks you, say so - it is exactly the kind of demand that
 promotes a roadmap item.
 
 ## See also
 
-- [Container lifecycle](../spec-language.md) — §"Container Lifecycle": full seed/reset semantics
-- Tutorial: [Containers](../tutorial/05-advanced/09-containers.md) — reuse + seed/reset in context
-- Tutorial: [Go microservice end-to-end](../tutorial/05-advanced/22-go-microservice-end-to-end.md) — `seed=` with a real schema file
-- [Mock services](../mock-services.md) — declarative state for simulated dependencies
+- [Container lifecycle](../spec-language.md) - §"Container Lifecycle": full seed/reset semantics
+- Tutorial: [Containers](../tutorial/05-advanced/09-containers.md) - reuse + seed/reset in context
+- Tutorial: [Go microservice end-to-end](../tutorial/05-advanced/22-go-microservice-end-to-end.md) - `seed=` with a real schema file
+- [Mock services](../mock-services.md) - declarative state for simulated dependencies

--- a/docs/rfcs/0048-causal-guided-exploration.md
+++ b/docs/rfcs/0048-causal-guided-exploration.md
@@ -1,0 +1,106 @@
+# RFC-048: Causal-Guided Exploration — DPOR + LDFI on the Mediated Boundary
+
+> **Status: Draft.** Epic RFC. Commits Directions 1 (DPOR) and 2 (LDFI) from [RFC-047](https://github.com/faultbox/Faultbox/issues/132) (Theoretical Foundations) as a single coupled epic. Builds on RFC-041 (Temporal Properties — the causal/`happens_before` API), RFC-042 (Exploration Plan — the leaf/plan-tree engine and the reserved `interleavings="dpor"` stub), RFC-014 (hold/release scheduler — the actuator), and RFC-034 (traffic observability — the lineage source). Relates to RFC-046 (Beyond L1): the soundness boundary defined here is exactly the line a Path-C runtime would push downward.
+>
+> In-tree document: `docs/rfcs/0048-causal-guided-exploration.md`.
+
+## Summary
+
+Faultbox's exploration space has two axes: **which order** mediated events occur in (interleavings) and **which faults** are injected (the matrix). Today both are explored badly — `parallel(interleavings=)` ships launch-ordering only, and `fault_matrix` is a blind Cartesian product whose only coverage metric is dependency-edges-faulted. This epic reduces *both* axes on a *shared causal substrate*, and reports each with the *same explicitly-scoped guarantee*:
+
+- **Direction 1 — DPOR** reduces the interleaving axis: explore one representative per Mazurkiewicz-equivalence class of mediated events, using the `happens_before` order Faultbox already emits as the independence relation, and the RFC-014 hold/release scheduler as the actuator.
+- **Direction 2 — LDFI** reduces the fault axis: derive the causal lineage of a *successful* outcome, compute the minimal fault sets that could break every observed derivation (hitting set), and inject only those — carrying a coverage statement instead of a cell count.
+
+The two directions are coupled, not bolted together: they consume one causal-graph extraction library (Phase 0), and they emit one **coverage statement** vocabulary. DPOR is "the order axis," LDFI is "the fault axis"; together they turn the matrix into a state-space search with a stated — and honestly bounded — guarantee.
+
+**The load-bearing design decision in this RFC is the soundness boundary** (next section). Faultbox does not control goroutine/thread scheduling at L1, so neither direction may claim absolute soundness. Both make completeness claims *relative to the mediated boundary*, using *conservative* relations so the claim is never "covered when it wasn't." That honesty is the guarantee story, not a hole in it.
+
+## The soundness boundary (read this first)
+
+Every claim in this RFC is scoped to **the mediated boundary**: the set of events Faultbox observes and can control — intercepted syscalls (seccomp user-notify) and proxied protocol messages. Between two consecutive mediated events on a thread, the SUT runs arbitrary **uncontrolled interior**: goroutine creation, channel ops, shared-memory access, lock acquisition, and Go-runtime / OS scheduling. Faultbox neither observes nor controls that interior at L1.
+
+This has a precise consequence for each direction, and a single governing principle.
+
+**Governing principle — conservative relations.** A reduction is only sound if the relation it prunes on is *correct*. Faultbox derives its relations (independence for DPOR, lineage for LDFI) from mediated events only, so it cannot see in-interior dependencies. We therefore make the relations **conservative**: declare two events independent / a fault irrelevant *only with positive evidence* (different processes → true isolation; provably disjoint external resources → different DB rows by key, different files/keys). Absent evidence, treat as dependent / relevant. Conservatism costs executions (less pruning) and **buys soundness at the boundary**: the failure mode is "explored more than necessary," never "claimed covered when it wasn't."
+
+**What Faultbox claims, and what it explicitly does not:**
+
+| | Claimed (scoped) | **Not** claimed |
+|---|---|---|
+| **DPOR** | Complete w.r.t. orderings of *mediated* events under a conservative independence relation. | Complete w.r.t. intra-process goroutine/thread interleavings. A race whose two accesses have **no mediated event between them** is invisible and unexplored. |
+| **LDFI** | No fault set of size ≤ k *from the modeled fault space*, over the *observed* lineage, breaks the success outcome. | No fault outside the model; no unobserved derivation. |
+
+**Why the scoped claim is still the one customers want.** The races Faultbox is bought to find are overwhelmingly **external-state** races — check-then-act on a DB row, lost update on a cache key, double-process of a queue message, an `UPDATE` racing a concurrent `SELECT`. The shared state lives *behind a mediated interface*, so the racing accesses *are* mediated events and **do** cross the boundary. The customer's confirmed accept-race (in-memory status check + unconditional `UPDATE`, mediated DB events between) is exactly this class. Pure in-memory data races are `go test -race`'s job; Faultbox should not claim them — and saying so plainly is more credible to a sophisticated buyer than an absolute claim they can falsify in five minutes.
+
+**The boundary is also the roadmap.** The line "below which Faultbox cannot see" is precisely what a Path-C deterministic-scheduling runtime (RFC-046) would push downward. The L1 scoped guarantee is honest *today* and *motivates* the L5 north star: to extend completeness below the mediated boundary, you buy the deterministic runtime. The boundary is a product axis, not an embarrassment.
+
+## Motivation
+
+Three forces make this the right next epic:
+
+1. **It closes the two gaps the field evaluation surfaced.** The truck-api eval confirmed both a request-handling race that requires a specific interleaving (DPOR's target) and a fault-matrix that explodes with a coverage metric that means almost nothing (LDFI's target). This epic is the direct, principled answer to both.
+2. **The substrate already exists; the algorithms don't.** DPOR's hardest input — the independence relation — is the `happens_before` / `concurrent_with` order FB emits (RFC-041). LDFI's input — the causal derivation of a success — is the same DAG plus RFC-034 traffic observability. The actuator DPOR needs to *drive* a schedule is the RFC-014 hold/release scheduler. We are implementing algorithms over data we already produce, not building new runtime.
+3. **The guarantee is the moat.** "No fault combination of size ≤ k breaks this, and every mediated interleaving was explored" is a different *category* of claim than "we ran 137 cells." It is the defensible differentiation versus blind chaos engineering — and, scoped honestly, it is one Faultbox can actually stand behind.
+
+## Direction 1 — DPOR on the mediated-event engine
+
+**Entry point.** RFC-042 rc2 already reserved `parallel(interleavings="dpor")` as an explicit "future release" error. This epic implements it.
+
+**Independence relation.** Two mediated events are independent iff conservative evidence says they cannot interfere: distinct processes/services (address-space isolation), or operations on disjoint external resources (different DB row keys, cache keys, file paths, queue partitions) as resolved from the proxied protocol payload. All other same-process pairs are dependent. This is derived from the RFC-041 vector clocks + correlation IDs, intersected with the resource-key extraction the protocol plugins already do for fault matching.
+
+**Actuator.** The hold/release scheduler (RFC-014) pauses a thread at the seccomp-notify stop point of a mediated event and releases in a chosen order. DPOR decides the schedule; hold/release enforces it. Control exists *only* at mediated points — which is exactly why the completeness claim is boundary-scoped.
+
+**Algorithm.** Optimal DPOR (Abdulla et al., POPL 2014 — source sets / wakeup trees) over the conservative independence relation, paired with **iterative context bounding** (CHESS; Musuvathi & Qadeer, PLDI 2007) so the search prioritizes few-preemption schedules (empirically where bugs cluster) and degrades gracefully under a cost bound rather than exploding.
+
+**Prototype & validation (customer-driven).** The evaluation team has offered to co-drive this on their confirmed accept-race with a running environment. Success = DPOR-driven search finds the violating interleaving within a bounded, conservative exploration and reports the leaf — where today's launch-ordering misses it. **This prototype also empirically answers the central open question:** does sound boundary-scoped DPOR hold for real external-state races at L1 (expected yes), and how much does conservatism inflate the search (the practicality question).
+
+## Direction 2 — Lineage-driven fault injection (LDFI)
+
+**Lineage.** Take the `happens_before` DAG of mediated events leading to an asserted **success** event (a 2xx, a committed write, a confirmed message). That DAG — which upstream calls, DB writes, and cache reads the success depended on — is the lineage. It comes from the RFC-041 causal API + RFC-034 observability; no new capture.
+
+**Hitting set.** Compute, via MaxSAT / minimal-hitting-set, the minimal sets of injectable faults that break *every* observed derivation of the success. Inject only those. New component: the solver (well-understood) plus the boundary-conservative fault-relevance relation (when unsure whether a fault could affect a derivation, include it — explore more).
+
+**Iterative loop (the honest version).** LDFI's power comes from reasoning over *alternative* derivations (redundancy = fault tolerance), but Faultbox observes one run at a time. So LDFI here is a fixpoint loop: derive lineage → hitting set → inject the minimal sets → observe whether success still derives (possibly via a redundant path FB hadn't seen) → augment the lineage → recompute → repeat until no new derivation appears. The coverage statement is over the *accumulated, observed* lineage space — scoped, not absolute, per the boundary section.
+
+**Surface.** A `plan` mode (e.g. `faultbox plan --ldfi --success <probe> --max-k N`) that replaces the Cartesian matrix with the hitting-set-derived suite, emitting the coverage statement. The resulting suite should be *smaller* than the current matrix while carrying the "no k-set breaks it" statement — and still surface genuine degradations (the slow-DB read endpoint).
+
+## Shared substrate & unified report
+
+**Phase 0 — causal-graph extraction (landed first).** One library that turns the event log into a causal DAG with the conservative independence/relevance relations, plus a formal definition of the mediated boundary and the disclaimed-nondeterminism set. Both directions consume it. This answers RFC-047 OQ5 (share it) and is the dependency for everything below.
+
+**Unified coverage statement.** Both directions emit one report artifact in the bundle, with identical scoping language:
+- DPOR → "explored *M* interleaving classes of *N* mediated events; complete at the mediated boundary under conservative independence."
+- LDFI → "no fault set of size ≤ *k* from the modeled space breaks *success*, over the observed lineage."
+
+Each statement names what it does **not** cover (goroutine/thread interleavings; unmodeled faults / unobserved derivations) — the disclaimer is part of the artifact, not buried in docs.
+
+## Phasing
+
+**Predecessors — this epic is third in line.** The agreed sequencing is **Direction 4 → Direction 3 → this epic (1 & 2)**. Both predecessors are load-bearing here, for different reasons:
+
+- **Direction 4 (verdict semantics) — gates the *claims*.** Both directions emit a PASS/FAIL/**INCONCLUSIVE** verdict: DPOR reports "violation found," LDFI reasons over a "success outcome." That verdict logic is hand-rolled today (RFC-041). Two reduction algorithms claiming guarantees on top of an ad-hoc verdict table is unsound by construction, so Direction 4 — pin the verdict semantics to LTL₃ / LTL_f and re-derive the table — must land first. It is a ~2-week specification task, cheap and off the algorithm critical path, but no coverage statement is trustworthy until it is done.
+- **Direction 3 (gray/metastable vocabulary) — enriches LDFI's fault space.** Because the gray/metastable primitives (`degrade(...)`, `transient(...)`-then-check-recovery) land *before* this epic, LDFI's modeled fault space includes them from the start — the hitting set ranges over "degrade" and "transient-trigger" faults, not just `deny`/`delay`/`drop`. This turns what would have been a later extension into a day-one design input (see Open Questions).
+
+- **Phase 0 — shared causal-graph extraction + boundary definition.** Conservative independence/relevance from VCs + correlation IDs + protocol resource keys. Co-requisite: the Direction-4 verdict-semantics fix above. (RFC-047 OQ5.)
+- **Phase 1 — DPOR** on the customer's accept-race, co-developed. Implements `interleavings="dpor"` + context bounding. Empirically validates boundary-scoped soundness and conservatism cost. (RFC-047 OQ1.)
+- **Phase 2 — LDFI** on a write-path success lineage: solver + iterative loop + `--ldfi` surface + coverage statement. (RFC-047 OQ2.)
+- **Phase 3 — unified coverage report** + scoping language across both, wired into the HTML report and `plan.json`.
+
+Each phase ships independently behind its own flag; Phase 0 unblocks 1 and 2 in parallel.
+
+## Impact
+
+- **Breaking changes:** none. `interleavings="dpor"` activates a currently-reserved error value; `--ldfi` is additive; the Cartesian `fault_matrix` stays the default.
+- **Performance:** both directions *reduce* executions versus naïve exhaustive/Cartesian — that is the point. Conservatism trades some of that reduction back for a sound boundary-scoped claim; the solver and independence bookkeeping are small relative to the SUT runs they eliminate.
+- **Positioning:** delivers the "stated guarantees" half of the Antithesis-class-but-open-source framing, on the current L1 substrate, with claims scoped so they survive contact with a skeptical buyer.
+
+## Open Questions
+
+1. **Conservatism cost (DPOR).** How much does the conservative independence relation inflate the search on a real service, and is iterative context bounding enough to keep it tractable? (Phase 1 measures this.)
+2. **Lineage fidelity (LDFI).** How meaningful is the coverage statement when lineage is observed at the mediated boundary rather than derived from program semantics? Is the iterative loop's fixpoint reached in practice, or does it chase derivations indefinitely on a redundant system? (Phase 2 measures this.)
+3. **Resource-key precision.** Independence/relevance both lean on extracting the external resource a mediated event touches (DB row, cache key) from the protocol payload. How precise is this per plugin, and what is the failure mode when it's coarse (it must fail *toward* dependence/relevance — explore more)?
+4. **Gray/metastable fault space (LDFI).** Direction 3 lands before this epic, so its `degrade`/`transient` primitives are in LDFI's modeled fault space from the start. Open: does the hitting-set formulation treat a `transient`-trigger fault (whose effect is a temporal recovery property, not a single broken derivation) the same as a point fault, or does it need a distinct "did the system fail to recover" success predicate?
+
+## References
+
+Condensed from RFC-047 (full citations there). DPOR: Flanagan & Godefroid (POPL 2005); Abdulla et al. (POPL 2014); Musuvathi & Qadeer (PLDI 2007, CHESS); Mazurkiewicz (1986). LDFI: Alvaro, Rosen & Hellerstein (SIGMOD 2015); Alvaro et al. (SoCC 2016). Causal foundations: Lamport (1978); Mattern (1989).

--- a/docs/rfcs/0050-gray-metastable-faults.md
+++ b/docs/rfcs/0050-gray-metastable-faults.md
@@ -11,7 +11,9 @@ Faultbox's fault primitives map cleanly onto the classic dependability taxonomy 
 - **Gray failures** — a component that *limps*: passes health checks while serving slow / partial / wrong responses to real traffic. The defining feature is **differential observability** — the failure detector's view (healthy) diverges from the user's view (degraded).
 - **Metastable failures** — a system that stays broken *after the trigger is removed*, sustained by a feedback loop (retry storms, cache stampedes). The defining feature is **non-recovery**: a transient perturbation latches into a persistent bad state.
 
-This RFC (1) maps Faultbox's primitives onto the dependability taxonomy to make the coverage explicit, and (2) adds the minimal vocabulary for the two gaps: a first-class **`degrade(...)`** fault and a **`transient(...)`-then-check-recovery** idiom. Both are demoable, low-risk, and squarely in Faultbox's spec-language wheelhouse; the field evaluation confirmed both gaps (a read endpoint that degraded under a slow database — a baby gray failure — and observed retry amplification on a mutating path).
+This RFC (1) maps Faultbox's primitives onto the dependability taxonomy to make the coverage explicit, and (2) adds the vocabulary for the two gaps: a first-class **`degrade(...)`** fault, a **`transient(...)`** trigger-then-withdraw fault, a **`load(...)`** background traffic driver, and a narrow **bounded-recovery** temporal operator (`eventually(p, after=, within=)`). The field evaluation confirmed both gaps (a read endpoint that degraded under a slow database — a baby gray failure — and observed retry amplification on a mutating path).
+
+**Two honesty caveats, made load-bearing in the design below rather than buried:** (a) *gray failure* — Faultbox can reproduce the degradation and let you assert the health/data-path *divergence*, but it does **not** model the orchestrator/failure-detector that would *act* on the healthcheck; the exemption also only works when the healthcheck is proxy-routed. (b) *metastable failure* — a metastable latch is **load-induced**: it only appears when sustained traffic pushes the system past a tipping point. Faultbox drives the SUT with scripted `step()` calls, not production load, so `transient` alone tests only "does the system recover from a brief fault" (the *easy* direction — most do). Catching real metastability requires the new `load(...)` driver to supply the sustaining pressure. This RFC treats load generation as the *other half* of the feature, not an afterthought.
 
 ## Motivation
 
@@ -54,54 +56,107 @@ always(health_ok)                    # the platform keeps thinking it's healthy 
 eventually(user_slo_violated)        # … while users see the SLO break
 ```
 
-A test where both hold under `degrade` has reproduced a gray failure: the system masks a real degradation from its own failure detector. That divergence is the bug, and it is exactly what a kill-a-node tool cannot surface.
+A test where both hold under `degrade` has reproduced the *observable signature* of a gray failure: the health path stays green while users see the SLO break. That divergence is the bug, and it is exactly what a kill-a-node tool cannot surface.
 
-### `transient(...)` — metastable trigger + recovery check
+**Scope — what `degrade` does and does not model.** Two honest limits:
 
-The essence of a metastable failure is **non-recovery after the trigger clears.** Faultbox already has the lifecycle (`fault_start`/`fault_stop`); `transient` wraps it with an explicit withdrawal and a recovery anchor:
+- **The healthcheck must be proxy-routed** for the `health_path` exemption to mean anything. A container-native `HEALTHCHECK` or a k8s liveness probe that hits the pod directly does not traverse the Faultbox proxy, so `degrade` cannot hold it green while degrading other paths. `degrade` validates the exemption target at spec-load and errors if the service's healthcheck is not routed through an interface the proxy owns.
+- **There is no failure detector in the loop.** Faultbox does not model an orchestrator/load-balancer that *acts* on the healthcheck (evicts, reroutes, opens a circuit). So `always(health_ok)` asserts *the test author observed the health path stay 200*, not *a real detector was fooled into a wrong decision*. `degrade` reproduces the differential-observability *condition*; verifying the *consequence* (does the platform mis-route because of it) is out of scope until a modeled detector exists (a possible future RFC). Stated plainly so the demo claim stays honest.
+
+### `load(...)` — the other half of metastability
+
+A metastable latch is **load-induced**: the sustaining feedback loop (retry storm, connection-pool exhaustion, cache stampede) only engages when traffic holds the system past its tipping point. Scripted `step()` calls in the test body do not supply that. So `transient` needs a companion that generates **sustained background traffic** through the proxy:
+
+```python
+load(
+    target   = api.http,                 # drive requests at this interface
+    request  = lambda: api.http.get("/feed"),
+    rate     = "200rps",                 # constant offered load …
+    duration = "30s",                    # … for the window that spans the transient
+)
+```
+
+`load` runs concurrently with the test body, firing `request` at `rate`. Because every request crosses the proxy, the response of the loop to the transient — retries piling up, latency climbing, throughput collapsing and *staying* collapsed — is **observable at the mediated boundary**. Without `load`, `transient` only exercises recover-from-a-brief-fault (the easy direction); with it, the test can actually reach and detect a latched state. `load` is a minimal constant-rate generator (no ramps/arrival-distribution modelling in v1); those are a later refinement.
+
+### `transient(...)` + bounded recovery — the metastability check
+
+`transient` wraps the existing `fault_start`/`fault_stop` lifecycle with an explicit withdrawal, emitting a `fault_removed` anchor:
 
 ```python
 transient(
     fault    = deny(connect, "ECONNREFUSED"),   # the trigger (e.g. upstream outage)
     duration = "5s",                            # … withdrawn after 5s (or until=<event>)
 )
-# emits a `fault_removed` anchor when the trigger is withdrawn
 ```
 
-paired with a **bounded recovery property** (the MTL recovery shape noted in RFC-049):
+Under sustained `load`, the metastability question is: *after the trigger is gone, does the system re-quiesce, or stay latched?* That is a **bounded-recovery property** — this RFC owns the narrow temporal operator for it:
 
 ```python
-# after the trigger is gone, load/latency/queue-depth must return to baseline within N
 eventually(recovered, after = "fault_removed", within = "10s")
-# FAIL if the system stays latched in the bad state — that is metastability
+# recovered within the window → PASS; deadline passes still latched → FAIL (metastable)
 ```
 
-What makes this observable on Faultbox's substrate: the feedback loop's signal (request/retry volume, queue depth) crosses the **mediated boundary** — the proxy sees retry traffic stay elevated after `fault_stop`. "Recovered" is defined relative to a **pre-trigger baseline** captured by `await_stable` before the transient fires. If the post-withdrawal state never re-quiesces to that baseline within the window, the test FAILs as metastable.
+**This is a new temporal operator, not free.** RFC-049 (accepted) deliberately deferred general MTL/STL and kept `always(between=)` as the only metric form. `eventually(p, after=anchor, within=duration)` is the *minimal* slice needed here: a single anchor plus a hard deadline — not full MTL. Its verdict plugs into the RFC-049 framework cleanly: **the `within` deadline is a declared end-of-trace for that property** (LTL_f-style), so an unsatisfied recovery *at the deadline* is a definitive **FAIL** — not INCONCLUSIVE — because the bound, not a timeout, closed it. (If the enclosing test times out *before* the deadline, the property is still `?` → INCONCLUSIVE, per RFC-049.)
 
-### Minimalism (RFC-044 ethos)
+**"Recovered" is boundary-scoped — the same discipline as RFC-048.** The recovery signal must be something Faultbox observes at the mediated boundary: request/retry rate, error rate, or latency *through the proxy*. Internal signals the SUT never exposes across the boundary — queue depth, in-process pool saturation — are **not** usable as `recovered` predicates, exactly as RFC-048's guarantees are scoped to mediated events. The default `recovered` baseline is a pre-trigger `await_stable` quiescence of the boundary signal; a spec may override with an explicit predicate over boundary-observable quantities (e.g. `p99_latency < baseline * 1.2`). If the loop never engaged (the transient did not perturb the boundary signal at all), the recovery check is vacuous → it emits a `vacuous_property` warning (reusing the RFC-049 vacuity mechanism) so a scenario that never actually stressed the system does not read as a green PASS.
 
-Both additions are deliberately thin: `degrade` is one named composite over existing proxy mechanism; `transient` is a lifecycle wrapper plus the recovery-property shape Faultbox already has via `eventually`/`await_stable`. No new engine subsystem. The new surface is two builtins and one anchor event (`fault_removed`).
+### Worked example — a metastable retry storm
+
+Putting the three pieces together on the eval's mutating path (the one that showed retry amplification):
+
+```python
+db  = service("db", image = "postgres:16", interface("pg", "postgres", 5432), healthcheck = tcp("localhost:5432"))
+api = service("api", image = "shop-api:latest", interface("http", "http", 8080),
+    depends_on = [db], healthcheck = http("localhost:8080/health"))
+
+def test_retry_storm_is_transient():
+    # 1. hold steady offered load across the whole scenario
+    load(target = api.http, request = lambda: api.http.post("/orders", body = ORDER),
+         rate = "200rps", duration = "30s")
+
+    # 2. capture the pre-trigger boundary baseline (request/latency quiesced)
+    await_stable(quiescence_window = "2s")
+
+    # 3. a brief DB outage — then withdraw it
+    transient(fault = deny(db.pg, connect = "ECONNREFUSED"), duration = "5s")
+
+    # 4. the metastability check: once the DB is back, the boundary signal must
+    #    re-quiesce within 10s. If retries keep the system pinned, this FAILs.
+    eventually(recovered, after = "fault_removed", within = "10s")
+
+test("retry_storm_is_transient", body = test_retry_storm_is_transient, timeout = "60s")
+```
+
+The bug this catches: the DB recovers at t=5s, but client/queue retries built up during the outage keep offered load above the tipping point, so the system never re-quiesces — `recovered` never holds within the window → **FAIL (metastable)**. Remove the `load(...)` and the same test passes trivially (a 5s outage with no sustained pressure recovers on its own) — which is exactly why `load` is load-bearing, not optional.
+
+### Minimalism vs. what this actually costs (RFC-044 ethos)
+
+`degrade` is a thin named composite over existing proxy mechanism. `transient` is a thin lifecycle wrapper. But the feature is **not** free: reproducing real metastability requires the new `load(...)` traffic driver (a genuine new subsystem, kept minimal), and the bounded-recovery check requires the new `eventually(after=, within=)` operator (a narrow MTL slice RFC-049 deferred). The honest surface is **three builtins** (`degrade`, `transient`, `load`), **one temporal-operator extension**, and **one anchor event** (`fault_removed`) — larger than the original "two thin builtins" framing, because the metastability half needs load and a deadline to mean anything.
 
 ## Impact
 
-- **Breaking changes:** none — both are additive builtins.
-- **Feeds RFC-048 (LDFI).** `degrade` and `transient` join the modeled fault space, so LDFI's hitting set ranges over "degrade" and "transient-trigger" faults, not just `deny`/`delay`/`drop` (RFC-048 OQ4). Note the open question there: a `transient` fault's "break" is a *recovery property failing*, not a single broken derivation, so LDFI needs a distinct success-predicate hook for it.
-- **Report.** Gray and metastable get first-class labels and the paired-property view, so a degraded-but-green run reads as a gray failure rather than a confusing PASS.
+- **Breaking changes:** none — all additive builtins.
+- **Feeds RFC-048 (LDFI) — but only `degrade` fits cleanly.** `degrade` is a degradation that can break a success *derivation*, so it joins LDFI's modeled fault space and its hitting set directly (alongside `deny`/`delay`/`drop`). **`transient`/metastability does not fit LDFI's model:** its "break" is a *recovery property failing over time under load*, not a single fault breaking a derivation of a success event. LDFI's hitting-set formulation has no natural place for it. So the honest statement is: `degrade` extends LDFI; `transient` is a *different verification shape* that LDFI does not subsume (RFC-048 OQ4 should be narrowed to `degrade` only). Do not claim both enter LDFI's fault space.
+- **Report.** Gray and metastable get first-class labels and the paired-property view, so a degraded-but-green run reads as a gray failure rather than a confusing PASS, and a non-recovering transient reads as metastable rather than a bare temporal FAIL.
+- **New subsystem cost.** `load(...)` is a real (if minimal) traffic generator — the first time Faultbox drives *sustained* offered load rather than discrete `step()` calls. Worth calling out as the one non-trivial engine addition in this RFC.
 
 ## Open Questions
 
-1. **Primitive vs composition surface.** Ship `degrade`/`transient` as builtins (proposed), or as documented recipes over `response`/`fault_start`? Builtins win on report-labeling and discoverability; recipes win on spec-language minimalism. Leaning builtins precisely because the *report semantics* (labeling the class) need a first-class type.
-2. **"Recovered" baseline definition.** Is pre-trigger `await_stable` quiescence the right baseline, or should the user declare the recovery predicate explicitly (queue depth < X, p99 < Y)? Probably both: a default baseline from quiescence, overridable by an explicit predicate.
-3. **Health-path mediation for `degrade`.** The `health_path` exemption assumes the health check traverses the proxy. For container healthchecks that hit the service directly (not through the FB proxy), how is the exemption enforced — does `degrade` require the healthcheck to be proxy-routed?
-4. **Recovery-window clock.** Is `within=` wall-clock or virtual-time? Under `--virtual-time` the metastable feedback loop's timing must advance consistently; ties to the RFC-049 MTL recovery semantics.
+1. **`load(...)` fidelity in v1.** Constant-rate offered load is the minimum that can induce a latch. Is that enough to reproduce real metastability, or does the tipping point need closed-loop behaviour (client-side retry/backoff modelling, arrival-distribution, ramps)? v1 ships constant-rate + client retries observed at the boundary; ramps/distributions are a follow-up. How is `load`'s own traffic distinguished in the trace from the body's `step()` calls (a `source=load` tag)?
+2. **Recovery-window clock (`within=`).** Wall-clock or virtual-time? Under `--virtual-time` the feedback loop's timing must advance consistently, and `load`'s rate must be virtual-time-aware, else the metastable window is non-reproducible. Ties to the bounded-recovery operator's semantics.
+3. **`degrade` without a proxy-routed healthcheck.** The scope section requires the healthcheck to traverse the proxy for the exemption to hold; `degrade` errors at spec-load otherwise. Is a hard error the right call, or should it warn-and-degrade-everything (losing the differential but still injecting the degradation)?
+4. **Primitive vs recipe surface (minor).** `degrade`/`transient` could ship as documented recipes over `response`/`fault_start`, but the *report-labeling* (gray/metastable as first-class classes) needs a real type — hence builtins. `load` must be a builtin regardless (new mechanism).
+
+*Resolved in this revision:* the "recovered" baseline is a boundary-observable signal (default: pre-trigger `await_stable` quiescence, overridable by a boundary-scoped predicate — internal queue depth is explicitly excluded); the recovery operator is a narrow bounded-`eventually` whose deadline is an LTL_f end-of-trace for that property (FAIL at deadline, per RFC-049); a never-engaged loop emits a `vacuous_property` warning.
 
 ## Implementation Plan
 
-1. Write the taxonomy mapping into `docs/` (concepts + reference) — the table above, made complete.
-2. `degrade(...)` builtin: parse + validate, lower to existing proxy `response`/`error` + path-exemption + probability fan-out; add the `gray_failure` report label.
-3. `transient(...)` builtin: wrap `fault_start`/`fault_stop` with a duration/until withdrawal and emit the `fault_removed` anchor; add `eventually(..., after=, within=)` recovery-property support (or confirm it composes from existing temporal + the anchor).
-4. Baseline capture via `await_stable` + the recovery verdict; `metastable` report label.
-5. Hand the two new fault types to RFC-048's fault-space enumeration.
+1. Write the taxonomy mapping into `docs/` (concepts + reference) — the table above, made complete, with the two scope caveats stated.
+2. **`load(...)` builtin first** — the constant-rate background traffic driver through the proxy, virtual-time-aware, tagging its requests `source=load`. It is the prerequisite for any real metastability test, so it leads.
+3. `degrade(...)` builtin: parse + validate (including the proxy-routed-healthcheck check), lower to existing proxy `response`/`error` + path-exemption + probability fan-out; add the `gray_failure` report label.
+4. Bounded-recovery operator: `eventually(p, after=anchor, within=duration)` with the RFC-049-consistent verdict (FAIL at the deadline). Boundary-scoped `recovered` default via `await_stable`; vacuity warning when the loop never engages.
+5. `transient(...)` builtin: wrap `fault_start`/`fault_stop` with duration/until withdrawal, emit the `fault_removed` anchor; `metastable` report label.
+6. Hand **`degrade` only** to RFC-048's LDFI fault-space enumeration (not `transient` — see Impact).
 
 ## References
 

--- a/docs/rfcs/0050-gray-metastable-faults.md
+++ b/docs/rfcs/0050-gray-metastable-faults.md
@@ -1,0 +1,108 @@
+# RFC-050: Gray & Metastable Faults — Closing the Fault-Model Gaps
+
+> **Status: Draft.** Feature RFC (Direction 3 of [RFC-047](https://github.com/faultbox/Faultbox/issues/132)). **Second in the agreed research-epic sequence (D4 → D3 → RFC-048 DPOR+LDFI).** Builds on RFC-041 (Temporal Properties — the recovery property), the fault lifecycle (`fault_start`/`fault_stop`), and the protocol proxy (`response`/`error`/`drop`/`delay`, path matching). Feeds RFC-048: the primitives defined here enter LDFI's modeled fault space.
+>
+> In-tree document: `docs/rfcs/0050-gray-metastable-faults.md`.
+
+## Summary
+
+Faultbox's fault primitives map cleanly onto the classic dependability taxonomy for crash, omission, and timing failures — but two failure *classes* that disproportionately hurt real production systems are expressible only awkwardly today:
+
+- **Gray failures** — a component that *limps*: passes health checks while serving slow / partial / wrong responses to real traffic. The defining feature is **differential observability** — the failure detector's view (healthy) diverges from the user's view (degraded).
+- **Metastable failures** — a system that stays broken *after the trigger is removed*, sustained by a feedback loop (retry storms, cache stampedes). The defining feature is **non-recovery**: a transient perturbation latches into a persistent bad state.
+
+This RFC (1) maps Faultbox's primitives onto the dependability taxonomy to make the coverage explicit, and (2) adds the minimal vocabulary for the two gaps: a first-class **`degrade(...)`** fault and a **`transient(...)`-then-check-recovery** idiom. Both are demoable, low-risk, and squarely in Faultbox's spec-language wheelhouse; the field evaluation confirmed both gaps (a read endpoint that degraded under a slow database — a baby gray failure — and observed retry amplification on a mutating path).
+
+## Motivation
+
+Gray and metastable failures are *the* modes that survive positive-path QA and chaos engineering's "kill a node" repertoire, because neither is a clean crash: the gray one masks itself from the very health signal the platform trusts, and the metastable one only appears *after* the obvious fault is gone. Making Faultbox express and *verify* them is both a real capability gap and a sharp, marketable differentiator — "watch Faultbox catch a retry storm that survives the trigger being removed" is a demo no kill-a-node tool can match. As the user-facing epic in the D4→D3→RFC-048 sequence, D3 is the one that lands the next user.
+
+## Technical Details
+
+### The taxonomy mapping
+
+| Fault class (Avizienis et al. 2004; Cristian 1991) | Faultbox primitive today | Status |
+|---|---|---|
+| Crash-stop | `deny(connect, ECONNREFUSED)` | ✅ clean |
+| Omission | `drop` (protocol), `deny` (syscall) | ✅ clean |
+| Timing (slow) | `delay` (syscall), `response(delay=)` (protocol) | ✅ clean |
+| Byzantine (wrong value) | `response(...)` rewrite to a plausible-but-wrong body | ✅ expressible |
+| **Gray (differential observability)** | `delay` + `response` + path matching, by hand | ⚠️ no first-class form |
+| **Metastable (non-recovery)** | `fault_start` → `fault_stop` + `eventually`, by hand | ⚠️ no idiom |
+
+The two gaps are not missing *mechanism* — the proxy can already slow, rewrite, and path-match, and the fault lifecycle can already trigger-then-withdraw. They are missing a **first-class name and the paired verification**, which is what turns "a fault you could hand-assemble" into "a failure class Faultbox tests and reports as such."
+
+### `degrade(...)` — gray failure as a primitive
+
+The essence of a gray failure is that the **health path stays green while the data path rots.** `degrade` is a protocol-interface fault that injects sub-total degradation on real traffic while exempting the health-check path:
+
+```python
+degrade(
+    health_path = "/healthz",        # kept fast + 200 so the orchestrator never evicts
+    latency     = "800ms",           # data-path slowdown
+    error_rate  = 0.1,               # partial, not total — probability fan-out under the hood
+    # optional: partial = lambda body: truncate(body),  # wrong/partial response
+)
+```
+
+It composes from primitives that exist — `response(delay=)`, `error(...)`, the RFC-042 probability fan-out (`error_rate` → `max_fires`/`mode`), and proxy path matching for the `health_path` exemption — but ships as one named fault so the report can label it **"gray failure (differential observability)"** rather than a pile of unrelated proxy rules.
+
+**The paired verification is the point.** A `degrade` fault is meant to be checked against the *divergence itself*:
+
+```python
+always(health_ok)                    # the platform keeps thinking it's healthy …
+eventually(user_slo_violated)        # … while users see the SLO break
+```
+
+A test where both hold under `degrade` has reproduced a gray failure: the system masks a real degradation from its own failure detector. That divergence is the bug, and it is exactly what a kill-a-node tool cannot surface.
+
+### `transient(...)` — metastable trigger + recovery check
+
+The essence of a metastable failure is **non-recovery after the trigger clears.** Faultbox already has the lifecycle (`fault_start`/`fault_stop`); `transient` wraps it with an explicit withdrawal and a recovery anchor:
+
+```python
+transient(
+    fault    = deny(connect, "ECONNREFUSED"),   # the trigger (e.g. upstream outage)
+    duration = "5s",                            # … withdrawn after 5s (or until=<event>)
+)
+# emits a `fault_removed` anchor when the trigger is withdrawn
+```
+
+paired with a **bounded recovery property** (the MTL recovery shape noted in RFC-049):
+
+```python
+# after the trigger is gone, load/latency/queue-depth must return to baseline within N
+eventually(recovered, after = "fault_removed", within = "10s")
+# FAIL if the system stays latched in the bad state — that is metastability
+```
+
+What makes this observable on Faultbox's substrate: the feedback loop's signal (request/retry volume, queue depth) crosses the **mediated boundary** — the proxy sees retry traffic stay elevated after `fault_stop`. "Recovered" is defined relative to a **pre-trigger baseline** captured by `await_stable` before the transient fires. If the post-withdrawal state never re-quiesces to that baseline within the window, the test FAILs as metastable.
+
+### Minimalism (RFC-044 ethos)
+
+Both additions are deliberately thin: `degrade` is one named composite over existing proxy mechanism; `transient` is a lifecycle wrapper plus the recovery-property shape Faultbox already has via `eventually`/`await_stable`. No new engine subsystem. The new surface is two builtins and one anchor event (`fault_removed`).
+
+## Impact
+
+- **Breaking changes:** none — both are additive builtins.
+- **Feeds RFC-048 (LDFI).** `degrade` and `transient` join the modeled fault space, so LDFI's hitting set ranges over "degrade" and "transient-trigger" faults, not just `deny`/`delay`/`drop` (RFC-048 OQ4). Note the open question there: a `transient` fault's "break" is a *recovery property failing*, not a single broken derivation, so LDFI needs a distinct success-predicate hook for it.
+- **Report.** Gray and metastable get first-class labels and the paired-property view, so a degraded-but-green run reads as a gray failure rather than a confusing PASS.
+
+## Open Questions
+
+1. **Primitive vs composition surface.** Ship `degrade`/`transient` as builtins (proposed), or as documented recipes over `response`/`fault_start`? Builtins win on report-labeling and discoverability; recipes win on spec-language minimalism. Leaning builtins precisely because the *report semantics* (labeling the class) need a first-class type.
+2. **"Recovered" baseline definition.** Is pre-trigger `await_stable` quiescence the right baseline, or should the user declare the recovery predicate explicitly (queue depth < X, p99 < Y)? Probably both: a default baseline from quiescence, overridable by an explicit predicate.
+3. **Health-path mediation for `degrade`.** The `health_path` exemption assumes the health check traverses the proxy. For container healthchecks that hit the service directly (not through the FB proxy), how is the exemption enforced — does `degrade` require the healthcheck to be proxy-routed?
+4. **Recovery-window clock.** Is `within=` wall-clock or virtual-time? Under `--virtual-time` the metastable feedback loop's timing must advance consistently; ties to the RFC-049 MTL recovery semantics.
+
+## Implementation Plan
+
+1. Write the taxonomy mapping into `docs/` (concepts + reference) — the table above, made complete.
+2. `degrade(...)` builtin: parse + validate, lower to existing proxy `response`/`error` + path-exemption + probability fan-out; add the `gray_failure` report label.
+3. `transient(...)` builtin: wrap `fault_start`/`fault_stop` with a duration/until withdrawal and emit the `fault_removed` anchor; add `eventually(..., after=, within=)` recovery-property support (or confirm it composes from existing temporal + the anchor).
+4. Baseline capture via `await_stable` + the recovery verdict; `metastable` report label.
+5. Hand the two new fault types to RFC-048's fault-space enumeration.
+
+## References
+
+A. Avizienis, J.-C. Laprie, B. Randell, C. Landwehr, "Basic Concepts and Taxonomy of Dependable and Secure Computing," *IEEE TDSC* 1(1), 2004. · F. Cristian, "Understanding Fault-Tolerant Distributed Systems," *CACM* 34(2), 1991. · F. Schneider, "Implementing Fault-Tolerant Services Using the State Machine Approach," *ACM CSUR* 22(4), 1990. · P. Huang et al., "Gray Failure: The Achilles' Heel of Cloud-Scale Systems," *HotOS* 2017. · N. Bronson et al., "Metastable Failures in Distributed Systems," *HotOS* 2021. · L. Huang et al., "Metastable Failures in the Wild," *OSDI* 2022.

--- a/docs/tutorial/01-first-taste/01-first-fault.md
+++ b/docs/tutorial/01-first-taste/01-first-fault.md
@@ -5,13 +5,13 @@
 
 ## Goals & Purpose
 
-Most production outages are not exotic. They are ordinary failures — a
-full disk, a refused connection, a slow reply — hitting error-handling
+Most production outages are not exotic. They are ordinary failures - a
+full disk, a refused connection, a slow reply - hitting error-handling
 code that has never once executed. The study that named this pattern
 ("Simple Testing Can Prevent Most Critical Failures", OSDI 2014) found
 that the large majority of catastrophic distributed-system failures came
 from incorrect handling of ordinary, non-fatal errors. Those are the
-bugs this tutorial teaches you to close — one
+bugs this tutorial teaches you to close - one
 [bug class](https://faultbox.io/docs/concepts/bug-classes) at a time,
 starting with the smallest possible demonstration: one program, one
 injected failure.
@@ -21,11 +21,11 @@ API, it can return errors**. When your code calls `write()`, it assumes
 the bytes reach the disk. When it calls `connect()`, it assumes the
 network is there. Faultbox intercepts that API at the kernel level, so
 your program has no way to avoid or detect the interception. This is
-not mocking — it's real.
+not mocking - it's real.
 
 **The question you should be asking:** *"What happens to my program when
 an ordinary operation returns an ordinary error?"* Most teams discover
-the answer in production — at 3am, during a traffic spike. Faultbox lets
+the answer in production - at 3am, during a traffic spike. Faultbox lets
 you discover it now, on your laptop.
 
 ## How it works
@@ -41,7 +41,7 @@ Your program                    Kernel                     Faultbox
     |<-- errno = EIO -------------|                           |
 ```
 
-This works on **any binary** — Go, Rust, C, Java, Python. No code changes,
+This works on **any binary** - Go, Rust, C, Java, Python. No code changes,
 no special libraries. The kernel is the interception point.
 
 ## Run the target program normally
@@ -73,11 +73,11 @@ net failed: ... connect: network is unreachable (took 2ms)
 > **Why "network is unreachable"?** This is NOT a fault injection.
 > `faultbox run` creates an **isolated network namespace** for the target
 > process (PID, mount, and network are all sandboxed). The target has no
-> network access — only loopback. This is a safety feature: the target
+> network access - only loopback. This is a safety feature: the target
 > can't make real external calls during testing.
 >
 > The filesystem still works because it uses the mount namespace which
-> shares `/tmp/`. The network error is normal and expected — ignore it
+> shares `/tmp/`. The network error is normal and expected - ignore it
 > for now. In later chapters, we'll inject network faults explicitly
 > with `connect=deny("ECONNREFUSED")`.
 
@@ -110,10 +110,10 @@ Notice what happened:
 - The seccomp filter was installed for syscall 64 (`write` on arm64)
 - **Four** write syscalls were intercepted and denied with EIO
 - The target exited with error code 1
-- **The target's own output is missing** — it tried to `write()` to stdout
+- **The target's own output is missing** - it tried to `write()` to stdout
   but that write was also denied! The program couldn't even print its error.
 
-This demonstrates a key point: `write=EIO:100%` denies ALL writes — to files,
+This demonstrates a key point: `write=EIO:100%` denies ALL writes - to files,
 to stdout, to network sockets. The program had no way to report what went wrong
 because the reporting mechanism (stdout) was itself broken.
 
@@ -158,9 +158,9 @@ make lima-run CMD='faultbox run --fault "openat=ENOENT:100%:/data/*" bin/linux/t
 ```
 
 The target writes to `/tmp/` (not `/data/`), so the filesystem test succeeds.
-(You'll still see "network is unreachable" — that's the namespace sandbox,
+(You'll still see "network is unreachable" - that's the namespace sandbox,
 not your fault rule.) **The intuition:** production failures are usually
-localized — one volume fails, not all storage. Path targeting simulates
+localized - one volume fails, not all storage. Path targeting simulates
 exactly that.
 
 > **fd→path resolution:** Path filtering works for both file-path syscalls
@@ -194,7 +194,7 @@ cascades into downstream timeouts. Delays let you find these problems.
 - `--fault "syscall=ERRNO:PROB%"` denies syscalls with specific errors
 - `--fault "syscall=delay:DURATION:PROB%"` introduces latency
 - Path globs (`:/data/*`) target specific files
-- seccomp-notify works at the kernel level — no code changes needed
+- seccomp-notify works at the kernel level - no code changes needed
 - **The mental model:** think of every syscall as an API call that can fail
 
 ## What's next
@@ -202,11 +202,11 @@ cascades into downstream timeouts. Delays let you find these problems.
 Running `faultbox run` with manual flags works for exploration, but it doesn't
 scale. You need:
 
-- **Repeatable tests** — run the same scenario every time, in CI
-- **Multi-service topologies** — your API depends on a database, which depends on storage
-- **Assertions** — not just "did it crash?" but "did it return the right error code?"
+- **Repeatable tests** - run the same scenario every time, in CI
+- **Multi-service topologies** - your API depends on a database, which depends on storage
+- **Assertions** - not just "did it crash?" but "did it return the right error code?"
 
-Chapter 2 introduces Starlark spec files — a way to codify your system
+Chapter 2 introduces Starlark spec files - a way to codify your system
 topology and test scenarios as code.
 
 ## Exercises
@@ -230,6 +230,6 @@ topology and test scenarios as code.
 
 4. **Selective denial**: Run with `--fault "openat=ENOENT:100%:/tmp/faultbox*"`.
    The glob targets only the test file. Does the target still run? What about
-   its other operations? Now try `--fault "write=EIO:100%:/tmp/faultbox*"` —
-   does path filtering work for `write` the same way as `openat`? (Yes — Faultbox
+   its other operations? Now try `--fault "write=EIO:100%:/tmp/faultbox*"` -
+   does path filtering work for `write` the same way as `openat`? (Yes - Faultbox
    resolves fd→path via `/proc`, so write path targeting works.)

--- a/docs/tutorial/01-first-taste/01-first-fault.md
+++ b/docs/tutorial/01-first-taste/01-first-fault.md
@@ -5,21 +5,28 @@
 
 ## Goals & Purpose
 
-Every program trusts the operating system. When your code calls `write()`,
-it assumes the bytes reach the disk. When it calls `connect()`, it assumes
-the network is there. But in production, these assumptions break: disks
-fill up, networks partition, I/O errors corrupt data.
+Most production outages are not exotic. They are ordinary failures — a
+full disk, a refused connection, a slow reply — hitting error-handling
+code that has never once executed. The study that named this pattern
+("Simple Testing Can Prevent Most Critical Failures", OSDI 2014) found
+that the large majority of catastrophic distributed-system failures came
+from incorrect handling of ordinary, non-fatal errors. Those are the
+bugs this tutorial teaches you to close — one
+[bug class](https://faultbox.io/docs/concepts/bug-classes) at a time,
+starting with the smallest possible demonstration: one program, one
+injected failure.
+
+The core intuition of this chapter: **the OS is an API, and like any
+API, it can return errors**. When your code calls `write()`, it assumes
+the bytes reach the disk. When it calls `connect()`, it assumes the
+network is there. Faultbox intercepts that API at the kernel level, so
+your program has no way to avoid or detect the interception. This is
+not mocking — it's real.
 
 **The question you should be asking:** *"What happens to my program when
-the OS returns an error it doesn't expect?"*
-
-Most teams discover the answer in production — at 3am, during a traffic
-spike. Faultbox lets you discover it now, on your laptop.
-
-In this chapter you'll build the core intuition: **the OS is an API, and
-like any API, it can return errors**. Faultbox intercepts that API at the
-kernel level, so your program has no way to avoid or detect the interception.
-This is not mocking — it's real.
+an ordinary operation returns an ordinary error?"* Most teams discover
+the answer in production — at 3am, during a traffic spike. Faultbox lets
+you discover it now, on your laptop.
 
 ## How it works
 

--- a/docs/tutorial/01-first-taste/02-first-test.md
+++ b/docs/tutorial/01-first-taste/02-first-test.md
@@ -198,6 +198,37 @@ by design — independent tests are parallelizable and debuggable.
 3. How do I know they're ready?
 4. What should happen when I interact with them?
 
+## You just tested at the boundary
+
+Notice what your spec actually contains: a system under test plus a
+**stand-in dependency**. `mock-db` is not a production database — it is
+a small, protocol-faithful simulation that Faultbox fully controls.
+
+This is Faultbox's core adoption pattern, and it scales all the way up.
+In real projects, the one real thing in the spec is *your* service —
+the image you already have — while the dependencies you can't run
+(another team's API, a paid SaaS, the company Kafka) are simulated with
+`mock_service()`, `redis.server(state=...)`, or OpenAPI-generated stubs
+([Chapter 17](../05-advanced/17-mock-services.md)). You never need the
+whole company's system on your laptop to test how your service survives
+its dependencies failing.
+
+## Your first report
+
+Every `faultbox test` run writes a `.fb` bundle — a self-contained
+archive of the run: spec, environment, event trace, replay script. Turn
+the latest one into a shareable HTML report:
+
+```bash
+faultbox report run-*.fb
+# → wrote report.html
+```
+
+Open `report.html` in a browser: a swim-lane trace of every service and
+every operation in your test. [Chapter 23](../05-advanced/23-reports.md)
+teaches you to read it in depth; for now, remember that any run can
+become an artifact you attach to a PR or an incident ticket.
+
 ## What's next
 
 You can now write tests for the happy path — "when everything works, here's

--- a/docs/tutorial/01-first-taste/02-first-test.md
+++ b/docs/tutorial/01-first-taste/02-first-test.md
@@ -6,7 +6,7 @@
 ## Goals & Purpose
 
 In chapter 1 you injected faults manually. That's useful for exploration,
-but not for building confidence. You need **repeatable specifications** —
+but not for building confidence. You need **repeatable specifications** -
 files that describe your system and what "working" means.
 
 The key insight: **a distributed system's behavior is defined by its topology
@@ -14,10 +14,10 @@ The key insight: **a distributed system's behavior is defined by its topology
 write both down, you can test them automatically.
 
 This chapter teaches you to think in terms of:
-- **Services** — the components of your system
-- **Interfaces** — how they communicate
-- **Healthchecks** — what "ready" means
-- **Test functions** — what "correct" means
+- **Services** - the components of your system
+- **Interfaces** - how they communicate
+- **Healthchecks** - what "ready" means
+- **Test functions** - what "correct" means
 
 After this chapter, you'll have a mental framework for specifying any
 system: "these services exist, they talk over these protocols, and when I
@@ -25,7 +25,7 @@ do X, I expect Y."
 
 ## Starlark
 
-Faultbox uses Starlark — a Python dialect designed for configuration.
+Faultbox uses Starlark - a Python dialect designed for configuration.
 If you know Python, you know Starlark. No imports, no classes, no exceptions.
 Just functions, variables, and data. Configuration is code.
 
@@ -69,7 +69,7 @@ Let's break this down:
 connections."
 
 **The test function** says: "when I send PING, I expect PONG." That's your
-specification — a concrete, executable claim about system behavior.
+specification - a concrete, executable claim about system behavior.
 
 ## Run it
 
@@ -102,7 +102,7 @@ For each `test_*` function, Faultbox:
 5. Report result + syscall trace
 ```
 
-Every test gets **fresh instances** — services are restarted between tests.
+Every test gets **fresh instances** - services are restarted between tests.
 No state leaks. This is critical: if test A's data affected test B's result,
 your specs would be unreliable.
 
@@ -118,7 +118,7 @@ db = service("db", "/tmp/mock-db",
 
 | Parameter | What it means | Why it matters |
 |-----------|---------------|----------------|
-| `"db"` | Service name | Appears in logs and traces — you'll use it to filter events |
+| `"db"` | Service name | Appears in logs and traces - you'll use it to filter events |
 | `"/tmp/mock-db"` | Binary path | The actual program to run |
 | `interface("main", "tcp", 5432)` | Communication endpoint | Declares how other services connect |
 | `env = {...}` | Environment variables | Configure the process without changing code |
@@ -146,7 +146,7 @@ For HTTP interfaces (chapter 3), you get `.get()`, `.post()`, etc.
 
 ## Assertions
 
-Two basic assertions — simple but powerful:
+Two basic assertions - simple but powerful:
 
 ```python
 assert_eq(actual, expected)           # equality check
@@ -154,7 +154,7 @@ assert_true(condition, "message")     # boolean check
 ```
 
 They fail the test immediately with a clear error message. No fuzzy matching,
-no eventual consistency — did the value match or not?
+no eventual consistency - did the value match or not?
 
 ## Adding more tests
 
@@ -181,7 +181,7 @@ faultbox test my-first-test.star --test set_and_get
 
 **Each test is independent.** The database restarts between tests, so
 `test_set_and_get` doesn't depend on `test_ping` having run first. This is
-by design — independent tests are parallelizable and debuggable.
+by design - independent tests are parallelizable and debuggable.
 
 ## What you learned
 
@@ -201,12 +201,12 @@ by design — independent tests are parallelizable and debuggable.
 ## You just tested at the boundary
 
 Notice what your spec actually contains: a system under test plus a
-**stand-in dependency**. `mock-db` is not a production database — it is
+**stand-in dependency**. `mock-db` is not a production database - it is
 a small, protocol-faithful simulation that Faultbox fully controls.
 
 This is Faultbox's core adoption pattern, and it scales all the way up.
-In real projects, the one real thing in the spec is *your* service —
-the image you already have — while the dependencies you can't run
+In real projects, the one real thing in the spec is *your* service -
+the image you already have - while the dependencies you can't run
 (another team's API, a paid SaaS, the company Kafka) are simulated with
 `mock_service()`, `redis.server(state=...)`, or OpenAPI-generated stubs
 ([Chapter 17](../05-advanced/17-mock-services.md)). You never need the
@@ -215,7 +215,7 @@ its dependencies failing.
 
 ## Your first report
 
-Every `faultbox test` run writes a `.fb` bundle — a self-contained
+Every `faultbox test` run writes a `.fb` bundle - a self-contained
 archive of the run: spec, environment, event trace, replay script. Turn
 the latest one into a shareable HTML report:
 
@@ -231,14 +231,14 @@ become an artifact you attach to a PR or an incident ticket.
 
 ## What's next
 
-You can now write tests for the happy path — "when everything works, here's
+You can now write tests for the happy path - "when everything works, here's
 what I expect." But the interesting questions are about failure:
 
 - What happens when the database can't write to disk?
 - What happens when the API can't reach the database?
 - What happens when writes are slow?
 
-Chapter 3 introduces `fault()` — a way to inject specific failures into
+Chapter 3 introduces `fault()` - a way to inject specific failures into
 specific services during specific test scenarios.
 
 ## Exercises
@@ -247,7 +247,7 @@ specific services during specific test scenarios.
    `GET mykey`, and asserts the result is `"myvalue"`.
 
 2. **Missing key**: Add a test that does `GET nonexistent` and asserts
-   the result is `"NOT_FOUND"`. (This tests the error path — just as
+   the result is `"NOT_FOUND"`. (This tests the error path - just as
    important as the happy path.)
 
 3. **Overwrite**: Add a test that sets the same key twice with different

--- a/docs/tutorial/02-syscall-level/06-domain-model.md
+++ b/docs/tutorial/02-syscall-level/06-domain-model.md
@@ -30,11 +30,11 @@ def test_slow_network():
 
 This works. But look at what happened:
 
-1. **The scenario is duplicated three times** — `api.post(path="/data/key", body="value")`
+1. **The scenario is duplicated three times** - `api.post(path="/data/key", body="value")`
    appears in every test, copied and pasted.
-2. **The faults are inlined** — `connect=deny("ECONNREFUSED")` has no name. When you
+2. **The faults are inlined** - `connect=deny("ECONNREFUSED")` has no name. When you
    need "db down" in another test, you type it again.
-3. **The assertions are embedded** — if you add a fourth fault, you copy-paste again.
+3. **The assertions are embedded** - if you add a fourth fault, you copy-paste again.
 
 With 5 scenarios and 4 fault modes, you have 20 hand-written test functions.
 With 10 scenarios and 8 fault modes, you have 80. The approach doesn't scale.
@@ -82,7 +82,7 @@ Each layer is **defined once, reused everywhere**:
 
 ## Scenarios as probes
 
-A scenario is a **probe** — it exercises the system and returns an observable
+A scenario is a **probe** - it exercises the system and returns an observable
 result. No assertions inside.
 
 ```python
@@ -101,14 +101,14 @@ api = service("api", BIN + "/mock-api",
 )
 
 def order_flow():
-    """Place an order — return the response for external validation."""
+    """Place an order - return the response for external validation."""
     api.post(path="/data/mykey", body="myvalue")
     return api.get(path="/data/mykey")
 
 scenario(order_flow)
 
 def health_check():
-    """Check API health — return the response."""
+    """Check API health - return the response."""
     return api.get(path="/health")
 
 scenario(health_check)
@@ -121,7 +121,7 @@ faults with different expected outcomes:
 - Under `db_down`: `status >= 500`
 - Under `slow_network`: `status == 200` but `duration_ms > 400`
 
-The scenario doesn't judge — it just reports what happened.
+The scenario doesn't judge - it just reports what happened.
 
 ## Named fault assumptions
 
@@ -149,7 +149,7 @@ A fault assumption is a **reusable failure mode**. It carries:
 - A target service
 - The syscall-level faults to apply
 
-You can also attach **monitors** — invariants that must hold whenever this
+You can also attach **monitors** - invariants that must hold whenever this
 fault is active:
 
 ```python
@@ -168,7 +168,7 @@ db_down = fault_assumption("db_down",
 Now every test that uses `db_down` automatically verifies that no traffic
 reaches the DB. You write the invariant once.
 
-## Fault scenarios — one scenario, one fault, one oracle
+## Fault scenarios - one scenario, one fault, one oracle
 
 The simplest composition: pair one scenario with one fault assumption and
 an `expect` oracle that validates the result:
@@ -184,7 +184,7 @@ fault_scenario("order_db_down",
 This registers `test_order_db_down`. When it runs:
 1. Installs `db_down` fault rules (and its monitors)
 2. Calls `order_flow()`, captures the return value
-3. Passes the return value to `expect` — which asserts on it
+3. Passes the return value to `expect` - which asserts on it
 4. Cleans up
 
 **No fault (happy path oracle):**
@@ -199,7 +199,7 @@ fault_scenario("order_happy",
 )
 ```
 
-Without `faults=`, the scenario runs under normal conditions — useful for
+Without `faults=`, the scenario runs under normal conditions - useful for
 validating the happy path with explicit expectations.
 
 **Smoke test (no oracle):**
@@ -212,7 +212,7 @@ fault_scenario("order_disk_full_smoke",
 ```
 
 Without `expect=`, the test passes as long as the scenario completes
-without crashing. Good for initial discovery — "does it survive this fault?"
+without crashing. Good for initial discovery - "does it survive this fault?"
 
 **Multiple faults simultaneously:**
 
@@ -231,7 +231,7 @@ fault_scenario("order_cascade",
 `fault_scenario()` is the right tool when you have **one specific combination**
 to test. When you have many scenarios × many faults, use `fault_matrix()`.
 
-## The fault matrix — the cross-product
+## The fault matrix - the cross-product
 
 When you have multiple scenarios and multiple fault assumptions, the matrix
 generates all combinations automatically:
@@ -265,12 +265,12 @@ health_check        │ PASS (206ms)  │ PASS (205ms)  │ PASS (705ms)
 Result: 6/6 passed
 ```
 
-**Cells without overrides** use `default_expect` — a baseline check
+**Cells without overrides** use `default_expect` - a baseline check
 ("must return something"). Cells with overrides use the specific oracle.
 
 ## When to use which approach
 
-The domain-centric model doesn't replace the test-centric model — it builds
+The domain-centric model doesn't replace the test-centric model - it builds
 on top of it:
 
 | Approach | When to use | Example |
@@ -281,11 +281,11 @@ on top of it:
 | `fault_matrix()` | Systematic coverage: many scenarios × many faults | 5 scenarios × 4 faults = 20 tests |
 | `faultbox generate` | Discovery: let Faultbox propose failure modes | Auto-generates assumptions + matrix |
 
-**Most users start with `fault_scenario()`** — it's the workhorse for
+**Most users start with `fault_scenario()`** - it's the workhorse for
 individual fault tests. **Graduate to `fault_matrix()`** when you have
 multiple scenarios and faults that should be cross-tested.
 
-## Composition — combining fault assumptions
+## Composition - combining fault assumptions
 
 Fault assumptions compose. Define simple ones and combine them:
 
@@ -402,7 +402,7 @@ assumptions. Add a third fault and you get 6 matrix tests automatically.
 
 - **Test-centric** works for small specs but duplicates scenario + fault + assertion
 - **Domain-centric** separates WHAT (scenarios), WHAT BREAKS (assumptions), WHAT'S CORRECT (oracles)
-- `scenario(fn)` registers a probe — returns observables, no assertions
+- `scenario(fn)` registers a probe - returns observables, no assertions
 - `fault_assumption()` names a reusable failure mode
 - `fault_matrix()` generates the cross-product
 - Monitors on assumptions enforce invariants across all tests
@@ -411,10 +411,10 @@ assumptions. Add a third fault and you get 6 matrix tests automatically.
 ## What's next
 
 **From here forward, all tutorial examples use the domain-centric model.**
-When you see a scenario, a fault assumption, or a matrix — that's the
+When you see a scenario, a fault assumption, or a matrix - that's the
 standard approach for writing Faultbox specs.
 
 Continue to:
-- [Part 3: Protocol-Level Faults](../03-protocol-level/07-http-redis.md) — HTTP, database, broker faults
-- [Part 4: Safety & Verification](../04-safety/14-invariants.md) — invariants, monitors, partitions
-- [Part 5: Advanced Features](../05-advanced/09-containers.md) — containers, generation, event sources
+- [Part 3: Simulate the Boundary](../05-advanced/17-mock-services.md) - mock the dependencies you can't run
+- [Part 4: Real Infrastructure](../03-protocol-level/07-http-redis.md) - protocol faults on real HTTP, databases, containers
+- [Part 5: Safety & Verification](../04-safety/14-invariants.md) - invariants, monitors, partitions

--- a/docs/tutorial/03-protocol-level/08-databases.md
+++ b/docs/tutorial/03-protocol-level/08-databases.md
@@ -81,7 +81,7 @@ fault_scenario("slow_query",
 )
 ```
 
-The proxy parses the Postgres wire protocol — it sees the actual SQL query
+The proxy parses the Postgres wire protocol - it sees the actual SQL query
 text and matches against your pattern.
 
 ## MySQL: Same API, different protocol
@@ -110,7 +110,7 @@ fault_scenario("mysql_read_only",
 )
 ```
 
-Same fault assumption API — the proxy knows to speak MySQL wire protocol
+Same fault assumption API - the proxy knows to speak MySQL wire protocol
 because the interface is declared as `"mysql"`.
 
 ## Redis: Command-level faults
@@ -284,13 +284,15 @@ fault_scenario("slow_auth",
 - `scenario(fn)` registers probe functions that return observables
 - `fault_assumption(name, target=, ...)` defines named, reusable fault configs
 - `fault_scenario(name, scenario=, faults=, expect=)` composes tests from scenarios and faults
-- The proxy speaks the real wire protocol — matches SQL queries, Redis commands, Kafka topics
+- The proxy speaks the real wire protocol - matches SQL queries, Redis commands, Kafka topics
 - 10 protocols supported, covering 30+ products
 - Combine with syscall faults for cascading failure scenarios
 
 ## What's next
 
-Part 4 covers advanced features: testing real infrastructure with Docker
-containers, auto-generating failure scenarios from happy paths, capturing
-structured events from stdout and message queues, and defining high-level
-named operations.
+You can fault real databases and brokers through their protocols. The
+remaining piece of real infrastructure is running them the way production
+does - in containers. Chapter 9 launches real Postgres and Redis under
+Faultbox control, with the seed/reset lifecycle and container reuse.
+
+Continue: [Chapter 9: Containers](../05-advanced/09-containers.md)

--- a/docs/tutorial/04-safety/16-partitions.md
+++ b/docs/tutorial/04-safety/16-partitions.md
@@ -7,7 +7,7 @@
 
 Network partitions are the most dangerous failure mode in distributed
 systems. Unlike a crashed server (which is clearly down), a partition
-creates **ambiguity** — each side thinks the other might be alive or dead.
+creates **ambiguity** - each side thinks the other might be alive or dead.
 
 This ambiguity causes split-brain: two nodes both think they're the
 primary. Two order services both accept the last item in stock. Two
@@ -19,13 +19,13 @@ your system handles partitions without violating safety invariants.
 
 ## partition() builtin
 
-Partitions are bidirectional — they affect two services at once. Unlike
+Partitions are bidirectional - they affect two services at once. Unlike
 `fault_assumption()` (which targets one service), partitions remain as
 standalone test functions:
 
 ```python
 def test_network_split():
-    """Orders can't reach inventory — should return 503."""
+    """Orders can't reach inventory - should return 503."""
     def scenario():
         resp = orders.post(path="/orders", body='...')
         assert_eq(resp.status, 503)
@@ -117,7 +117,7 @@ def test_no_stock_change_during_partition():
     """
     def scenario():
         resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
-        # We don't care about the status — we care about the invariant.
+        # We don't care about the status - we care about the invariant.
 
         # No WAL write should happen on inventory (no reservation).
         assert_never(
@@ -146,13 +146,13 @@ Test that the system recovers after the partition heals:
 ```python
 def test_recovery_after_partition():
     """System works again after partition is resolved."""
-    # Phase 1: partition — orders should fail.
+    # Phase 1: partition - orders should fail.
     def during_partition():
         resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
         assert_eq(resp.status, 503)
     partition(orders, inventory, run=during_partition)
 
-    # Phase 2: partition resolved — orders should work.
+    # Phase 2: partition resolved - orders should work.
     resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
     assert_eq(resp.status, 200)
 ```
@@ -176,14 +176,14 @@ reach B, but B can still reach A), use `fault()` directly:
 def test_one_way_partition():
     """Orders can't reach inventory, but inventory can still function.
 
-    This simulates asymmetric network failure — common when a firewall
+    This simulates asymmetric network failure - common when a firewall
     rule is misconfigured or a load balancer drops traffic in one direction.
     """
     def scenario():
         resp = orders.post(path="/orders", body='{"sku":"widget","qty":1}')
         assert_eq(resp.status, 503)
 
-        # Inventory is fine — it just doesn't receive requests.
+        # Inventory is fine - it just doesn't receive requests.
         # If another client could reach it directly, it would work.
     fault(orders, connect=deny("ECONNREFUSED", label="one-way partition"),
         run=scenario)
@@ -201,7 +201,7 @@ def test_one_way_partition():
 
 ## Partitions and the domain-centric model
 
-`partition()` is bidirectional — it affects two services at once. This
+`partition()` is bidirectional - it affects two services at once. This
 means it can't be expressed as a single `fault_assumption()` (which targets
 one service). Partitions remain standalone test functions, even in
 domain-centric specs:
@@ -221,7 +221,7 @@ def test_partition():
     partition(orders, inventory, run=scenario)
 ```
 
-`faultbox generate` handles this automatically — it produces a `fault_matrix()`
+`faultbox generate` handles this automatically - it produces a `fault_matrix()`
 for standard faults and separate `def test_*` functions for partitions.
 
 ## What you learned
@@ -230,8 +230,8 @@ for standard faults and separate `def test_*` functions for partitions.
 - Partitions + monitors verify safety under network failure
 - Test recovery after partition resolution
 - One-way partitions use `fault()` with `connect=deny()`
-- Partitions are standalone tests — not part of `fault_matrix()`
-- Partitions are the hardest failure mode — test them explicitly
+- Partitions are standalone tests - not part of `fault_matrix()`
+- Partitions are the hardest failure mode - test them explicitly
 
 ## What's next
 
@@ -240,5 +240,5 @@ You've completed the Safety & Verification section. You can now:
 - Write monitors that verify them continuously
 - Test under network partitions
 
-Continue to [Part 5: Advanced](../05-advanced/index.md) for containers,
-scenarios, event sources, named operations, and LLM integration.
+Continue to [Chapter 10: Scenarios & Fault Matrix](../05-advanced/10-scenarios.md) -
+generate the fault cross-product for every scenario you've declared.

--- a/docs/tutorial/04-safety/24-determinism.md
+++ b/docs/tutorial/04-safety/24-determinism.md
@@ -5,23 +5,23 @@
 
 ## Goals & Purpose
 
-When a Faultbox test fails the same way twice but passes the third time, you have one of two problems: a real race condition, or your service-under-test is doing I/O that Faultbox isn't watching. The latter is what RFC-040 calls **unmediated I/O** — and until v0.13.0, Faultbox couldn't tell you which one it was.
+When a Faultbox test fails the same way twice but passes the third time, you have one of two problems: a real race condition, or your service-under-test is doing I/O that Faultbox isn't watching. The latter is what RFC-040 calls **unmediated I/O** - and until v0.13.0, Faultbox couldn't tell you which one it was.
 
 This chapter teaches you to:
 - **Read the L0–L5 determinism taxonomy** and place your test on it
 - **Use `determinism()`** to make the spec's reproducibility promise explicit
-- **Use `nondeterministic_ok=`** as the documented escape hatch — and recognise the anti-pattern of using it to silence flakes
+- **Use `nondeterministic_ok=`** as the documented escape hatch - and recognise the anti-pattern of using it to silence flakes
 - **Debug strict-mode failures** with the runtime override flag
 
 ## The taxonomy in one paragraph
 
 Faultbox v0.13.0 ships **L1: mediated-event determinism**. That means: same plan-node + seed → causal-precedence-equivalent log of the events Faultbox mediated (proxy traffic, faulted syscalls). Concurrent events may interleave differently across replays, and any I/O Faultbox doesn't see (a background `getrandom` call, a DNS lookup outside the proxy, `clock_gettime` for a request-ID timestamp) is invisible to the contract.
 
-Higher levels (L2–L5) are roadmap. Lower (L0) is plan-only determinism — useful for `--dry-run` but not for actual test outcomes. The full taxonomy lives in [docs/determinism.md](../../determinism.md); for this chapter we focus on L1 because that's what runs today.
+Higher levels (L2–L5) are roadmap. Lower (L0) is plan-only determinism - useful for `--dry-run` but not for actual test outcomes. The full taxonomy lives in [docs/determinism.md](../../determinism.md); for this chapter we focus on L1 because that's what runs today.
 
 ## Strict mode is on by default
 
-The default spec — no `determinism()` call — runs at L1 with `strict=True`:
+The default spec - no `determinism()` call - runs at L1 with `strict=True`:
 
 ```python
 service("api", "/usr/local/bin/api",
@@ -37,11 +37,11 @@ Run this. If `api` calls `getrandom` to mint a request ID, you'll see:
 ```
 test_smoke FAIL: strict determinism: unmediated_io[rand] from service "api"
   (syscall=getrandom, pid=4242)
-  — add "rand" to determinism(allow=...) or service("api",
+  - add "rand" to determinism(allow=...) or service("api",
     nondeterministic_ok=[...]) to tolerate, or fix the underlying I/O leak
 ```
 
-The error names the category, the service, the syscall, and the two escape hatches — in that order. The third option (fix the SUT) is intentional: most untolerated `unmediated_io` events are real flakes-in-waiting, and silencing them is debt.
+The error names the category, the service, the syscall, and the two escape hatches - in that order. The third option (fix the SUT) is intentional: most untolerated `unmediated_io` events are real flakes-in-waiting, and silencing them is debt.
 
 ## When to tolerate, when to fix
 
@@ -100,7 +100,7 @@ The two lists union; they don't replace.
 determinism(allow = ["clock", "rand", "dns", "network-unmediated"])
 ```
 
-If you find yourself adding every category to the spec-level `allow=`, you're effectively running with `strict=False`. Just write that — the intent is honest, and a future reader knows you opted out deliberately. `allow=` is for documented exceptions, not for chasing green builds.
+If you find yourself adding every category to the spec-level `allow=`, you're effectively running with `strict=False`. Just write that - the intent is honest, and a future reader knows you opted out deliberately. `allow=` is for documented exceptions, not for chasing green builds.
 
 ## Local debug iteration without editing the spec
 
@@ -112,7 +112,7 @@ faultbox test smoke.star --no-strict-determinism
 
 This flips strict off for the duration of one run. The `unmediated_io` events still appear in the trace and bundle (now as warnings, visible in `--format json` and the HTML report); they just don't fail the test. The spec is unchanged, your CI is unchanged.
 
-The override is bidirectional — `--strict-determinism` also forces strict on if a spec turned it off. Useful for one-off compliance checks before merging.
+The override is bidirectional - `--strict-determinism` also forces strict on if a spec turned it off. Useful for one-off compliance checks before merging.
 
 ## What L1 detection actually catches
 
@@ -120,15 +120,15 @@ Five categories. Three caveats worth knowing.
 
 | Category | Caught | Not caught |
 |----------|--------|------------|
-| `clock` | `clock_gettime` syscall path | **Go's `time.Now()`** — uses VDSO, which seccomp can't intercept. Best-effort. |
+| `clock` | `clock_gettime` syscall path | **Go's `time.Now()`** - uses VDSO, which seccomp can't intercept. Best-effort. |
 | `rand` | `getrandom` + `/dev/urandom` reads | An in-process Mersenne twister seeded once at startup |
-| `dns` | `connect()` to port 53 outside declared interfaces | DoH / DoT — encrypted DNS over HTTPS or TLS |
-| `network-unmediated` | `connect()` to any address/port not matching an `interface()` and not a Faultbox proxy listener | Nothing — this is the cleanest signal |
-| `fs-unmediated` | reserved category in v0.13.0 — accepted in `allow=` lists but not detected yet | (everything for now) |
+| `dns` | `connect()` to port 53 outside declared interfaces | DoH / DoT - encrypted DNS over HTTPS or TLS |
+| `network-unmediated` | `connect()` to any address/port not matching an `interface()` and not a Faultbox proxy listener | Nothing - this is the cleanest signal |
+| `fs-unmediated` | reserved category in v0.13.0 - accepted in `allow=` lists but not detected yet | (everything for now) |
 
-The Go VDSO caveat is load-bearing for most users: if every service in your stack is Go and you don't tolerate `clock`, strict mode will *under-report* clock drift, not over-report. That's the right side of the trade — false negatives are debt; false positives are noise. Document the limit in your spec comments.
+The Go VDSO caveat is load-bearing for most users: if every service in your stack is Go and you don't tolerate `clock`, strict mode will *under-report* clock drift, not over-report. That's the right side of the trade - false negatives are debt; false positives are noise. Document the limit in your spec comments.
 
-This VDSO blindness is resolved only at **Path C (Faultbox Sentry fork)** — see [RFC-046](../../rfcs/0046-beyond-l1-roadmap.md). Path B gVisor (v0.14.x) replaces the TCP proxy with gVisor netstack but does *not* run SUT code inside gVisor Sentry, so VDSO calls remain outside seccomp reach at v0.14.x.
+This VDSO blindness is resolved only at **Path C (Faultbox Sentry fork)** - see [RFC-046](../../rfcs/0046-beyond-l1-roadmap.md). Path B gVisor (v0.14.x) replaces the TCP proxy with gVisor netstack but does *not* run SUT code inside gVisor Sentry, so VDSO calls remain outside seccomp reach at v0.14.x.
 
 ## Worked example: a real flake
 
@@ -144,19 +144,19 @@ def test_request_id_in_response():
     assert_true("X-Request-ID" in resp.headers)
 ```
 
-Pre-v0.13.0 you'd see this fail intermittently in CI with no useful signal — the request ID is non-empty, but the test that *also* asserts it matches a regex pattern flakes when the random bytes contain unprintable characters.
+Pre-v0.13.0 you'd see this fail intermittently in CI with no useful signal - the request ID is non-empty, but the test that *also* asserts it matches a regex pattern flakes when the random bytes contain unprintable characters.
 
 With v0.13.0, the first run shows:
 
 ```
 test_request_id_in_response FAIL: strict determinism: unmediated_io[rand]
-  from service "api" (syscall=getrandom, pid=4242) — ...
+  from service "api" (syscall=getrandom, pid=4242) - ...
 ```
 
 You investigate. The request ID is fine for the test, but the unprintable-character check is brittle. You decide to:
 
 1. Fix the brittleness (assert on length, not pattern), and
-2. Accept the underlying randomness — it doesn't change behavior the test asserts on.
+2. Accept the underlying randomness - it doesn't change behavior the test asserts on.
 
 The final spec:
 
@@ -172,7 +172,7 @@ def test_request_id_in_response():
     assert_true(len(rid) >= 16, "request ID should be at least 16 chars")
 ```
 
-Strict mode is happy. The brittleness is gone. The PR review now has an explicit signal — `nondeterministic_ok = ["rand"]` — that says "we considered randomness here and decided it's fine." Future readers can challenge the decision; future tests can't accidentally inherit silent drift.
+Strict mode is happy. The brittleness is gone. The PR review now has an explicit signal - `nondeterministic_ok = ["rand"]` - that says "we considered randomness here and decided it's fine." Future readers can challenge the decision; future tests can't accidentally inherit silent drift.
 
 ## Exercises
 
@@ -182,4 +182,4 @@ Strict mode is happy. The brittleness is gone. The PR review now has an explicit
 
 3. **Read a strict-determinism bundle.** Run a strict-mode failure to completion, then `faultbox report <bundle.fb>`. Find the strict-determinism row in the manifest summary; click into the drill-down; identify the exact `unmediated_io` event in the swim-lane viewer.
 
-4. **Run with the CLI override.** Take a strict-spec test you know fails, run it with `--no-strict-determinism`, and observe the change in outcome. Convince yourself that the spec-level configuration didn't change — only the runtime decision did.
+4. **Run with the CLI override.** Take a strict-spec test you know fails, run it with `--no-strict-determinism`, and observe the change in outcome. Convince yourself that the spec-level configuration didn't change - only the runtime decision did.

--- a/docs/tutorial/04-safety/25-choose-and-assume.md
+++ b/docs/tutorial/04-safety/25-choose-and-assume.md
@@ -1,20 +1,20 @@
-# Chapter 25: Non-deterministic Operators — `choose`, `assume`, `halt`
+# Chapter 25: Non-deterministic Operators - `choose`, `assume`, `halt`
 
 **Duration:** 30 minutes
 **Prerequisites:** [Chapter 14 (Invariants & Safety Properties)](14-invariants.md) completed, RFC-043 operators landed in v0.13.0
 
 ## Goals & Purpose
 
-Chapter 14 taught you to write invariants that hold across every test. But you still wrote one test per scenario. When the scenario space is large — three retry strategies × four fault kinds × two timeout values — you'd write 24 separate tests and copy-paste the body across all of them.
+Chapter 14 taught you to write invariants that hold across every test. But you still wrote one test per scenario. When the scenario space is large - three retry strategies × four fault kinds × two timeout values - you'd write 24 separate tests and copy-paste the body across all of them.
 
 The four operators in this chapter let you describe the *space* of scenarios as one test, and Faultbox produces 24 leaves at run time. Each leaf is its own deterministic execution with a unique `LeafID` and full bundle attribution. The plan tree shows exactly what was explored.
 
 This chapter teaches you to:
-- **`choose("name", [opts])`** — declare a finite N-way axis the plan tree fans out over
-- **`assume(predicate)`** — filter the plan tree to only the leaves you care about
-- **`halt(reason)`** — prune the current branch from inside the body
-- **`nondet()`** — the non-deterministic boolean shorthand
-- **The discovery run** — why your body runs once "for free" before fan-out
+- **`choose("name", [opts])`** - declare a finite N-way axis the plan tree fans out over
+- **`assume(predicate)`** - filter the plan tree to only the leaves you care about
+- **`halt(reason)`** - prune the current branch from inside the body
+- **`nondet()`** - the non-deterministic boolean shorthand
+- **The discovery run** - why your body runs once "for free" before fan-out
 
 By the end you'll write one test that explores hundreds of scenarios without copy-paste.
 
@@ -22,9 +22,9 @@ By the end you'll write one test that explores hundreds of scenarios without cop
 
 You're testing a checkout service. Three things vary across your test matrix:
 
-- **`retries`** — how many times the client retries on failure (0, 1, 3)
-- **`fault`** — what the downstream returns (503, 504, timeout)
-- **`backoff_ms`** — the delay between retries (10ms, 100ms)
+- **`retries`** - how many times the client retries on failure (0, 1, 3)
+- **`fault`** - what the downstream returns (503, 504, timeout)
+- **`backoff_ms`** - the delay between retries (10ms, 100ms)
 
 In Chapter 14's style you'd write 3 × 3 × 2 = 18 tests. With RFC-043 operators you write one:
 
@@ -34,17 +34,17 @@ def test_checkout_robustness():
     fault    = choose("fault",   ["503", "504", "timeout"])
     backoff  = choose("backoff_ms", [10, 100])
 
-    # Some combinations don't make sense — retries=0 with timeout
+    # Some combinations don't make sense - retries=0 with timeout
     # is uninteresting because there's nothing to retry.
     if retries == 0 and fault == "timeout":
-        halt("nothing to retry — uninteresting branch")
+        halt("nothing to retry - uninteresting branch")
 
     api.checkout(retries=retries, expected_fault=fault, backoff_ms=backoff)
 ```
 
-That's 18 leaves minus the halted ones. Each leaf runs as its own test execution, gets its own bundle row, and shows up in the report with its axis values: `test_checkout_robustness [leaf 7 — retries=1, fault=2, backoff_ms=0]`.
+That's 18 leaves minus the halted ones. Each leaf runs as its own test execution, gets its own bundle row, and shows up in the report with its axis values: `test_checkout_robustness [leaf 7 - retries=1, fault=2, backoff_ms=0]`.
 
-## `choose("name", [opts])` — finite N-way axis
+## `choose("name", [opts])` - finite N-way axis
 
 `choose()` is a Starlark builtin that returns one of the options. The first argument is the axis name (visible in the report); the second is the option list. The plan walker fans the test out across every option.
 
@@ -55,15 +55,15 @@ def test_retries():
 ```
 
 Running this with `faultbox test spec.star` produces three leaves:
-- `test_retries [leaf 0 — retries=0]` — body sees `n == 0`
-- `test_retries [leaf 1 — retries=1]` — body sees `n == 1`
-- `test_retries [leaf 2 — retries=2]` — body sees `n == 3`
+- `test_retries [leaf 0 - retries=0]` - body sees `n == 0`
+- `test_retries [leaf 1 - retries=1]` - body sees `n == 1`
+- `test_retries [leaf 2 - retries=2]` - body sees `n == 3`
 
-> **Leaf-ID convention.** The display shows the *option index*, not the option *value*. For `choose("retries", [0, 1, 3])`, leaf 2 carries option index 2 — which decodes to the value 3. The full axis-value mapping is in the bundle's `plan.json`.
+> **Leaf-ID convention.** The display shows the *option index*, not the option *value*. For `choose("retries", [0, 1, 3])`, leaf 2 carries option index 2 - which decodes to the value 3. The full axis-value mapping is in the bundle's `plan.json`.
 
 ### Anonymous form
 
-`choose([opts])` without a name still returns the first option, but doesn't fan out — there's no key for the plan tree to address the axis by:
+`choose([opts])` without a name still returns the first option, but doesn't fan out - there's no key for the plan tree to address the axis by:
 
 ```python
 n = choose([10, 20, 30])    # always returns 10; no fan-out
@@ -83,9 +83,9 @@ def test_matrix():
     # 2 × 3 = 6 leaves
 ```
 
-Mix freely with the other rc2 axes (`probability=` on faults, `interleavings=` on `parallel()` — see Chapter 26): cardinality multiplies.
+Mix freely with the other rc2 axes (`probability=` on faults, `interleavings=` on `parallel()` - see Chapter 26): cardinality multiplies.
 
-## `assume(predicate)` — filter the plan tree
+## `assume(predicate)` - filter the plan tree
 
 Sometimes the cross-product contains leaves you don't want to run. The classic case: a configuration constraint that only makes sense for some axis combinations.
 
@@ -102,9 +102,9 @@ test("checkout",
 )
 ```
 
-The `assume=` kwarg on `test()` takes a list of predicates. Each predicate receives a `choices` dict mapping axis names to the leaf's selected option **value** (not the index — the dict carries what the body would observe from `choose()`, so a predicate that reads `choices["retries"]` against `choose("retries", [0, 1, 3])` sees one of `0`, `1`, `3` directly). Leaves where any predicate returns False are recorded as **halted** — they don't contribute to pass/fail.
+The `assume=` kwarg on `test()` takes a list of predicates. Each predicate receives a `choices` dict mapping axis names to the leaf's selected option **value** (not the index - the dict carries what the body would observe from `choose()`, so a predicate that reads `choices["retries"]` against `choose("retries", [0, 1, 3])` sees one of `0`, `1`, `3` directly). Leaves where any predicate returns False are recorded as **halted** - they don't contribute to pass/fail.
 
-> **Visibility:** Per-test `assume=` predicates evaluate at body entry. They see the leaf's axis assignment for any `choose()` call recorded during the discovery run (the first body execution; see below). Conditional choose() calls — axes that only appear in some branches — may not show up in `choices` for every leaf. Best practice: declare all axes unconditionally at the start of the body.
+> **Visibility:** Per-test `assume=` predicates evaluate at body entry. They see the leaf's axis assignment for any `choose()` call recorded during the discovery run (the first body execution; see below). Conditional choose() calls - axes that only appear in some branches - may not show up in `choices` for every leaf. Best practice: declare all axes unconditionally at the start of the body.
 
 ### Top-level `assume()`
 
@@ -125,11 +125,11 @@ Top-level `assume()` evaluates at spec load against the current axis snapshot. U
 
 ### Predicate sandbox
 
-`assume()` predicates are sandboxed at spec load: they can't call `fault()`, `service()`, `parallel()`, `halt()`, `eventually()`, `await_*`, or any other runtime-mutating builtin. The denylist mirrors RFC-041's monitor sandbox — predicates are pure functions of the `choices` argument.
+`assume()` predicates are sandboxed at spec load: they can't call `fault()`, `service()`, `parallel()`, `halt()`, `eventually()`, `await_*`, or any other runtime-mutating builtin. The denylist mirrors RFC-041's monitor sandbox - predicates are pure functions of the `choices` argument.
 
 Predicate Starlark errors (e.g. indexing a missing key) map to `Result="error"` (not `"fail"`), distinguishing spec-authoring bugs from actual SUT behavioral failures.
 
-## `halt(reason="")` — prune from inside the body
+## `halt(reason="")` - prune from inside the body
 
 `halt()` lets the body itself decide a leaf is uninteresting and prune it. Same effect as a false `assume()` predicate, but lives at the call site:
 
@@ -139,18 +139,18 @@ def test_checkout():
     fault    = choose("fault", ["503", "504", "timeout"])
 
     if retries == 0 and fault == "timeout":
-        halt("nothing to retry — uninteresting branch")
+        halt("nothing to retry - uninteresting branch")
 
     api.checkout(retries=retries, expected_fault=fault)
 ```
 
-The halted leaf is recorded with `Result="halted"` — counted separately from pass/fail/inconclusive in the suite summary. Halt is not a verdict; CI gates that ignore halted runs see a clean exit.
+The halted leaf is recorded with `Result="halted"` - counted separately from pass/fail/inconclusive in the suite summary. Halt is not a verdict; CI gates that ignore halted runs see a clean exit.
 
 ### Where halt is rejected
 
-- **Module top-level** — errors at spec load (`halt("…")` outside a function body).
-- **Inside `setup=`** — runtime error before the body runs.
-- **Inside a monitor `check=` / `update=` lambda** — produces an opaque "monitor violation: halt" message; use `assume()` to filter branches instead.
+- **Module top-level** - errors at spec load (`halt("…")` outside a function body).
+- **Inside `setup=`** - runtime error before the body runs.
+- **Inside a monitor `check=` / `update=` lambda** - produces an opaque "monitor violation: halt" message; use `assume()` to filter branches instead.
 
 ### halt() vs assume()
 
@@ -161,7 +161,7 @@ The halted leaf is recorded with `Result="halted"` — counted separately from p
 | Visibility | Can use any body-time state | Sees axis assignments only |
 | Use for | "This combo doesn't make sense given runtime state I just computed" | "This combo is structurally uninteresting" |
 
-## `nondet()` — non-deterministic boolean
+## `nondet()` - non-deterministic boolean
 
 `nondet()` is sugar for `choose([True, False])`. Like anonymous `choose()`, it doesn't fan out (no name), so it always returns `True`. Use the named form for fan-out:
 
@@ -176,7 +176,7 @@ api.run()
 
 ## The discovery run
 
-Faultbox can't enumerate leaves without knowing what axes exist. So it runs your body **once** in *discovery* mode — a synthetic "leaf 0" that records every `choose()` call but skips `assume=` evaluation (the choices dict is empty at this point — predicates indexing a body-time key would spuriously error).
+Faultbox can't enumerate leaves without knowing what axes exist. So it runs your body **once** in *discovery* mode - a synthetic "leaf 0" that records every `choose()` call but skips `assume=` evaluation (the choices dict is empty at this point - predicates indexing a body-time key would spuriously error).
 
 After discovery, the plan walker enumerates the real leaves and re-executes the body once per leaf with the explicit axis assignment pinned. Each re-execution sees the same `choose()` calls return their leaf-specific value.
 
@@ -184,15 +184,15 @@ What this means in practice:
 
 - **The body runs N+1 times for N leaves**, not N. Discovery is leaf 0's prep.
 - **`assume=` predicates fire only for the N real leaves**, not for discovery.
-- **Side effects in the body fire N+1 times.** If your body emits a side effect — writing to a Go-side counter, mutating a fixture — be aware. Faultbox state (services, faults, event log) resets between leaves so the body sees a fresh environment each time.
+- **Side effects in the body fire N+1 times.** If your body emits a side effect - writing to a Go-side counter, mutating a fixture - be aware. Faultbox state (services, faults, event log) resets between leaves so the body sees a fresh environment each time.
 
-## Putting it together — a real-world matrix
+## Putting it together - a real-world matrix
 
 ```python
 api = service("api", binary="./api", interface("http", "http", 8080))
 db  = service("db",  image="postgres:16-alpine")
 
-# Module-level axes — visible to assume= predicates.
+# Module-level axes - visible to assume= predicates.
 retries_axis = choose("retries", [0, 1, 3])
 fault_axis   = choose("fault",   ["503", "504", "timeout"])
 
@@ -211,7 +211,7 @@ test("checkout_matrix",
 
 Running this produces 3 × 3 = 9 leaves; the halted branch (`retries=0, fault="timeout"`) is recorded as halted and skipped. The remaining 8 leaves run as 8 separate test executions, each with its own bundle row and trace.
 
-The bundle's `plan.json` lists every axis and option set; the HTML report's tests table shows the per-leaf assignment in the row name. `faultbox plan spec.star` prints the tree without launching services — useful when you want to know "how many leaves will this produce?" before committing CI time.
+The bundle's `plan.json` lists every axis and option set; the HTML report's tests table shows the per-leaf assignment in the row name. `faultbox plan spec.star` prints the tree without launching services - useful when you want to know "how many leaves will this produce?" before committing CI time.
 
 ## Exercises
 

--- a/docs/tutorial/04-safety/26-plan-fanout.md
+++ b/docs/tutorial/04-safety/26-plan-fanout.md
@@ -1,4 +1,4 @@
-# Chapter 26: Plan-Tree Fan-Out — `faultbox plan`, probability, interleavings
+# Chapter 26: Plan-Tree Fan-Out - `faultbox plan`, probability, interleavings
 
 **Duration:** 30 minutes
 **Prerequisites:** [Chapter 25 (Non-deterministic Operators)](25-choose-and-assume.md) completed, [Chapter 5 (Exploring Concurrency)](../02-syscall-level/05-concurrency.md) reviewed
@@ -10,12 +10,12 @@ Chapter 25's `choose()` taught you to declare a finite axis the plan tree fans o
 The three axis kinds compose. A spec with two `choose()` axes, one probabilistic fault with `max_fires=3`, and one `parallel(interleavings="all")` with 3 branches produces `2 × 2 × 2³ × 3! = 192` leaves. Reading that number out of `faultbox plan` is cheaper than discovering it from a 20-minute CI run.
 
 This chapter teaches you to:
-- **Probability fan-out** — turn stochastic fault firing into exhaustive coverage
-- **Interleaving fan-out** — explore every branch ordering of `parallel()`
-- **`faultbox plan`** — preview the plan tree without launching services
-- **Reading the report** — find a specific leaf's trace in a bundle
+- **Probability fan-out** - turn stochastic fault firing into exhaustive coverage
+- **Interleaving fan-out** - explore every branch ordering of `parallel()`
+- **`faultbox plan`** - preview the plan tree without launching services
+- **Reading the report** - find a specific leaf's trace in a bundle
 
-## Probability fan-out — `max_fires` + `mode="exhaustive"`
+## Probability fan-out - `max_fires` + `mode="exhaustive"`
 
 Pre-rc2 Faultbox treated `probability=p` stochastically: at each trigger point the seeded RNG decided whether the rule fired this time. A single test run produced one realization. Reproducing a rare bug required hunting for the right seed.
 
@@ -49,18 +49,18 @@ Each leaf is a deterministic execution. The bundle records the per-occurrence ve
 | Combination | Behavior |
 |-------------|----------|
 | `probability=1.0` | Always fires. No fan-out. `max_fires=` rejected. |
-| `probability<1, max_fires=` unset | Stochastic — legacy RNG path. |
-| `probability<1, max_fires=N` | Exhaustive — `2^N` leaves with deterministic vector. Default mode. |
-| `probability<1, max_fires=N, mode="stochastic"` | Rejected at spec load — `max_fires=` is incompatible with stochastic. |
-| `probability<1, mode="exhaustive"` (no `max_fires`) | Rejected at spec load — would silently degrade to stochastic. |
+| `probability<1, max_fires=` unset | Stochastic - legacy RNG path. |
+| `probability<1, max_fires=N` | Exhaustive - `2^N` leaves with deterministic vector. Default mode. |
+| `probability<1, max_fires=N, mode="stochastic"` | Rejected at spec load - `max_fires=` is incompatible with stochastic. |
+| `probability<1, mode="exhaustive"` (no `max_fires`) | Rejected at spec load - would silently degrade to stochastic. |
 
 ### Bare `probability=p` is unaffected
 
-This is the migration story. Existing specs that use `probability=0.3` *without* `max_fires=` keep the stochastic RNG path verbatim — no behavior change, no surprise extra leaves in CI. Opting into exhaustive fan-out is an explicit `max_fires=N` add.
+This is the migration story. Existing specs that use `probability=0.3` *without* `max_fires=` keep the stochastic RNG path verbatim - no behavior change, no surprise extra leaves in CI. Opting into exhaustive fan-out is an explicit `max_fires=N` add.
 
 > **Scope note:** rc2 probability fan-out is syscall-level (`delay()` / `deny()`). Protocol-level (`response()` / `error()` / `drop()`) still uses the stochastic path; the `max_fires=` surface threads through `internal/proxy` in a follow-up.
 
-## Interleaving fan-out — `parallel(..., interleavings=)`
+## Interleaving fan-out - `parallel(..., interleavings=)`
 
 `parallel(fn1, fn2, …)` (Chapter 5) runs branches concurrently. rc2 adds an `interleavings=` kwarg that turns each ordering into a leaf:
 
@@ -77,14 +77,14 @@ Policies:
 
 | Value | Leaves produced |
 |-------|-----------------|
-| `1` (default) | One — runs once, branches concurrently as in rc1 |
-| `"all"` | `factorial(N)` — every distinct ordering |
-| `"critical"` | `min(2N-1, N!)` — head-to-head + sequential pairs heuristic |
-| Integer N | `min(N, factorial(branches))` — capped subset, first N in plan order |
+| `1` (default) | One - runs once, branches concurrently as in rc1 |
+| `"all"` | `factorial(N)` - every distinct ordering |
+| `"critical"` | `min(2N-1, N!)` - head-to-head + sequential pairs heuristic |
+| Integer N | `min(N, factorial(branches))` - capped subset, first N in plan order |
 
 For 3 branches with `"all"`, that's 3! = 6 leaves with launch orderings `[a,b,c]`, `[a,c,b]`, `[b,a,c]`, …
 
-### Reserved values — locked for future RFCs
+### Reserved values - locked for future RFCs
 
 ```python
 parallel(a, b, interleavings = "dpor")          # → spec-load error, RFC-009
@@ -95,9 +95,9 @@ These are explicit "future release" rejections so CI integrations gating on the 
 
 ### Scope limit (rc2)
 
-Today's interleaving is **launch ordering** — branches launch sequentially in the per-leaf order. Mediated-event-level interleaving (two branches running concurrently while the engine releases their syscalls in a specific sequence) is a follow-up. The kwarg surface and plan-tree leaf descriptors are in place for that work to plug into; specs you write today stay valid when the engine refines.
+Today's interleaving is **launch ordering** - branches launch sequentially in the per-leaf order. Mediated-event-level interleaving (two branches running concurrently while the engine releases their syscalls in a specific sequence) is a follow-up. The kwarg surface and plan-tree leaf descriptors are in place for that work to plug into; specs you write today stay valid when the engine refines.
 
-## `faultbox plan` — preview the cross-product
+## `faultbox plan` - preview the cross-product
 
 Before committing CI time to a test, ask Faultbox what it will run:
 
@@ -115,7 +115,7 @@ Plan tree:
 Totals: 37 instances
 ```
 
-The command runs *only* spec loading + static analysis — no services launched, no Docker pulls, no Lima VM start. Sub-100ms even for large specs.
+The command runs *only* spec loading + static analysis - no services launched, no Docker pulls, no Lima VM start. Sub-100ms even for large specs.
 
 ### `--check-cost --max-instances N`
 
@@ -145,9 +145,9 @@ $ faultbox plan checkout.star --format=json | jq '.totals.instances'
 
 The JSON schema is versioned (`schema_version: 1`); the same shape lives in every bundle's `plan.json` so tooling that reads one reads both.
 
-## Composition — the cross-product
+## Composition - the cross-product
 
-The three axis kinds — `choose`, probability, interleaving — multiply:
+The three axis kinds - `choose`, probability, interleaving - multiply:
 
 ```python
 def test_everything():
@@ -164,7 +164,7 @@ def test_everything():
 The plan walker enumerates the cross-product in mixed-radix order so leaf indices are stable across runs. The bundle's `plan.json` records every axis; the HTML report's tests table shows the per-leaf assignment in the row label:
 
 ```
-test_everything [leaf 17 — retries=2, parallel#3, wal[01]]
+test_everything [leaf 17 - retries=2, parallel#3, wal[01]]
 ```
 
 ## Reading a specific leaf's trace
@@ -172,10 +172,10 @@ test_everything [leaf 17 — retries=2, parallel#3, wal[01]]
 Each leaf gets its own trace event log. To find leaf 17's events:
 
 1. Open the HTML report (`faultbox report run.fb` produces `report.html`).
-2. The tests table shows every leaf as a separate row — sort/filter by name to find your test.
+2. The tests table shows every leaf as a separate row - sort/filter by name to find your test.
 3. Click the leaf row to open the drill-down: per-leaf trace, swim-lane visualization, replay command.
 
-For CLI inspection: `cat run.fb/manifest.json | jq '.tests[] | select(.leaf_id=="17")'` gets the row metadata; `faultbox replay run.fb --test test_everything --leaf 17` (when leaf-selection lands — currently leaves share the test name in `--test`) reruns that specific configuration.
+For CLI inspection: `cat run.fb/manifest.json | jq '.tests[] | select(.leaf_id=="17")'` gets the row metadata; `faultbox replay run.fb --test test_everything --leaf 17` (when leaf-selection lands - currently leaves share the test name in `--test`) reruns that specific configuration.
 
 ## When to use which axis kind
 
@@ -186,7 +186,7 @@ For CLI inspection: `cat run.fb/manifest.json | jq '.tests[] | select(.leaf_id==
 | Two independent operations that might arrive in any order | `parallel(a, b, interleavings="all")` |
 | Combination that doesn't make sense | `halt()` inside body, or `assume=` predicate |
 
-For test design: pick the smallest axis count that exercises the failure modes you care about. `choose("retries", [0, 1])` + `probability=0.3, max_fires=1` is usually more informative than `choose("retries", [0, 1, 2, 3, 4, 5])` — diminishing returns set in fast and the plan grows multiplicatively.
+For test design: pick the smallest axis count that exercises the failure modes you care about. `choose("retries", [0, 1])` + `probability=0.3, max_fires=1` is usually more informative than `choose("retries", [0, 1, 2, 3, 4, 5])` - diminishing returns set in fast and the plan grows multiplicatively.
 
 ## Exercises
 
@@ -194,10 +194,10 @@ For test design: pick the smallest axis count that exercises the failure modes y
 
 2. **Cost gate.** Add the `faultbox plan --check-cost --max-instances 50` invocation to your repo's pre-commit hook. Add an axis that pushes the count over 50 and confirm the hook blocks the commit.
 
-3. **Exhaustive WAL coverage.** Take an existing spec that uses `probability=0.3` on a WAL write. Add `max_fires=3, mode="exhaustive"` and observe the eight-leaf plan tree (2³) in `faultbox plan`. Find the leaf where every WAL write fired — what does the trace look like compared to the all-passed leaf?
+3. **Exhaustive WAL coverage.** Take an existing spec that uses `probability=0.3` on a WAL write. Add `max_fires=3, mode="exhaustive"` and observe the eight-leaf plan tree (2³) in `faultbox plan`. Find the leaf where every WAL write fired - what does the trace look like compared to the all-passed leaf?
 
 4. **Interleaving identity.** Compare `parallel(a, b, interleavings=1)` and `parallel(a, b, interleavings="all")` plans. The first should produce 1 leaf, the second 2. Verify with `faultbox plan`.
 
 ## What's next
 
-You've reached the end of Part 4. The full v0.13.0 verification toolkit is at your disposal: invariants (Ch 14), monitors (Ch 15), partitions (Ch 16), determinism (Ch 24), operators (Ch 25), and plan-tree fan-out (this chapter). Part 5 covers advanced operational features — containers, scenario generation, event sources, and LLM agent integration.
+You've reached the end of Part 5. The full verification toolkit is at your disposal: invariants (Ch 14), monitors (Ch 15), partitions (Ch 16), scenarios & the fault matrix (Ch 10), determinism (Ch 24), operators (Ch 25), and plan-tree fan-out (this chapter). Part 6 covers the power tools - event sources, named operations, LLM agents, bundles, and reports.

--- a/docs/tutorial/05-advanced/09-containers.md
+++ b/docs/tutorial/05-advanced/09-containers.md
@@ -1,12 +1,12 @@
-# Chapter 9: Containers — Real Infrastructure
+# Chapter 9: Containers - Real Infrastructure
 
 **Duration:** 30 minutes
 **Prerequisites:** [Chapter 0 (Setup)](../00-prelude/00-setup.md) completed, Docker running
 
 ## Goals & Purpose
 
-Chapters 1-6 used mock binaries — lightweight, fast, controllable. But in
-production, your services talk to Postgres, Redis, Kafka, Elasticsearch —
+Chapters 1-6 used mock binaries - lightweight, fast, controllable. But in
+production, your services talk to Postgres, Redis, Kafka, Elasticsearch -
 real infrastructure with real complexity.
 
 The question is: **does your error handling work against real Postgres, or
@@ -16,17 +16,17 @@ management, and its own error handling. The failure modes are different.
 
 Faultbox solves this by running real Docker containers with the same seccomp
 fault injection used for binaries. The same `fault_assumption()` and
-`fault_scenario()` API, the same assertions, the same trace output — but
+`fault_scenario()` API, the same assertions, the same trace output - but
 now against real infrastructure.
 
 This chapter teaches you to:
 - **Orchestrate Docker containers** with Faultbox (instead of docker-compose)
-- **Inject faults into real databases** — Postgres, Redis
-- **Understand container networking** — how services find each other
-- **Use per-service filtering** — only intercept syscalls on faulted services
+- **Inject faults into real databases** - Postgres, Redis
+- **Understand container networking** - how services find each other
+- **Use per-service filtering** - only intercept syscalls on faulted services
 
 After this chapter, you'll be able to answer: "what happens to my API when
-Postgres has a disk I/O error?" — tested against real Postgres, not a mock.
+Postgres has a disk I/O error?" - tested against real Postgres, not a mock.
 
 ## How container mode works
 
@@ -49,7 +49,7 @@ A tiny shim binary is injected into the container. It installs the seccomp
 filter, sends the listener fd to the host via a Unix domain socket
 (SCM_RIGHTS), then exec's the original entrypoint. This works with
 multi-process containers (Kafka, shell chains) because the fd is acquired
-before exec — no PID tracking or `CAP_SYS_PTRACE` needed.
+before exec - no PID tracking or `CAP_SYS_PTRACE` needed.
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ docker version                  # verify Docker is available
 Instead of a binary path, use `image=` or `build=`:
 
 ```python
-# Pull from registry — no Dockerfile needed
+# Pull from registry - no Dockerfile needed
 postgres = service("postgres",
     interface("main", "tcp", 5432),
     image = "postgres:16-alpine",
@@ -96,7 +96,7 @@ api = service("api",
 )
 ```
 
-Three service sources — exactly one required:
+Three service sources - exactly one required:
 
 | Parameter | When to use |
 |-----------|-------------|
@@ -201,7 +201,7 @@ The diagnostic output shows the expansion:
 ```
 
 **Note:** Postgres uses `pwrite64` for data pages, not `write`. The syscall
-family expansion handles this automatically — you write `write=deny(...)` and
+family expansion handles this automatically - you write `write=deny(...)` and
 it covers all write variants.
 
 ## Per-service filtering
@@ -260,7 +260,7 @@ def reset_db():
 
 Without reuse: 11 tests × 20s = 220s. With reuse: 20s + 11 × 0.5s = **25s**.
 
-> Seed and reset do more than speed things up — they are how a real
+> Seed and reset do more than speed things up - they are how a real
 > service gets its schema, migrations, and fixtures in place at all.
 > The full decision table (init scripts vs migrations vs fixtures vs
 > mock state) is in [Seeding Data & Initial State](../../guides/seeding-data.md).
@@ -277,24 +277,24 @@ Without reuse: 11 tests × 20s = 220s. With reuse: 20s + 11 × 0.5s = **25s**.
 - `reuse=True` with `seed`/`reset` cuts multi-test execution time by 5-10x
 - Requires Linux + Docker
 
-**The key takeaway:** you can now test your actual production dependencies —
+**The key takeaway:** you can now test your actual production dependencies -
 not mocks. "What happens when Postgres runs out of disk?" is tested against
 real Postgres.
 
 ## What's next
 
 You can test real infrastructure. But writing failure tests by hand is
-slow — Chapter 10 shows how to auto-generate them.
+slow - Chapter 10 shows how to auto-generate them.
 
 **Continue:**
-- [Chapter 10: Scenarios & Generation](10-scenarios.md) — register
+- [Chapter 10: Scenarios & Generation](10-scenarios.md) - register
   happy paths with `scenario()`, auto-generate fault mutations
-- [Chapter 11: Event Sources & Observability](11-event-sources.md) — capture
+- [Chapter 11: Event Sources & Observability](11-event-sources.md) - capture
   stdout, WAL changes, Kafka messages as trace events
 
 **Reference:**
-- [Spec Language Reference](../../spec-language.md) — complete API
-- [CLI Reference](../../cli-reference.md) — all commands and flags
+- [Spec Language Reference](../../spec-language.md) - complete API
+- [CLI Reference](../../cli-reference.md) - all commands and flags
 - Explore the `demo/faultbox.star` for a complete working example
 
 ## Exercises
@@ -314,5 +314,5 @@ slow — Chapter 10 shows how to auto-generate them.
 4. **Graceful degradation**: The demo API connects to Redis but doesn't use it
    yet. Imagine it cached values in Redis. Write a `fault_assumption` that
    faults Redis (`connect=deny("ECONNREFUSED")`) and a `fault_scenario` that
-   expects the API still works via Postgres. This tests graceful degradation —
+   expects the API still works via Postgres. This tests graceful degradation -
    a key production resilience pattern.

--- a/docs/tutorial/05-advanced/09-containers.md
+++ b/docs/tutorial/05-advanced/09-containers.md
@@ -283,14 +283,12 @@ real Postgres.
 
 ## What's next
 
-You can test real infrastructure. But writing failure tests by hand is
-slow - Chapter 10 shows how to auto-generate them.
+You can now run your service against real infrastructure. Part 5 turns to
+the question that makes all of this pay off: what must ALWAYS hold, no
+matter which fault fires?
 
-**Continue:**
-- [Chapter 10: Scenarios & Generation](10-scenarios.md) - register
-  happy paths with `scenario()`, auto-generate fault mutations
-- [Chapter 11: Event Sources & Observability](11-event-sources.md) - capture
-  stdout, WAL changes, Kafka messages as trace events
+**Continue:** [Chapter 14: Invariants & Safety Properties](../04-safety/14-invariants.md) -
+the properties your system must never violate, under every fault in the matrix.
 
 **Reference:**
 - [Spec Language Reference](../../spec-language.md) - complete API

--- a/docs/tutorial/05-advanced/10-scenarios.md
+++ b/docs/tutorial/05-advanced/10-scenarios.md
@@ -7,24 +7,24 @@
 ## Goals & Purpose
 
 [Chapter 6](../02-syscall-level/06-domain-model.md) introduced the domain-centric
-model — separating scenarios, fault assumptions, and oracles into three
+model - separating scenarios, fault assumptions, and oracles into three
 independent layers. This chapter builds on that with `faultbox generate`:
 automatic failure discovery that outputs the domain-centric format.
 
 **The question:** "Have I tested every way this system can break?"
 
 This chapter teaches you to:
-- **Register scenario probes** — describe what the system does
-- **Auto-generate fault assumptions** — let Faultbox propose failure modes
-- **Review and curate** — add overrides with expected behavior
-- **Organize specs across files** — use `load()` for clean separation
+- **Register scenario probes** - describe what the system does
+- **Auto-generate fault assumptions** - let Faultbox propose failure modes
+- **Review and curate** - add overrides with expected behavior
+- **Organize specs across files** - use `load()` for clean separation
 
 After this chapter, your workflow becomes: write the happy path once,
 generate all failures automatically, review, commit.
 
 ## The `scenario()` builtin
 
-A scenario is a **probe** — a function that exercises the system and returns
+A scenario is a **probe** - a function that exercises the system and returns
 an observable result. Register it with `scenario()`:
 
 ```python
@@ -56,7 +56,7 @@ Save this as `scenario-test.star`.
 
 `scenario(order_flow)` does two things:
 1. **Registers** the function for the failure generator and fault composition
-2. **Runs it as a test** — equivalent to naming it `test_order_flow`
+2. **Runs it as a test** - equivalent to naming it `test_order_flow`
 
 The return value is captured and available for use with `fault_scenario(expect=)`
 and `fault_matrix(overrides=)`. See the "Fault Composition" section below.
@@ -152,8 +152,8 @@ def test_order_flow_db_partition():
 
 **What happened:** the generator created named `fault_assumption()` for each
 fault mode and composed them into a `fault_matrix()`. Each assumption is
-reusable — you can reference `db_down` in custom `fault_scenario()` calls.
-No invented API calls, no guessed assertions — your exact happy path under
+reusable - you can reference `db_down` in custom `fault_scenario()` calls.
+No invented API calls, no guessed assertions - your exact happy path under
 different failure conditions.
 
 ## Running generated tests
@@ -183,10 +183,10 @@ Result: 6/6 passed
 
 How to read the results:
 
-- **PASS** — the scenario completed without crashing under this fault.
+- **PASS** - the scenario completed without crashing under this fault.
   Since no `expect` was set, "pass" just means "didn't crash". Add
   `overrides=` to `fault_matrix()` to specify expected behavior per cell.
-- **FAIL** — the scenario crashed or timed out under this fault.
+- **FAIL** - the scenario crashed or timed out under this fault.
   This is a **discovered failure mode** worth investigating.
 
 To add expected behavior, edit the generated file and add overrides:
@@ -237,7 +237,7 @@ fault_scenario("order_custom_failure",
 )
 ```
 
-## Dry run — preview without generating
+## Dry run - preview without generating
 
 **Linux:**
 ```bash
@@ -257,7 +257,7 @@ make lima-run CMD="faultbox generate scenario-test.star --dry-run"
 
 ## Multiple scenarios
 
-Register as many scenarios as you want — each gets its own `.faults.star`:
+Register as many scenarios as you want - each gets its own `.faults.star`:
 
 ```python
 def order_flow():
@@ -279,7 +279,7 @@ faultbox generate scenario-test.star
 # → health_check.faults.star
 ```
 
-## Fault composition — writing tests by hand
+## Fault composition - writing tests by hand
 
 Auto-generation is great for discovery, but real tests need specific
 expectations. That's what `fault_assumption()`, `fault_scenario()`,
@@ -302,7 +302,7 @@ disk_full = fault_assumption("disk_full",
 )
 ```
 
-### Fault scenarios — one scenario, one fault, one oracle
+### Fault scenarios - one scenario, one fault, one oracle
 
 ```python
 fault_scenario("order_db_down",
@@ -315,7 +315,7 @@ fault_scenario("order_db_down",
 This registers `test_order_db_down`. The `expect` callback receives the
 scenario's return value and validates it with assertions.
 
-### Fault matrix — the cross-product
+### Fault matrix - the cross-product
 
 Instead of writing N×M tests by hand:
 
@@ -334,7 +334,7 @@ fault_matrix(
 
 ### Monitors on fault assumptions
 
-Attach invariants to fault assumptions — they fire automatically in every
+Attach invariants to fault assumptions - they fire automatically in every
 test that uses the assumption:
 
 ```python
@@ -356,7 +356,7 @@ gets `no_db_traffic` automatically.
 ## The workflow
 
 ```
-1. Write scenario() probes — describe how things work, return results
+1. Write scenario() probes - describe how things work, return results
 2. faultbox generate → creates <scenario>.faults.star with fault_matrix()
 3. faultbox test *.faults.star → discover failures
 4. Add overrides= with expected behavior per (scenario, fault) cell
@@ -367,7 +367,7 @@ gets `no_db_traffic` automatically.
 
 ## What you learned
 
-- `scenario(fn)` registers a probe — runs as test + available for composition
+- `scenario(fn)` registers a probe - runs as test + available for composition
 - `faultbox generate` creates `fault_assumption()` + `fault_matrix()` per scenario
 - `fault_assumption()` names and reuses fault configurations
 - `fault_scenario()` composes probe + fault + expect oracle
@@ -378,5 +378,6 @@ gets `no_db_traffic` automatically.
 ## What's next
 
 You've automated failure discovery and structured fault composition.
-Chapter 11 introduces **event sources** — capturing structured stdout,
-database WAL changes, and message queue events as first-class trace data.
+[Chapter 24](../04-safety/24-determinism.md) pins down the determinism
+contract behind all of it - what L0/L1 guarantee, and how unmediated
+I/O is detected and reported.

--- a/docs/tutorial/05-advanced/10-scenarios.md
+++ b/docs/tutorial/05-advanced/10-scenarios.md
@@ -9,6 +9,16 @@
 [Chapter 6](../02-syscall-level/06-domain-model.md) introduced the domain-centric
 model - separating scenarios, fault assumptions, and oracles into three
 independent layers. This chapter builds on that with `faultbox generate`:
+
+> **Deprecation note (v0.13.0).** `faultbox generate` still works in
+> v0.13.x but is deprecated and will be removed in v0.14.0 (RFC-044).
+> The modern equivalent is `faultbox plan --suggest` - the same
+> topology-driven analysis through the plan-tree pipeline, printing
+> copy-pasteable stubs for uncovered edges instead of writing files
+> (see [Chapter 26](../04-safety/26-plan-fanout.md)). Everything this
+> chapter teaches about scenarios, fault assumptions, and the fault
+> matrix is unchanged - only the generation command is moving.
+
 automatic failure discovery that outputs the domain-centric format.
 
 **The question:** "Have I tested every way this system can break?"
@@ -369,6 +379,7 @@ gets `no_db_traffic` automatically.
 
 - `scenario(fn)` registers a probe - runs as test + available for composition
 - `faultbox generate` creates `fault_assumption()` + `fault_matrix()` per scenario
+- `faultbox generate` is deprecated: `faultbox plan --suggest` is the forward path
 - `fault_assumption()` names and reuses fault configurations
 - `fault_scenario()` composes probe + fault + expect oracle
 - `fault_matrix()` generates the cross-product of scenarios × faults

--- a/docs/tutorial/05-advanced/13-llm-mcp.md
+++ b/docs/tutorial/05-advanced/13-llm-mcp.md
@@ -10,7 +10,7 @@ title: "Chapter 13: LLM Agents & MCP Integration"
 ## Goals & Purpose
 
 Faultbox is designed for two types of users: **human engineers** and
-**LLM agents**. Both write specs, run tests, and fix code — but LLM agents
+**LLM agents**. Both write specs, run tests, and fix code - but LLM agents
 need structured output and tool integration instead of human-readable text.
 
 This chapter teaches you to:
@@ -45,7 +45,7 @@ available immediately.
 
 ## Custom slash commands
 
-### `/fault-test` — Run tests
+### `/fault-test` - Run tests
 
 Type `/fault-test` in Claude Code. It finds your `.star` spec, runs all
 tests with `--format json`, and reports:
@@ -53,14 +53,14 @@ tests with `--format json`, and reports:
 - Failure reasons with replay commands
 - Diagnostics with fix suggestions
 
-### `/fault-generate` — Generate specs
+### `/fault-generate` - Generate specs
 
 Type `/fault-generate`. It detects your project setup:
 - Has `docker-compose.yml`? Generates spec from compose
 - Has a Go/Node/Python service? Generates a starter spec
 - Has an existing spec? Runs `faultbox generate` for failure scenarios
 
-### `/fault-diagnose` — Analyze failures
+### `/fault-diagnose` - Analyze failures
 
 Type `/fault-diagnose` after a test failure. It reads the JSON output,
 finds the relevant source code, and suggests specific fixes based on
@@ -68,7 +68,7 @@ the diagnostic codes:
 
 | Diagnostic | What it means |
 |-----------|---------------|
-| `FAULT_FIRED_BUT_SUCCESS` | Fault hit but service didn't return error — missing error handling |
+| `FAULT_FIRED_BUT_SUCCESS` | Fault hit but service didn't return error - missing error handling |
 | `FAULT_NOT_FIRED` | Wrong syscall variant or path filter |
 | `SERVICE_CRASHED` | Unhandled error caused panic |
 | `TIMEOUT_DURING_FAULT` | Possible infinite retry loop |
@@ -253,8 +253,9 @@ For editors other than Claude Code, configure the MCP server manually.
 
 ## What's next
 
-You've completed the Faultbox tutorial. You now know how to:
+You've covered the core of the Faultbox tutorial. You now know how to:
 - Inject syscall-level and protocol-level faults
+- Mock the dependencies you can't run
 - Write temporal assertions on internal behavior
 - Explore concurrent interleavings
 - Monitor invariants across all tests
@@ -262,8 +263,12 @@ You've completed the Faultbox tutorial. You now know how to:
 - Generate failure scenarios automatically
 - Integrate with LLM agents for automated testing
 
+**Remaining chapters:** [.fb Bundles](20-bundles.md), the
+[end-to-end Go microservice walkthrough](22-go-microservice-end-to-end.md),
+and [Reading Reports](23-reports.md).
+
 **Next steps:**
 - Add Faultbox to your CI pipeline
 - Write scenario() functions for your critical paths
-- Run `faultbox generate` to discover untested failure modes
+- Run `faultbox plan --suggest` to discover untested failure modes
 - Use `/fault-diagnose` to fix issues found by the generator

--- a/docs/tutorial/05-advanced/21-jwt-mocks.md
+++ b/docs/tutorial/05-advanced/21-jwt-mocks.md
@@ -1,4 +1,4 @@
-# Chapter 21: JWT/JWKS Mocks — Stub Auth-Protected Services
+# Chapter 21: JWT/JWKS Mocks - Stub Auth-Protected Services
 
 **Duration:** 12 minutes
 **Prerequisites:** [Chapter 17 (Mock Services)](17-mock-services.md), familiarity with JWT bearer tokens
@@ -10,7 +10,7 @@ problem when it lands on a fault-injection harness: **the SUT verifies
 JWT signatures against a JWKS endpoint that doesn't exist in the test
 environment.** Customers reaching for Faultbox ended up writing their
 own `jwtgen` Go tool, building a separate HTTP service, threading
-private keys around — same shape every time.
+private keys around - same shape every time.
 
 `@faultbox/mocks/jwt.star` (shipped in v0.9.9) collapses all of that
 to one constructor. It auto-generates an Ed25519 keypair at spec-load
@@ -23,7 +23,7 @@ This chapter teaches you to:
 - **Stand up a JWKS-publishing mock** with one Starlark call.
 - **Mint tokens** in the test driver and pass them as
   `Authorization: Bearer …`.
-- **Compose with other Faultbox primitives** — fault the JWKS
+- **Compose with other Faultbox primitives** - fault the JWKS
   endpoint to test client-side caching, or run JWT-protected requests
   through the data-path proxy from RFC-024.
 
@@ -51,7 +51,7 @@ api = service("api", "/tmp/your-app",
 Two things are different from a plain `mock_service`:
 
 - `auth` is a **struct**, not a `ServiceDef`. The actual service is
-  at `auth.service` — that's what you pass to `depends_on=` and use
+  at `auth.service` - that's what you pass to `depends_on=` and use
   for env wiring.
 - The struct also carries `auth.sign(claims=…)` and `auth.jwks` so
   your tests can mint tokens and (if needed) inspect the published
@@ -68,7 +68,7 @@ for:
 | `GET /.well-known/jwks.json` | JWKS document with the published Ed25519 public key |
 | `GET /jwks` | Alias for clients that hit a non-standard path |
 
-The discovery doc points `jwks_uri` at the issuer string you passed —
+The discovery doc points `jwks_uri` at the issuer string you passed -
 **make sure that URL resolves to the mock from inside the SUT**. In
 binary mode, `auth.service.main.addr` is `localhost:8090`. In
 container mode, the proxy data-path (RFC-024) points the SUT at
@@ -96,11 +96,11 @@ def test_authorised_request():
 Notes on claims:
 
 - **All fields pass through verbatim.** `iat`, `exp`, `aud`, `iss` are
-  yours to set — the mock doesn't auto-populate timestamps so spec
+  yours to set - the mock doesn't auto-populate timestamps so spec
   authors stay in control of token expiry semantics.
 - **Common claim names:** `sub` (subject), `iat`/`exp` (Unix
   timestamps), `aud` (audience), `iss` (issuer URL). Check what your
-  app's middleware actually validates — the inDrive PoC lost hours
+  app's middleware actually validates - the inDrive PoC lost hours
   to a `user_id` vs `uid` claim-name mismatch (FB §2.1 #2).
 
 ## 4 · Test rejection paths
@@ -133,7 +133,7 @@ fail to verify the signature, and 401.
 
 ## 5 · Compose with faults
 
-Now the interesting part — combine JWT mocks with the rest of the
+Now the interesting part - combine JWT mocks with the rest of the
 Faultbox toolkit.
 
 ### Fault the JWKS endpoint
@@ -161,7 +161,7 @@ def test_jwks_outage_uses_cache():
               ).status_code == 200))
 ```
 
-### Slow JWKS — exercise client timeouts
+### Slow JWKS - exercise client timeouts
 
 ```python
 def test_slow_jwks_breaks_login():
@@ -180,7 +180,7 @@ def test_slow_jwks_breaks_login():
 `jwt.server()` is **EdDSA only** (Ed25519). Modern OIDC issuers
 (Auth0, Okta, Keycloak with EdDSA enabled) and well-maintained
 in-house auth services accept this. Older RSA/HS256-only stacks
-need a different mock — file an issue if you hit one.
+need a different mock - file an issue if you hit one.
 
 Other things v0.9.9 deliberately doesn't ship:
 
@@ -189,7 +189,7 @@ Other things v0.9.9 deliberately doesn't ship:
   for separate issuers.
 - **Token introspection endpoints** (`/introspect`). If your SUT
   uses opaque tokens with introspection, `jwt.server` doesn't help
-  — use `mock_service` directly with custom routes.
+  - use `mock_service` directly with custom routes.
 
 ## Takeaways
 
@@ -198,7 +198,9 @@ Other things v0.9.9 deliberately doesn't ship:
 - `auth.sign(claims = {…})` mints tokens the SUT verifies via the
   published JWKS.
 - The mock composes with `fault()`, `depends_on=`, and the data-path
-  proxy — fault the JWKS endpoint to exercise client-side caching;
+  proxy - fault the JWKS endpoint to exercise client-side caching;
   delay it to exercise client-side timeouts.
 
-Next: [Chapter 22 — Reading Faultbox Reports →](22-reports.md) (v0.11.0)
+You've completed Part 3 - every kind of dependency you can't run now has
+a faultable stand-in. Next, the dependencies you *can* run:
+[Part 4 - Chapter 7: HTTP Protocol Faults](../03-protocol-level/07-http-redis.md).

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,6 +1,6 @@
 # Faultbox Tutorial
 
-Learn fault injection for distributed systems — from your first syscall
+Learn fault injection for distributed systems - from your first syscall
 fault to protocol-level proxy injection. Each chapter introduces one
 concept, explains *why* it matters, and builds on the previous.
 
@@ -38,7 +38,7 @@ make lima-create && make lima-build                 # macOS (one-time)
 | 1 | [Your First Fault](01-first-taste/01-first-fault.md) | 15 min |
 | 2 | [Writing Your First Test](01-first-taste/02-first-test.md) | 20 min |
 
-## Part 2: Syscall-Level Fault Injection
+## Part 2: Faults, Traces & Domains
 
 | # | Chapter | Duration |
 |---|---------|----------|
@@ -47,35 +47,51 @@ make lima-create && make lima-build                 # macOS (one-time)
 | 5 | [Exploring Concurrency](02-syscall-level/05-concurrency.md) | 25 min |
 | 6 | [From Tests to Domains](02-syscall-level/06-domain-model.md) | 20 min |
 
-## Part 3: Protocol-Level Fault Injection
+## Part 3: Simulate the Boundary
+
+Mock the dependencies you can't run - the fastest path to testing a
+real service whose dependencies belong to other teams.
+
+| # | Chapter | Duration |
+|---|---------|----------|
+| 17 | [Mock Services](05-advanced/17-mock-services.md) | 25 min |
+| 18 | [Typed gRPC Mocks](05-advanced/18-typed-grpc-mocks.md) | 20 min |
+| 19 | [OpenAPI Mocks](05-advanced/19-openapi-mocks.md) | 20 min |
+| 21 | [JWT/JWKS Mocks](05-advanced/21-jwt-mocks.md) | 15 min |
+
+## Part 4: Real Infrastructure
 
 | # | Chapter | Duration |
 |---|---------|----------|
 | 7 | [HTTP Protocol Faults](03-protocol-level/07-http-redis.md) | 25 min |
 | 8 | [Database & Broker Faults](03-protocol-level/08-databases.md) | 25 min |
+| 9 | [Containers](05-advanced/09-containers.md) | 30 min |
 
-## Part 4: Safety & Verification
+## Part 5: Safety & Verification
 
 | # | Chapter | Duration |
 |---|---------|----------|
 | 14 | [Invariants & Safety Properties](04-safety/14-invariants.md) | 30 min |
 | 15 | [Monitors & Temporal Properties](04-safety/15-monitors.md) | 30 min |
 | 16 | [Network Partitions](04-safety/16-partitions.md) | 20 min |
+| 10 | [Scenarios & Fault Matrix](05-advanced/10-scenarios.md) | 20 min |
 | 24 | [Determinism & the L1 Contract](04-safety/24-determinism.md) | 25 min |
-| 25 | [Non-deterministic Operators — `choose`, `assume`, `halt`](04-safety/25-choose-and-assume.md) | 30 min |
-| 26 | [Plan-Tree Fan-Out — `faultbox plan`, probability, interleavings](04-safety/26-plan-fanout.md) | 30 min |
+| 25 | [Non-deterministic Operators - `choose`, `assume`, `halt`](04-safety/25-choose-and-assume.md) | 30 min |
+| 26 | [Plan-Tree Fan-Out - `faultbox plan`, probability, interleavings](04-safety/26-plan-fanout.md) | 30 min |
 
-## Part 5: Advanced Features
+## Part 6: Power Tools
 
 | # | Chapter | Duration |
 |---|---------|----------|
-| 9 | [Containers](05-advanced/09-containers.md) | 30 min |
-| 10 | [Scenarios & Generation](05-advanced/10-scenarios.md) | 20 min |
 | 11 | [Event Sources & Observability](05-advanced/11-event-sources.md) | 25 min |
 | 12 | [Named Operations](05-advanced/12-named-ops.md) | 15 min |
 | 13 | [LLM Agents & MCP](05-advanced/13-llm-mcp.md) | 15 min |
-| 17 | [Mock Services](05-advanced/17-mock-services.md) | 25 min |
-| 18 | [Typed gRPC Mocks](05-advanced/18-typed-grpc-mocks.md) | 20 min |
+| 20 | [.fb Bundles](05-advanced/20-bundles.md) | 20 min |
+| 22 | [End-to-End Go Microservice](05-advanced/22-go-microservice-end-to-end.md) | 40 min |
+| 23 | [Reading Reports](05-advanced/23-reports.md) | 20 min |
+
+> Chapter numbers reflect the order chapters were written, not the
+> reading order - follow the parts top to bottom.
 
 ---
 

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -3,20 +3,26 @@
 Real-world scenarios showing how different engineering roles use Faultbox
 from day one.
 
+## Incidents
+
+| Story | Bug classes closed |
+|-------|--------------------|
+| [How a Checkout Survives a Kafka Outage](checkout-kafka-outage.md) | Unhandled dependency failure, missing timeout, failed recovery |
+
 ## Personas
 
 | Role | Story | Key Value |
 |------|-------|-----------|
-| [Backend Engineer](backend-engineer.md) | Proves DB retry logic doesn't double-charge | Deepest value — WAL assertions, concurrency exploration |
-| [QA Engineer](qa-engineer.md) | Tests 47 failure modes against existing containers | Fastest adopter — no code changes, just specs |
-| [Mobile Engineer](mobile-engineer.md) | Discovers BFF response shapes under partial failure | Contract testing — verifies backend promises |
+| [Backend Engineer](backend-engineer.md) | Proves DB retry logic doesn't double-charge | Deepest value - WAL assertions, concurrency exploration |
+| [QA Engineer](qa-engineer.md) | Tests 47 failure modes against existing containers | Fastest adopter - no code changes, just specs |
+| [Mobile Engineer](mobile-engineer.md) | Discovers BFF response shapes under partial failure | Contract testing - verifies backend promises |
 
 ## Common Pattern
 
 All three stories share the same arc:
 
-1. **Start from a real incident** — double-charge, Black Friday outage, infinite loading
-2. **Write a spec in minutes** — not days of infrastructure setup
-3. **Test existing code** — no mocks, no code changes, real containers
-4. **Get proof, not hope** — the assertion passes or shows exactly why it failed
-5. **Add to CI** — never regress
+1. **Start from a real incident** - double-charge, Black Friday outage, infinite loading
+2. **Write a spec in minutes** - not days of infrastructure setup
+3. **Test existing code** - no mocks, no code changes, real containers
+4. **Get proof, not hope** - the assertion passes or shows exactly why it failed
+5. **Add to CI** - never regress

--- a/docs/use-cases/backend-engineer.md
+++ b/docs/use-cases/backend-engineer.md
@@ -5,7 +5,7 @@
 ## The Problem
 
 Anna owns an order service that talks to Postgres, Redis, and a payment
-gateway. Last month, a 30-second Postgres failover caused double-charges —
+gateway. Last month, a 30-second Postgres failover caused double-charges -
 the retry logic didn't check idempotency keys.
 
 The team added a fix, but nobody could prove it worked. The only way to test
@@ -36,7 +36,7 @@ def test_payment_retry_on_db_failure():
     # First payment succeeds.
     api.post(path="/payments", body='{"amount": 100, "idempotency_key": "abc"}')
 
-    # DB fails — retry with same idempotency key.
+    # DB fails - retry with same idempotency key.
     def db_dies():
         resp = api.post(path="/payments", body='{"amount": 100, "idempotency_key": "abc"}')
         assert_eq(resp.status, 200)  # retry should succeed
@@ -49,20 +49,20 @@ def test_payment_retry_on_db_failure():
 
 ## What She Gets
 
-Proof that the double-charge bug is fixed. She adds this to CI — it runs on
+Proof that the double-charge bug is fixed. She adds this to CI - it runs on
 every PR. The next Postgres failover is a non-event.
 
 ## Growth Path
 
-- **Week 2:** Adds `--explore=all` for concurrent payment tests — two
+- **Week 2:** Adds `--explore=all` for concurrent payment tests - two
   payments for the same order arriving simultaneously.
 - **Month 2:** Uses `observe=[wal_stream(...)]` to monitor Postgres WAL
   events and verify transaction isolation.
 - **Month 3:** Builds a full failure matrix: Postgres down, Redis down,
-  payment gateway timeout, disk full — each is a test case in CI.
+  payment gateway timeout, disk full - each is a test case in CI.
 
 ## Key Value
 
 Anna gets **proof, not hope**. The assertion either passes or shows her
-exactly what went wrong — with syscall traces, ShiViz diagrams, and
+exactly what went wrong - with syscall traces, ShiViz diagrams, and
 replay seeds for deterministic reproduction.

--- a/docs/use-cases/checkout-kafka-outage.md
+++ b/docs/use-cases/checkout-kafka-outage.md
@@ -1,0 +1,122 @@
+# Use Case: How a Checkout Survives a Kafka Outage
+
+**Shape:** worked example - an order service, a Postgres it owns, and a
+Kafka it publishes to. Three bug classes closed in one spec: unhandled
+dependency failure, missing timeout, failed recovery.
+
+This is the incident every event-driven checkout has either had or is
+about to have: the broker goes away for five minutes, and the
+interesting question is not "did requests fail?" but "did money and
+state stay consistent, and did the system actually come back?"
+
+## The topology
+
+```python
+db = service("db", image = "postgres:16-alpine",
+    interface("main", "postgres", 5432),
+    volumes = {"./schema.sql": "/docker-entrypoint-initdb.d/schema.sql"},
+    reuse   = True,
+    reset   = lambda: db.main.exec(sql = "TRUNCATE orders RESTART IDENTITY CASCADE"),
+)
+
+kafka = service("kafka", image = "bitnami/kafka:3.7",
+    interface("main", "kafka", 9092),
+)
+
+api = service("api", image = "myteam/checkout-api",
+    interface("public", "http", 8080),
+    env = {"DB_ADDR": db.main.addr, "KAFKA_ADDR": kafka.main.addr},
+    depends_on = [db, kafka],
+    healthcheck = http("localhost:8080/health"),
+)
+```
+
+Only `myteam/checkout-api` is yours. Postgres and Kafka are stock
+images - and if you can't run a real Kafka in CI, the same spec works
+against a mock broker.
+
+## Class 1: the broker is gone
+
+What should checkout do when Kafka is down - fail the purchase, or
+accept it and publish later? Whatever your answer is, write it down:
+
+```python
+kafka_down = fault_assumption("kafka_down",
+    target  = kafka,
+    connect = deny("ECONNREFUSED"),
+)
+
+fault_scenario("checkout_broker_down",
+    scenario = place_order,
+    faults   = kafka_down,
+    expect   = lambda r: (
+        assert_eq(r.status, 201, "checkout must accept the order"),
+        assert_eq(r.json["fulfillment"], "deferred"),
+    ),
+)
+```
+
+The wrong answers this catches: a 500 to the customer because the
+producer constructor panicked, or - worse - a 201 with the order row
+written and the event silently dropped on the floor.
+
+## Class 2: the broker is slow, not down
+
+Slow is more dangerous than down: nothing errors, everything queues.
+
+```python
+kafka_slow = fault_assumption("kafka_slow",
+    target = kafka.main,
+    rules  = [delay(topic = "orders", delay = "2s")],
+)
+
+fault_scenario("checkout_broker_slow",
+    scenario = place_order,
+    faults   = kafka_slow,
+    expect   = lambda r: (
+        assert_eq(r.status, 201),
+        assert_lt(r.elapsed, "500ms",
+            "publish must be async or deadlined - checkout latency must not track broker latency"),
+    ),
+)
+```
+
+## Class 5: the broker comes back - does the system?
+
+The least-tested transition in production systems. The fault clears;
+the deferred events must actually flow.
+
+```python
+def test_broker_recovery(t):
+    with fault(kafka, connect = deny("ECONNREFUSED")):
+        api.public.post(path = "/orders", body = '{"cart": 42}')
+    # fault cleared - recovery is now the thing under test:
+    eventually(lambda trace: trace.event(type = "kafka_publish", topic = "orders"),
+               within = "30s")
+```
+
+If the producer is stuck on a dead connection pool, this test renders
+FAIL - not a silent green, and not a pass that quietly never checked
+anything: if the run ends before the evidence arrives, the verdict is
+INCONCLUSIVE.
+
+## The invariant that ties it together
+
+Orders and events must reconcile no matter which fault fired:
+
+```python
+def no_lost_orders(trace):
+    placed    = trace.count(match.event(type = "order_created"))
+    published = trace.count(match.event(type = "kafka_publish", topic = "orders"))
+    return published >= placed  # deferred is fine; lost is not
+
+always(no_lost_orders)
+```
+
+## What this buys you
+
+Three specs and one invariant close the three ways this outage hurts:
+the customer-facing failure, the latency coupling, and the silent
+non-recovery. Total spec size: under 80 lines. The `.fb` bundle from a
+failing run attaches to the incident ticket and replays the exact fault
+schedule that produced it.

--- a/docs/use-cases/gamedev.md
+++ b/docs/use-cases/gamedev.md
@@ -1,9 +1,9 @@
-# Gamedev — multiplayer backends, anti-cheat, MMORPG live ops
+# Gamedev - multiplayer backends, anti-cheat, MMORPG live ops
 
 A multiplayer game is one of the most asymmetric distributed systems in the
 industry. The hot path runs at 30-60Hz over custom UDP. Around it sits a
-backend zoo — matchmaker, auth, leaderboards, persistent world, anti-cheat,
-player store, social, telemetry — every one of which can ruin a session if it
+backend zoo - matchmaker, auth, leaderboards, persistent world, anti-cheat,
+player store, social, telemetry - every one of which can ruin a session if it
 misbehaves. Engineers running these backends need to know what happens when
 the matchmaker gets slow, when the anti-cheat backend disappears mid-match,
 when Postgres drops a write at the moment a raid loot drops.
@@ -31,22 +31,22 @@ and message queues, which is exactly what Faultbox already faults.
   03:14 last Tuesday."
 - **Matchmaker degradation** under load isn't itself a Faultbox question
   (load testers handle that), but matchmaker behaviour when its *upstream*
-  player-rating service is slow is — and that's where the real outages
+  player-rating service is slow is - and that's where the real outages
   start.
 
 ## How Faultbox helps
 
 | Need | Primitive | Read |
 |---|---|---|
-| Real cluster pods (k8s) without distributing dep images | `service(remote=...)` | [Spec language — Remote Services](/docs/reference/spec-language#remote-services) |
+| Real cluster pods (k8s) without distributing dep images | `service(remote=...)` | [Spec language - Remote Services](/docs/reference/spec-language#remote-services) |
 | Anti-cheat / store / billing HTTPS upstream faults | `tls=tls_cert(...)` + `error()` on the interface | [TLS upstreams](/docs/guides/connectivity#tls-upstreams-rfc-038) |
-| Network partitions across game-server replicas | `partition()` | [Tutorial 16 — Partitions](/docs/tutorial/04-safety/16-partitions) |
-| Persistent-world write failures (`EIO`, `ENOSPC`, partial) | syscall `write=deny()` / `pwrite=delay()` | [Tutorial 03 — Fault injection](/docs/tutorial/02-syscall-level/03-fault-injection) |
-| Auth / JWKS mocks for offline tests | `@faultbox/mocks/jwt.star` | [Tutorial 21 — JWT mocks](/docs/tutorial/05-advanced/21-jwt-mocks) |
-| Reproduce production incidents from any machine | `.fb` bundles + `faultbox replay` | [Tutorial 20 — Bundles](/docs/tutorial/05-advanced/20-bundles) |
-| Verify retry / circuit-breaker / timeout code fires | `assert_eventually()` / `assert_never()` | [Tutorial 14 — Invariants](/docs/tutorial/04-safety/14-invariants) |
+| Network partitions across game-server replicas | `partition()` | [Tutorial 16 - Partitions](/docs/tutorial/04-safety/16-partitions) |
+| Persistent-world write failures (`EIO`, `ENOSPC`, partial) | syscall `write=deny()` / `pwrite=delay()` | [Tutorial 03 - Fault injection](/docs/tutorial/02-syscall-level/03-fault-injection) |
+| Auth / JWKS mocks for offline tests | `@faultbox/mocks/jwt.star` | [Tutorial 21 - JWT mocks](/docs/tutorial/05-advanced/21-jwt-mocks) |
+| Reproduce production incidents from any machine | `.fb` bundles + `faultbox replay` | [Tutorial 20 - Bundles](/docs/tutorial/05-advanced/20-bundles) |
+| Verify retry / circuit-breaker / timeout code fires | `assert_eventually()` / `assert_never()` | [Tutorial 14 - Invariants](/docs/tutorial/04-safety/14-invariants) |
 
-## A real scenario — anti-cheat fail-open under unreachable telemetry
+## A real scenario - anti-cheat fail-open under unreachable telemetry
 
 The single most security-critical decision in a multiplayer-game backend:
 what happens when the anti-cheat vendor's telemetry endpoint is unreachable?
@@ -168,25 +168,25 @@ artifact instead of a stack trace screenshot.
 
 ## More scenarios this shape covers
 
-- **Cross-shard trade rollback** — `partition()` between two `game-server`
+- **Cross-shard trade rollback** - `partition()` between two `game-server`
   containers, inject `error()` on the trade-completion gRPC mid-flight,
   assert both sides agree on the rollback state.
-- **Save-game write failures** — `write=deny("ENOSPC")` on the persistence
+- **Save-game write failures** - `write=deny("ENOSPC")` on the persistence
   service during a raid completion, verify the loot ends up in the correct
   state (granted-and-recovered, not lost-and-charged).
-- **JWKS rotation** — swap the JWT mock's signing key during a scenario,
+- **JWKS rotation** - swap the JWT mock's signing key during a scenario,
   verify the SUT picks up the new public key on the next request and
   doesn't return cached 403s.
-- **Matchmaker degraded upstream** — slow the player-rating service by 2s,
+- **Matchmaker degraded upstream** - slow the player-rating service by 2s,
   verify matchmaker either times out gracefully or falls back to an open
   rating bracket. (Pure HTTP+DB, no gaming-specific primitives.)
-- **Anti-cheat full outage drill** — combine `anti_cheat_unreachable` with
+- **Anti-cheat full outage drill** - combine `anti_cheat_unreachable` with
   `db.write=deny()` to test the worst-case path: anti-cheat down AND the
   audit event can't be persisted. What does the game do?
 
 ## Read next
 
-- [Tutorial — Containers and real services](/docs/tutorial/05-advanced/09-containers) — the Docker-mode mechanics behind `image=`
-- [Tutorial — Mock services](/docs/tutorial/05-advanced/17-mock-services) — for the auth-stub / leaderboard-stub patterns
-- [Tutorial — End-to-end Go microservice](/docs/tutorial/05-advanced/22-go-microservice-end-to-end) — the closest existing tutorial to a full game-backend shape
-- [Spec language reference](/docs/reference/spec-language) — every primitive in one page
+- [Tutorial - Containers and real services](/docs/tutorial/05-advanced/09-containers) - the Docker-mode mechanics behind `image=`
+- [Tutorial - Mock services](/docs/tutorial/05-advanced/17-mock-services) - for the auth-stub / leaderboard-stub patterns
+- [Tutorial - End-to-end Go microservice](/docs/tutorial/05-advanced/22-go-microservice-end-to-end) - the closest existing tutorial to a full game-backend shape
+- [Spec language reference](/docs/reference/spec-language) - every primitive in one page

--- a/docs/use-cases/mobile-engineer.md
+++ b/docs/use-cases/mobile-engineer.md
@@ -5,7 +5,7 @@
 ## The Problem
 
 Priya's app talks to a BFF (backend-for-frontend) that aggregates data
-from 3 microservices. Users report "infinite loading" when on bad network —
+from 3 microservices. Users report "infinite loading" when on bad network -
 the app doesn't handle partial API failures because nobody documented what
 the BFF returns when a downstream service is down.
 
@@ -14,7 +14,7 @@ exact JSON shape to build the right loading states.
 
 ## Day 1 with Faultbox
 
-Priya doesn't test the app directly — she tests the BFF's behavior under
+Priya doesn't test the app directly - she tests the BFF's behavior under
 failure so she knows what responses to expect:
 
 ```python
@@ -67,24 +67,24 @@ def test_all_services_down():
 
 ## What She Gets
 
-A contract for how the BFF behaves under failure — she knows exactly what
+A contract for how the BFF behaves under failure - she knows exactly what
 JSON shape her app will receive when services are degraded. She codes the
 iOS loading states to match.
 
 ## Growth Path
 
-- **Week 1:** Adds tests for every "infinite loading" user report — each
+- **Week 1:** Adds tests for every "infinite loading" user report - each
   becomes a Faultbox spec that reproduces the exact failure mode.
 - **Week 2:** Backend team fixes the BFF based on her specs. Faultbox
   verifies each fix.
 - **Month 1:** Uses `print(resp.data)` during development to discover
   response shapes, then turns discoveries into assertions.
-- **Month 2:** Shares specs with the Android team — same failure contracts,
+- **Month 2:** Shares specs with the Android team - same failure contracts,
   same expectations.
 
 ## Key Value
 
-Priya uses Faultbox as a **contract testing tool** — she doesn't test her
+Priya uses Faultbox as a **contract testing tool** - she doesn't test her
 app, she tests the backend's promises. When the BFF says "we handle partial
 failures gracefully," she has specs that prove it. The "infinite loading"
 reports stop.

--- a/docs/use-cases/qa-engineer.md
+++ b/docs/use-cases/qa-engineer.md
@@ -13,7 +13,7 @@ claim under realistic failure conditions.
 
 ## Day 1 with Faultbox
 
-Marcus doesn't write Go — he writes Starlark specs that exercise existing
+Marcus doesn't write Go - he writes Starlark specs that exercise existing
 Docker images without any code changes:
 
 ```python
@@ -36,7 +36,7 @@ search = service("search",
 )
 
 def test_checkout_when_redis_down():
-    """Cart still works if Redis cache is gone — falls back to Postgres."""
+    """Cart still works if Redis cache is gone - falls back to Postgres."""
     api.post(path="/cart/add", body='{"sku": "TSHIRT", "qty": 1}')
 
     def redis_dies():
@@ -64,7 +64,7 @@ def test_full_disk_error_message():
 
 ## What He Gets
 
-Failure mode coverage for Black Friday scenarios. No code changes needed —
+Failure mode coverage for Black Friday scenarios. No code changes needed -
 he tests existing containers as-is. He adds 15 failure scenarios in a week.
 
 ## Growth Path
@@ -74,11 +74,11 @@ he tests existing containers as-is. He adds 15 failure scenarios in a week.
 - **Week 2:** Adds `--runs 100` nightly runs to catch intermittent failures
   under different interleavings.
 - **Month 1:** When a test fails, he files a ticket with the ShiViz trace
-  attached — engineers see exactly what happened without reproducing.
+  attached - engineers see exactly what happened without reproducing.
 - **Month 2:** Builds a dashboard of failure mode coverage per service.
 
 ## Key Value
 
-Marcus is the **fastest adopter** — he doesn't need to change code, just
+Marcus is the **fastest adopter** - he doesn't need to change code, just
 write specs against existing images. He turns "we think we handle errors"
 into "we verified we handle these 47 failure modes."

--- a/poc/example/showcase.star
+++ b/poc/example/showcase.star
@@ -1,0 +1,53 @@
+# showcase.star - the spec behind the site's sample report
+# (faultbox-site/public/sample-report.html). Regenerate with:
+#
+#   faultbox test showcase.star        # in the Lima VM, binaries in /tmp
+#   faultbox report <bundle.fb> -o ../../../faultbox-site/public/sample-report.html
+#
+# The suite deliberately encodes a requirement mock-api does not meet -
+# "reads must survive a cache outage" - so the report showcases a real
+# found bug: expected 200, got a raw 500.
+
+cache = service("cache",
+    "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    env = {"PORT": "5432"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api",
+    "/tmp/mock-api",
+    interface("public", "http", 8080),
+    env = {"PORT": "8080", "DB_ADDR": cache.main.addr},
+    depends_on = [cache],
+    healthcheck = http("localhost:8080/health"),
+)
+
+def test_happy_path():
+    """Write and read through the API - everything healthy."""
+    resp = api.post(path="/data/greeting", body="hello")
+    assert_eq(resp.status, 200)
+
+    resp = api.get(path="/data/greeting")
+    assert_eq(resp.status, 200)
+    assert_eq(resp.body, "hello")
+
+def test_slow_cache_within_deadline():
+    """Cache 300ms slower - requests must still complete fine."""
+    def scenario():
+        resp = api.post(path="/data/slowkey", body="v")
+        assert_eq(resp.status, 200)
+        assert_true(resp.duration_ms > 250, "expected the delay to be visible")
+
+    fault(cache, write=delay("300ms"), run=scenario)
+
+def test_reads_survive_cache_outage():
+    """A cache outage must not take reads down with it."""
+    api.post(path="/data/greeting", body="hello")  # warm the key
+
+    def scenario():
+        resp = api.get(path="/data/greeting")
+        assert_eq(resp.status, 200,
+            "reads must survive a cache outage - degrade, don't 500")
+
+    fault(api, connect=deny("ECONNREFUSED"), run=scenario)


### PR DESCRIPTION
Library-side half of the site repositioning (sells bug classes closed, not technology):

- Tutorial Part 1 reframed: OSDI'14 bug-class hook in ch1; ch2 names the boundary pattern and surfaces .fb bundle + faultbox report in the first session.
- Tutorial reading order restructured into 6 parts (README): mocks as Part 3 "Simulate the Boundary", real infra as Part 4, scenarios+determinism chapters folded into Part 5, power tools as Part 6. What's-next transitions updated in ch 6, 8, 9, 10, 13, 16, 21, 26.
- choosing-fault-levels guide flipped: bug-class -> level mapping first.
- Chapter 10: faultbox generate deprecation callout (plan --suggest forward path).
- poc/example/showcase.star: the spec behind the site's sample report (real found bug: 500 != 200 under cache outage).
- Em-dashes replaced with hyphens in touched files.

Mirrors the faultbox-site branch of the same name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)