### PR TITLE
feat: v0.14.1 — searching fault timing, and fixing what that exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,38 @@ Next-version work is tracked in
 - Data race in `netfault`'s test `fakeClock`: the defer-queue goroutine called
   `Stop()` while the test goroutine read `stopped` under the clock mutex. It
   did not fire during the v0.14.0 release gate and did fire here.
+- **`faultbox plan` was blind to `choose()`**, the construct most likely to
+  blow a budget. The runtime discovers axes by *executing* a test body once;
+  `plan` is static and executes nothing, so every `choose()`-driven test counted
+  as a single instance — the exploration spec that runs 24 leaves reported
+  `Total: 2 plan instances`. `--check-cost --max-instances N` exists to catch
+  fan-out blowups before they run and was under-reporting by 12×, which is
+  worse than having no gate, because a gate is trusted. Axes are now read
+  statically from the spec AST and multiplied into `Instances`, and the tree
+  shows where the cost comes from:
+
+  ```
+  ├── test "test_transfer_timing"  [def]
+  │   ├── 18 instances
+  │   └── choose
+  │       ├── warmup: [0, 10, 40]
+  │       ├── gap: [0ms, 400ms, 1200ms]
+  │       └── hold: [100ms, 900ms]
+  ```
+
+  Where an option list is computed rather than literal, its size is not
+  knowable without running the spec. That axis is reported as
+  `(computed — size unknown)` and the total becomes `at least N` — an estimate
+  that admits its gaps, rather than one that quietly rounds down. A `choose()`
+  reached through a helper function is likewise not attributed to the calling
+  test: static analysis cannot resolve the call graph, and inventing axes would
+  be worse than missing them.
+- **Inconclusive verdicts now print their reason.** `TestResult.Reason` has
+  always carried the explanation — `test timeout: body did not complete within
+  3m0.1s` — and the summary discarded it, leaving a bare `12 inconclusive`.
+  Diagnosing one such run took 36 minutes of log archaeology to establish that
+  every leaf had blocked in the same `await_stable`; the answer was in the
+  struct the whole time. Identical reasons are grouped with a count.
 
 ## [0.14.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,35 @@ Next-version work is tracked in
   `parallel()` branch) and is rejected inside `monitor()` / `assume()`
   predicates like the `await_*` family.
 
+### Fixed
+- **The packet gateway's TUN device no longer bricks a host when a run is
+  interrupted.** The device was the shared constant `faultbox0` and it is
+  *persistent* — it survives the process. Two consequences, both live in
+  v0.14.0: concurrent runs on one machine collided, and any run that died
+  without teardown left a device that failed **every later packet-fault run**
+  with `TUNSETIFF faultbox0: device or resource busy`, recoverable only by
+  `sudo ip link delete faultbox0`, documented nowhere. Three layers now:
+  devices are named per-process (`fbox<pid>`), so a leak is clutter rather than
+  an outage; `SIGTERM` is handled alongside `SIGINT` (`timeout`, CI runners and
+  Docker all send SIGTERM — the most common way to stop a run was the one that
+  leaked); and every run sweeps orphaned `fbox<pid>` devices whose owning
+  process is gone, which is what recovers a machine after a `SIGKILL` no signal
+  handler can catch. Devices owned by live processes are never touched.
+  New [troubleshooting §13](docs/troubleshooting.md).
+- **An interrupted suite no longer invents verdicts for tests it never ran.**
+  `RunAll` had no cancellation check anywhere in its loop, so Ctrl-C cancelled
+  the context and the walk continued: each remaining test started its services,
+  inherited an already-dead context, failed instantly, and was recorded as
+  INCONCLUSIVE. An 18-leaf search interrupted after one leaf reported
+  `1 passed, 17 inconclusive`. It now stops and says what did not happen —
+  `2 passed, 0 failed, 1 inconclusive, 15 not run (interrupted)` — with the new
+  `SuiteResult.Aborted` counter kept **distinct** from `Inconclusive`, since
+  "the test was indeterminate" and "the test never started" call for different
+  responses.
+- Data race in `netfault`'s test `fakeClock`: the defer-queue goroutine called
+  `Stop()` while the test goroutine read `stopped` under the clock mutex. It
+  did not fire during the v0.14.0 release gate and did fire here.
+
 ## [0.14.0] - 2026-07-28
 
 Packet-level network faults. Faultbox mediated at two layers — individual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+### Added
+- **`sleep(duration, clock="wall")`** — a wall-clock wait that is indifferent
+  to event traffic. Faultbox had two ways to wait and both were conditional on
+  the SUT: `await_stable()` returns on quiescence, `await_event()` on a
+  matching event. Neither can hold a fault open for a fixed time, and
+  `await_stable` fails at it in exactly the situation the wait is for — **an
+  active fault emits the events that prevent quiescence.** Measured on a 3-node
+  `hashicorp/raft` cluster under partition: 6681 events in three minutes,
+  longest quiet gap 338 ms, so every window above ~340 ms blocked until the
+  per-test deadline and reported INCONCLUSIVE. A fault-timing search that
+  should have run 18 configurations ran 6 and hung on 12, spending 36 minutes
+  to produce no signal; with `sleep()` the same search runs all 18 in about two
+  minutes. See
+  [the experiment](docs/design/2026-07-28-timing-exploration-experiment.md).
+
+  `sleep("0ms")` is a no-op rather than an error — deliberately unlike
+  `await_stable`, whose window must be positive — because the primary use is as
+  a `choose()` axis and "no delay" is that axis's natural baseline. A sleep
+  longer than the test's remaining budget is refused up front, naming both
+  numbers, instead of running into the deadline and reporting a bare timeout.
+  It emits no event (a supervisor-side wait is not something the SUT did, and
+  emitting one would reset the quiescence timer of an `await_stable` in a
+  `parallel()` branch) and is rejected inside `monitor()` / `assume()`
+  predicates like the `await_*` family.
+
 ## [0.14.0] - 2026-07-28
 
 Packet-level network faults. Faultbox mediated at two layers — individual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,42 @@ Next-version work is tracked in
   `parallel()` branch) and is rejected inside `monitor()` / `assume()`
   predicates like the `await_*` family.
 
+- **`bandwidth(rate, dir="both", queue="250ms")` and `mtu(size)`** — the two
+  link shapers deferred from v0.14.0. They take no matcher: a `packet_*` rule
+  says what happens to packets that look like a certain way, a shaper says what
+  kind of link this is.
+
+  `rate` accepts bit units (`"1mbit"`, `"512kbps"`) or byte units, which must
+  say so explicitly (`"2MB/s"`). A bare `"1000000"` is **rejected** — it could
+  be bits or bytes, and guessing would be a silent factor-of-eight error in the
+  one number the fault depends on. `queue=` bounds the backlog in *time*, so
+  the shaper drops when saturated the way a real bottleneck does; a rate
+  limiter with an unbounded queue is a memory leak with latency, and the sender
+  never observes the congestion a congestion-control bug needs to surface.
+
+  `mtu()` overrides the link MTU, so netstack advertises a smaller TCP MSS and
+  fragments — a real small-MTU path. v0.14.0 had to approximate this with
+  `packet_drop(len_gt=576)`, which drops oversized packets: that looks like a
+  black hole and behaves like nothing real. Sizes below the IPv4 minimum of 68
+  are rejected.
+
+  Both are gateway-wide (one TUN link, one NIC — a per-target knob would be one
+  that lies), both are cleared at test end, and both **error** on
+  `runtime="default"` rather than silently no-opping. Each run records what the
+  shaper did — `bandwidth_stats dir=c2s admitted=76 dropped=0
+  peak_backlog=38ms` — so "the link was configured slow" can be distinguished
+  from "the link was the bottleneck".
+
 ### Fixed
+- **`packet_delay(dir="s2c")` was a silent drop, not a delay.** Egress builds a
+  batch list, hands `release` a closure that appends to it, writes the batch
+  when the loop ends and frees it on return — so a packet released *later*, by
+  the defer queue's timer, was appended to a list nobody would ever write.
+  `packet_reorder` on egress had the same fate, and bandwidth pacing would have
+  inherited it. Both existing delay tests drove the ingress path, where release
+  goes straight to the dispatcher, so nothing caught it. A fault that silently
+  becomes a *different* fault is the exact failure this release line exists to
+  prevent. Late releases now take a direct path to the wire.
 - **The packet gateway's TUN device no longer bricks a host when a run is
   interrupted.** The device was the shared constant `faultbox0` and it is
   *persistent* — it survives the process. Two consequences, both live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+## [0.14.1] - 2026-07-29
+
+Searching fault *timing*, and fixing what that search exposed.
+
+v0.14.0 shipped packet faults and a Raft harness that could express a partition
+but not vary **when** it lands. Closing that gap took one new primitive — and
+turned up four defects, one of them a documented fault that silently did
+something else. So this release is one feature, one deferral delivered, and a
+set of corrections that matter more than either.
+
 ### Added
 - **`sleep(duration, clock="wall")`** — a wall-clock wait that is indifferent
   to event traffic. Faultbox had two ways to wait and both were conditional on

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -18,6 +18,10 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	// SIGTERM as well as SIGINT: `timeout`, most CI runners, and Docker all
+	// send SIGTERM, and v0.14.0 handled only SIGINT — so the common way to
+	// stop a run was also the one that leaked the TUN device.
+	"syscall"
 	"time"
 
 	faultbox "github.com/faultbox/Faultbox"
@@ -154,7 +158,7 @@ doneFlags:
 	logger := logging.New(logging.Config{Format: logFormat, Level: logLevel})
 	eng := engine.New(logger)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	ctx = logging.NewContext(ctx, logger)
 
@@ -178,8 +182,9 @@ doneFlags:
 }
 
 // testCmd handles:
-//   faultbox test faultbox.star [--test name] [--output results.json]
-//   faultbox test --config faultbox.yaml --spec spec.yaml [--output results.json]
+//
+//	faultbox test faultbox.star [--test name] [--output results.json]
+//	faultbox test --config faultbox.yaml --spec spec.yaml [--output results.json]
 func testCmd(args []string) int {
 	logFormat := logging.FormatAuto
 	logLevel := slog.LevelInfo
@@ -372,6 +377,11 @@ func testCmd(args []string) int {
 func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, normalizePath, formatFlag string, logFormat logging.Format, logLevel slog.Level, dryRun bool, bundlePath string, noBundle, noPlan bool) int {
 	logger := logging.New(logging.Config{Format: logFormat, Level: logLevel})
 	rt := star.New(logger)
+	// The packet gateway's TUN device is persistent: it survives the process
+	// unless something removes it. Every return path from here — a spec that
+	// fails to load, a suite error, a signal — must go through teardown, or
+	// the host is left with an orphan.
+	defer rt.Close()
 
 	// When --format json, redirect service stdout to stderr to keep stdout clean.
 	if formatFlag == "json" {
@@ -408,7 +418,7 @@ func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, n
 		return 0
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	// RFC-042 §8.7 — enumerate the plan tree BEFORE RunAll so plan.json
@@ -511,6 +521,12 @@ func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, n
 	}
 	if result.Halted > 0 {
 		summary += fmt.Sprintf(", %d halted", result.Halted)
+	}
+	if result.Aborted > 0 {
+		// Say "not run", never fold these into inconclusive. A summary that
+		// reports verdicts for tests an interrupt prevented from starting
+		// overstates what the run measured.
+		summary += fmt.Sprintf(", %d not run (interrupted)", result.Aborted)
 	}
 	fmt.Fprintln(os.Stderr, summary)
 
@@ -981,7 +997,7 @@ func testYAMLCmd(configPath, specPath, outputPath string, logFormat logging.Form
 	logger := logging.New(logging.Config{Format: logFormat, Level: logLevel})
 	eng := engine.New(logger)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	ctx = logging.NewContext(ctx, logger)
 
@@ -1069,7 +1085,6 @@ func initCmd(args []string) int {
 			return initClaude()
 		}
 	}
-
 
 	name := "myapp"
 	port := "8080"
@@ -2445,9 +2460,10 @@ func faultboxVersion() string {
 }
 
 // inspectCmd handles: `faultbox inspect <bundle.fb>`
-//   faultbox inspect run.fb                    # summary + file list
-//   faultbox inspect run.fb <path-in-archive>  # dump one file to stdout
-//   faultbox inspect run.fb --extract <dir>    # extract all to dir
+//
+//	faultbox inspect run.fb                    # summary + file list
+//	faultbox inspect run.fb <path-in-archive>  # dump one file to stdout
+//	faultbox inspect run.fb --extract <dir>    # extract all to dir
 //
 // Implements RFC-025 Phase 2. Version mismatches between the producer
 // and this binary are surfaced as warnings; inspect never refuses on

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -529,6 +529,7 @@ func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, n
 		summary += fmt.Sprintf(", %d not run (interrupted)", result.Aborted)
 	}
 	fmt.Fprintln(os.Stderr, summary)
+	printInconclusiveReasons(os.Stderr, result)
 
 	// Terminal replay hint per failed test (RFC-025 §Observability).
 	// Makes `replay_command` visible without digging into JSON. Skipped
@@ -580,6 +581,51 @@ func testStarCmd(starFile string, rcfg star.RunConfig, outputPath, shivizPath, n
 		return 3
 	}
 	return 0
+}
+
+// printInconclusiveReasons explains every INCONCLUSIVE verdict under the
+// summary line.
+//
+// TestResult.Reason has always carried the explanation — "test timeout: body
+// did not complete within 3m0.1s" — and the summary has always thrown it away,
+// printing a bare "12 inconclusive". Diagnosing one such run took 36 minutes of
+// manual log archaeology to establish that every leaf had blocked in the same
+// await_stable; the answer was already in the struct.
+//
+// Reasons are grouped, because a fan-out that fails the same way 12 times
+// should say so once with a count rather than scroll the real signal off the
+// screen.
+func printInconclusiveReasons(w io.Writer, result *star.SuiteResult) {
+	if result == nil || result.Inconclusive == 0 {
+		return
+	}
+	counts := make(map[string]int)
+	var order []string
+	for i := range result.Tests {
+		tr := &result.Tests[i]
+		if tr.Result != "inconclusive" {
+			continue
+		}
+		reason := tr.Reason
+		if reason == "" {
+			reason = "(no reason recorded)"
+		}
+		if _, seen := counts[reason]; !seen {
+			order = append(order, reason)
+		}
+		counts[reason]++
+	}
+	if len(order) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\ninconclusive:")
+	for _, reason := range order {
+		if n := counts[reason]; n > 1 {
+			fmt.Fprintf(w, "  %s (x%d)\n", reason, n)
+			continue
+		}
+		fmt.Fprintf(w, "  %s\n", reason)
+	}
 }
 
 // printMultiRunSummary prints compact output for multi-run mode.

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -53,7 +53,7 @@ func main() {
 }
 
 // version is set via -ldflags at build time.
-var version = "0.14.0"
+var version = "0.14.1"
 
 func run() int {
 	args := os.Args[1:]

--- a/cmd/faultbox/plan.go
+++ b/cmd/faultbox/plan.go
@@ -140,8 +140,12 @@ func planCmd(args []string) int {
 	// exceeds the user's budget, so CI pre-commit hooks can fail loudly
 	// before launching a multi-hour run.
 	if checkCost && maxInstances >= 0 && pt.Totals.Instances > maxInstances {
-		fmt.Fprintf(os.Stderr, "\ncost gate: plan has %d instances; --max-instances=%d exceeded\n",
-			pt.Totals.Instances, maxInstances)
+		atLeast := ""
+		if pt.Totals.Estimated {
+			atLeast = "at least "
+		}
+		fmt.Fprintf(os.Stderr, "\ncost gate: plan has %s%d instances; --max-instances=%d exceeded\n",
+			atLeast, pt.Totals.Instances, maxInstances)
 		return 2
 	}
 	return 0
@@ -205,7 +209,16 @@ func renderPlanText(w io.Writer, pt *plan.PlanTree) {
 	}
 
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Total: %d plan instance%s\n", pt.Totals.Instances, planPluralS(pt.Totals.Instances))
+	if pt.Totals.Estimated {
+		// Never print a bare number for an estimate. The whole failure this
+		// replaces is a total that looked authoritative and was not.
+		fmt.Fprintf(w, "Total: at least %d plan instance%s\n",
+			pt.Totals.Instances, planPluralS(pt.Totals.Instances))
+		fmt.Fprintln(w, "  (a choose() option list is computed, so its size is not "+
+			"knowable without running the spec)")
+	} else {
+		fmt.Fprintf(w, "Total: %d plan instance%s\n", pt.Totals.Instances, planPluralS(pt.Totals.Instances))
+	}
 
 	if len(pt.Topology.Services) > 0 {
 		fmt.Fprintf(w, "Services: %d (", len(pt.Topology.Services))
@@ -248,6 +261,12 @@ func renderPlanTest(w io.Writer, t plan.PlanTest, isLast bool) {
 	for _, comp := range t.Compositions {
 		var sub []string
 		for _, ax := range comp.Axes {
+			if ax.Estimated {
+				// Not "[]" — an empty list reads as "zero options" when what
+				// we mean is "we could not read the size without running it".
+				sub = append(sub, fmt.Sprintf("%s: (computed — size unknown)", ax.Name))
+				continue
+			}
 			sub = append(sub, fmt.Sprintf("%s: [%s]", ax.Name, strings.Join(ax.Values, ", ")))
 		}
 		children = append(children, child{label: string(comp.Kind), sub: sub})

--- a/docs/design/2026-07-28-timing-exploration-experiment.md
+++ b/docs/design/2026-07-28-timing-exploration-experiment.md
@@ -121,12 +121,24 @@ Without that check this document would report "bug 2 does not reproduce across
 18 timing configurations", which would have been the third false conclusion in
 this line of work.
 
-## Recommendation
+## Resolution of the first recommendation
 
-- **`sleep(duration)` / `hold(duration)`** — a real wall-clock wait, independent
-  of event traffic. Small, and it is the only thing standing between the current
-  harness and a genuine search over fault timing. This is now measured rather
-  than assumed.
+`sleep(duration, clock="wall")` shipped in the same branch. The identical
+18-leaf search, with `await_stable(quiescence_window=gap)` replaced by
+`sleep(gap)`:
+
+```
+BEFORE   6 passed, 0 failed, 12 inconclusive     36 minutes
+AFTER   18 passed, 0 failed                      ~2 minutes
+```
+
+Every leaf ran, the unwired-gateway guard stayed silent (so the partitions were
+real), and the full grid — `warmup` × `gap` × `hold` — was covered for the
+first time. `hashicorp/raft` still did not fail, but this is the first run of
+which that statement means anything: bug 2's timing space has now actually been
+sampled rather than skipped.
+
+## Remaining recommendations
 - Fix defects 1 and 2 together: signal-safe teardown plus a unique device name.
   Both are user-facing and both brick a machine until manually cleaned.
 - Defects 3 and 4 are honesty gaps of the same family as §4.2 — a number that

--- a/docs/design/2026-07-28-timing-exploration-experiment.md
+++ b/docs/design/2026-07-28-timing-exploration-experiment.md
@@ -1,0 +1,133 @@
+# Can the fault-timing space be searched with what v0.14.0 shipped?
+
+**Date:** 2026-07-28
+**Status:** Experiment complete. Answer: **half of it.**
+**Branch:** `epic/v0.14.1`
+**Follows:** [Raft mesh results §4.2](2026-07-28-raft-mesh-results.md)
+**Artifact:** [`poc/raft-cluster/explore.star`](../../poc/raft-cluster/explore.star)
+
+---
+
+## Why
+
+v0.14.0's Raft write-up closed on a specific claim: the harness could express
+the faults but not *search* the timing space, and `choose()` + `--explore`
+looked like it would close that gap with no new code. RFC-054's future-work
+list was reordered on the strength of that claim.
+
+It was a claim, not a measurement. This is the measurement.
+
+## Result
+
+| Axis | Verdict |
+|---|---|
+| **Work volume** — `submit(choose("behind", [25, 120, 400]))` | **Works.** 6/6 leaves, each with distinct cluster state. |
+| **Wall clock** — `await_stable(quiescence_window = choose(...))` | **Does not work.** 12/18 leaves hung 3 minutes each and reported INCONCLUSIVE. |
+
+The mechanism is not a bug in `await_stable`. It is a category error in using it
+as a delay, and it fails in the one situation the delay is for.
+
+## The measurement
+
+`await_stable` returns when no event has arrived for the full quiescence window.
+During an active partition, in a 3-node Raft cluster:
+
+```
+lines in one 3-minute leaf:     6681
+max quiet gap between events:   0.338 s
+```
+
+Every dropped packet emits a `packet` event; every failed heartbeat, every
+`requestVote` timeout emits a `stdout` event. The stream never goes quiet for
+longer than ~340 ms. So:
+
+| window | outcome |
+|---|---|
+| `50ms`, `100ms` | returns |
+| `400ms` | marginal — near the 338 ms boundary, timing-flaky |
+| `900ms`, `1200ms` | **never returns**; blocks until the 3-minute test deadline |
+
+**The fault generates the events that prevent quiescence.** The longer the delay
+asked for, the more certain it is never to arrive — exactly inverted from what a
+timing knob needs. `ignore=` does not rescue it: the noise is the SUT's own
+stdout, which is also what a spec legitimately waits on.
+
+12 leaves × 3 min = 36 minutes of wall clock, producing no signal about
+`hashicorp/raft` and one line of output:
+
+```
+6 passed, 0 failed, 12 inconclusive
+```
+
+## What this costs, stated plainly
+
+The wall-clock axis of the Raft transfer scenario (Antithesis bug 2) **has still
+never been exercised.** 12 of 18 leaves never reached their `/transfer` call.
+The snapshot scenario's work-volume axis (bug 3) did get a real search — 6
+leaves, follower lag from 25 to 400 entries, snapshot before and after rejoin,
+all converged.
+
+So the v0.14.0 report's §6 stands, with one correction: the missing capability is
+narrower and more specific than "fault-timing exploration". Fan-out works. What
+is missing is a way to say *wait 400 ms*.
+
+## Defects found
+
+Four, all reachable only because v0.14.0 shipped a TUN-backed gateway.
+
+**1. The TUN device leaks on SIGTERM.** `cmd/faultbox/main.go` installs
+`signal.NotifyContext(ctx, os.Interrupt)` — SIGINT only. A `timeout`-killed run,
+a CI job that overruns, or any `kill` leaves `faultbox0` behind. Every later
+packet-fault run on that host then dies with:
+
+```
+start packet gateway: TUNSETIFF faultbox0: device or resource busy
+```
+
+Recovery is `sudo ip link delete faultbox0`, documented nowhere. The teardown
+comment at `runtime.go:3045` anticipates precisely this leak; it only covers the
+normal path.
+
+**2. The device name is a constant.** `faultbox0` means two concurrent runs on
+one host collide, and the collision is indistinguishable from defect 1.
+
+**3. `faultbox plan` cannot see `choose()` axes.** It reported `Total: 2 plan
+instances` for a spec that runs 24 leaves. Axes are discovered by *executing* a
+discovery leaf (`runtime.go:1206`); `plan` is static and executes nothing. So
+`--check-cost --max-instances N`, whose entire purpose is catching fan-out
+blowups before they run, is blind to the construct most likely to cause one.
+
+**4. Timeout verdicts do not say why.** The summary reports `12 inconclusive`
+after 36 minutes with no indication that every one was an `await_stable` that
+could not quiesce. `TestResult.Reason` carries the text; the summary drops it.
+
+## What the guard caught
+
+Worth recording, because it is the counterfactual for this whole document.
+
+An earlier run of the same 18 leaves reported every leaf reaching
+`accepted=10` — the liveness assertion passing 18 times. It was meaningless: a
+leaked `faultbox0` from defect 1 meant no gateway attached, so the partitions
+dropped nothing. Instead of 18 green leaves, v0.14.0's fail-loudly check
+produced:
+
+```
+reason: packet faults were installed 8 time(s) but no netstack gateway was
+        attached, so no packet was affected; the result below would be meaningless
+```
+
+`accepted=10` everywhere is the exact signature of a partition that did nothing.
+Without that check this document would report "bug 2 does not reproduce across
+18 timing configurations", which would have been the third false conclusion in
+this line of work.
+
+## Recommendation
+
+- **`sleep(duration)` / `hold(duration)`** — a real wall-clock wait, independent
+  of event traffic. Small, and it is the only thing standing between the current
+  harness and a genuine search over fault timing. This is now measured rather
+  than assumed.
+- Fix defects 1 and 2 together: signal-safe teardown plus a unique device name.
+  Both are user-facing and both brick a machine until manually cleaned.
+- Defects 3 and 4 are honesty gaps of the same family as §4.2 — a number that
+  reads like coverage but is not.

--- a/docs/exploration.md
+++ b/docs/exploration.md
@@ -113,6 +113,59 @@ $ echo $?
 
 The plan output still prints — so the engineer who triggered the gate sees what they're paying for.
 
+#### `choose()` fan-out (v0.14.1)
+
+`choose()` axes count toward the total, and the tree shows where the cost comes
+from:
+
+```
+├── test "test_transfer_timing"  [def]
+│   ├── 18 instances
+│   └── choose
+│       ├── warmup: [0, 10, 40]
+│       ├── gap: [0ms, 400ms, 1200ms]
+│       └── hold: [100ms, 900ms]
+```
+
+Before v0.14.1 they did not. The runtime discovers axes by *executing* a test
+body once and recording the `choose()` calls that ran; `plan` is static and
+executes nothing, so every `choose()`-driven test counted as one instance — a
+spec that runs 24 leaves reported `Total: 2 plan instances`, and the cost gate
+under-reported by 12×. Axes are now read from the spec AST instead.
+
+**Two limits, both deliberate and both visible in the output.**
+
+A computed option list cannot be sized without running the spec:
+
+```
+└── choose
+    ├── dyn: (computed — size unknown)
+    └── lit: [a, b]
+
+Total: at least 2 plan instances
+  (a choose() option list is computed, so its size is not knowable without running the spec)
+```
+
+`at least` is the point. A cost estimate that silently rounds down is worse
+than none, because it is trusted.
+
+A `choose()` reached through a helper function is **not** attributed to the
+calling test — static analysis cannot resolve the call graph without executing
+it, and inventing axes would be worse than missing them. If you want a fan-out
+visible to the cost gate, call `choose()` in the test body:
+
+```python
+def test_x():
+    n = choose("n", [1, 2, 3])   # counted
+    run(n)
+
+def helper():
+    return choose("hidden", [1, 2])   # NOT attributed to test_y
+
+def test_y():
+    run(helper())
+```
+
 ## Plan as a bundle artifact
 
 Every `faultbox test` run writes the same plan tree into the `.fb` archive as `plan.json`, alongside `trace.json`. Pre-RFC-042 bundles stay valid: the report and CLI both treat a missing `plan.json` as "no plan data" rather than an error.

--- a/docs/rfcs/0054-gvisor-packet-and-file-mediation.md
+++ b/docs/rfcs/0054-gvisor-packet-and-file-mediation.md
@@ -380,11 +380,11 @@ packet_reset(**match)                         # synthesize RST, drop the origina
 packet_window(size=0, **match)                # rewrite advertised receive window
 ```
 
-**Deferred to v0.14.1:** two link-scoped shapers that take no matcher.
+**Shipped in v0.14.1:** two link-scoped shapers that take no matcher.
 
 ```python
-bandwidth(rate="1mbps", dir="c2s")   # NOT in v0.14.0
-mtu(size=576)                        # NOT in v0.14.0
+bandwidth(rate="1mbit", dir="c2s", queue="250ms")
+mtu(size=576)
 ```
 
 These are not per-packet rules — they need a token bucket and real
@@ -636,9 +636,13 @@ see below.
   search.
   - Sibling, small: `--runs N` should say when the spec has no seed-sensitive
     construct. Silence there is what made the Raft result readable as evidence.
-- **`bandwidth(rate=)` and `mtu(size=)` — v0.14.1.** Link-scoped shapers, deferred from
-  v0.14.0 because they need a token bucket and real fragmentation/PMTUD handling rather
-  than the per-packet match-and-act pipeline. `mtu()` is what scenario 8 actually wants.
+- ~~**`bandwidth(rate=)` and `mtu(size=)` — v0.14.1.**~~ **Shipped in v0.14.1.**
+  `bandwidth()` paces via a single-server model whose queue is bounded in *time*
+  (`queue="250ms"`), so it drops when saturated the way a real bottleneck does rather
+  than buffering forever. `mtu()` overrides the link MTU, so netstack derives a smaller
+  TCP MSS and fragments — a real small-MTU path, not the `packet_drop(len_gt=)`
+  approximation scenario 8 had to use. Measured on the corpus: at 64kbit the c2s
+  direction admitted 76 packets with a 38ms peak backlog; at 256kbit, 9ms.
 - **`watch()` filesystem observation — v0.14.1.** The sink ships in v0.14.0; the primitive
   is gated off until trace sessions can be installed at sandbox boot via
   `-pod-init-config`. See Decision record M5.

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -1916,9 +1916,56 @@ packet_window(size = 0, **match)        # rewrite the advertised receive window
 Rules are evaluated in declaration order and **first match wins**, so a narrow
 `packet_pass` above a broad `packet_drop` carves out an exception.
 
-> `bandwidth()` and `mtu()` are **not** in v0.14.0. They are link-scoped shapers
-> needing a token bucket and real fragmentation handling rather than the
-> match-and-act pipeline above; they land in v0.14.1.
+### Link shapers: `bandwidth()` and `mtu()` (v0.14.1)
+
+These take **no matcher**. Every `packet_*` rule answers "what happens to
+packets that look like this"; a shaper answers "what kind of link is this",
+which is a property of the path rather than of any packet crossing it.
+
+```python
+def test_slow_link():
+    bandwidth(rate = "1mbit")            # both directions
+    bandwidth(rate = "256kbit", dir = "s2c")
+    mtu(size = 576)
+    api.get(path = "/report")
+```
+
+**`bandwidth(rate, dir="both", queue="250ms")`**
+
+`rate` accepts bit units (`"1mbit"`, `"512kbps"`, `"1gbit"`) or byte units,
+which must say so explicitly (`"2MB/s"`, `"64kB/s"`). A bare number is
+**rejected** — `"1000000"` could be bits or bytes, and guessing would be a
+silent factor-of-eight error in the one value the whole fault depends on.
+
+`queue=` bounds how much traffic the shaper holds before it starts discarding.
+A rate limiter with an unbounded queue is not a slow link, it is a memory leak
+with latency: the sender never observes congestion, which is precisely the
+signal a congestion-control bug needs to surface. Expressed as time so it means
+the same thing at 1 Mbit and at 1 Gbit.
+
+**`mtu(size)`**
+
+A real small-MTU path: netstack derives its advertised TCP MSS and its IP
+fragmentation threshold from the link MTU, so the peer sends smaller segments.
+This is the difference from approximating it with `packet_drop(len_gt=576)`,
+which drops oversized packets — that looks like a black hole and behaves like
+nothing real. Sizes below the IPv4 minimum of 68 bytes are rejected.
+
+**Both are gateway-wide**, not per-target. There is one TUN link under one
+netstack NIC, so per-interface capacity is not something the gateway has to
+give; a per-target knob would be one that lies. Both are cleared at test end,
+so one test's slow link cannot become the next test's baseline.
+
+**Both refuse on `runtime="default"`** rather than silently doing nothing — a
+shaper that quietly no-ops leaves the test passing against a link that was
+never slow, and the run still looks like evidence.
+
+Each run records what the shaper actually did, so "the link was configured
+slow" can be told apart from "the link was the bottleneck":
+
+```
+bandwidth_stats  dir=c2s  admitted=76  dropped=0  peak_backlog=38ms
+```
 
 ### The matcher
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -131,6 +131,7 @@ Every builtin grouped by what it's for. Use Cmd-F to jump.
 [`always`](#alwayspredicate-between),
 [`await_event`](#await_eventpredicate_or_matcher),
 [`await_stable`](#await_stablequiescence_window-ignore),
+[`sleep`](#sleepduration-clockwall-v0141),
 [`test`](#testname-body-setup-expect-timeout-terminate_when-clock),
 [`match`](#the-match-module).
 
@@ -2660,7 +2661,7 @@ it from the spec-wide list so it doesn't double-register.
 **Sandbox restrictions** — `update` and `check` lambdas run in a
 restricted Starlark thread. Calls to `fault`, `service`, `assert_*`,
 `parallel`, `partition`, `eventually`, `always`, `monitor`,
-`await_stable`, `await_event`, `determinism`, `trace`, `trace_start`,
+`await_stable`, `await_event`, `sleep`, `determinism`, `trace`, `trace_start`,
 `trace_stop`, `events`, and friends are rejected at spec load with a
 clear error message. See
 [docs/temporal.md](temporal.md#sandbox-restrictions) for the full
@@ -2739,6 +2740,66 @@ def body():
 
 `ignore=` accepts a matcher or callable for events that should not
 reset the quiescence timer (heartbeats, telemetry, metric flushes).
+
+> **`await_stable` cannot hold a fault open for a fixed time.** An active
+> fault emits the events that prevent quiescence — see `sleep()` below.
+
+### `sleep(duration, clock="wall")` (v0.14.1)
+
+Blocks the body for a wall-clock duration, regardless of what the event log
+is doing. Only valid inside a test body.
+
+```python
+def test_transfer_during_partition():
+    partition_start(node1, node2)
+    sleep("400ms")                    # hold the partition open
+    node1.admin.post(path = "/transfer")
+    partition_stop(node1, node2)
+```
+
+**Use `sleep()` when you mean elapsed time, `await_stable()` when you mean
+"the system settled."** They are not interchangeable, and the difference
+matters most while a fault is installed:
+
+| | waits for | during an active fault |
+|---|---|---|
+| `await_stable(quiescence_window=W)` | no events for W | may never return |
+| `sleep(W)` | W of wall clock | returns after W |
+
+`await_stable` returns on quiescence, and a fault under test generates the
+events that prevent it. Measured on a 3-node `hashicorp/raft` cluster with a
+partition installed: **6681 events in three minutes, longest quiet gap 338 ms.**
+Every dropped packet and failed heartbeat resets the timer, so any window above
+~340 ms blocked until the per-test deadline and reported INCONCLUSIVE. `ignore=`
+does not rescue it — the noise is the SUT's own stdout, which specs
+legitimately wait on. Full measurement:
+[timing-exploration experiment](design/2026-07-28-timing-exploration-experiment.md).
+
+This makes `sleep()` the primitive for exploring fault *timing*:
+
+```python
+def test_transfer_timing():
+    gap = choose("gap", ["0ms", "400ms", "1200ms"])
+    partition_start(node1, node2)
+    sleep(gap)
+    node1.admin.post(path = "/transfer")
+```
+
+Notes:
+
+- **`sleep("0ms")` is a no-op, not an error** — deliberately unlike
+  `await_stable`, whose window must be positive. A `choose()` axis wants "no
+  delay" as its baseline, and a value that aborts the leaf instead of running
+  it turns a search into silence. A negative duration errors.
+- **A sleep longer than the test's remaining budget is refused up front**,
+  naming both numbers, rather than running into the deadline and reporting a
+  bare timeout.
+- **Emits no event.** A sleep is supervisor-side, not something the SUT did,
+  and emitting one would reset the quiescence timer of any `await_stable` in a
+  `parallel()` branch.
+- Rejected inside `monitor()` and `assume()` predicates, like the `await_*`
+  family.
+- `clock=` is reserved; `"wall"` is the only accepted value in this release.
 
 ### `test(name, body=, setup=, expect=, timeout=, terminate_when=, assume=, clock=)`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -276,6 +276,45 @@ missing alongside `faultbox`, container services never reach
 [README → Build from source](../README.md#build-from-source)). The shim
 is the container entrypoint; without it the container can't start.
 
+## 13. `TUNSETIFF ...: device or resource busy` on a packet-fault spec
+
+The packet gateway (`determinism(runtime = "gvisor")`) needs a TUN device, and
+a TUN device created with `ip tuntap add` is **persistent** — it outlives the
+process that made it. If a run dies without tearing down (SIGKILL, an OOM kill,
+a panic), the device stays behind.
+
+**In v0.14.1 this is self-healing.** Devices are named per-process
+(`fbox<pid>`), so a leftover cannot collide with a new run, and each run sweeps
+orphans on startup — any `fbox<pid>` whose owning process is gone is removed:
+
+```
+packet gateway: removed orphaned TUN device left by an earlier run
+  device=fbox999999 owner_pid=999999
+```
+
+Devices belonging to *live* processes are never touched, so concurrent runs on
+one host are fine.
+
+**If you are on v0.14.0**, the device was the shared constant `faultbox0` and
+neither property held: two concurrent runs collided, and one leaked device
+broke every later run on that host. Recover with:
+
+```bash
+sudo ip link delete faultbox0
+```
+
+Worth knowing because of how the failure presents: the run **continues**,
+installs its packet rules into a gateway that is not there, and every fault
+silently affects nothing. Faultbox fails the test rather than reporting that as
+a pass —
+
+```
+packet faults were installed 8 time(s) but no netstack gateway was attached,
+so no packet was affected; the result below would be meaningless
+```
+
+— but if you see that message, this is why.
+
 ## See also
 
 - [bundles.md](bundles.md) — bundle inspection (`faultbox inspect`)

--- a/internal/netfault/defer_test.go
+++ b/internal/netfault/defer_test.go
@@ -420,3 +420,31 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// PROBE: does delay work on EGRESS (S2C), or is it a silent drop?
+//
+// Both existing delay tests drive DeliverNetworkPacket (ingress). WritePackets
+// builds a local `forward` list, hands `release` a closure that appends to it,
+// writes the list once the loop finishes, and DecRefs it on return — so a
+// release that fires later, from the defer queue's timer, appends to a list
+// nobody will ever write.
+func TestDelayOnEgressActuallyDelivers(t *testing.T) {
+	clock := newFakeClock()
+	fe, _, lower := newTestEndpoint(t, Options{Clock: clock})
+	fe.SetRules(mustRules(t, &Rule{
+		Action: ActionDelay,
+		Delay:  250 * time.Millisecond,
+		Match:  Match{Dir: dirPtr(DirS2C)},
+	}))
+
+	writeOne(fe, makePacket(defaultPkt()))
+
+	if got := lower.count(); got != 0 {
+		t.Fatalf("packet written immediately (%d); the delay did not hold it", got)
+	}
+	clock.Advance(250 * time.Millisecond)
+	if !waitFor(t, 2*time.Second, func() bool { return lower.count() == 1 }) {
+		t.Fatalf("egress packet never written after the delay elapsed (count=%d) "+
+			"— delay on dir=\"s2c\" is silently dropping instead of delaying", lower.count())
+	}
+}

--- a/internal/netfault/endpoint.go
+++ b/internal/netfault/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -68,6 +69,18 @@ type FaultEndpoint struct {
 
 	flows   sync.Map // flow string -> *atomic.Int64 (per-flow packet ordinal)
 	stopped atomic.Bool
+
+	// clock is retained so the shaper can read the same time source the defer
+	// queue schedules against; a pacer computing waits from wall time while
+	// the queue runs on a fake clock would be untestable.
+	clock Clock
+
+	// Link shapers (RFC-054 v0.14.1). Nil when unset — the common case — so
+	// an unshaped link pays one atomic load per packet.
+	shapeC2S atomic.Pointer[shaper]
+	shapeS2C atomic.Pointer[shaper]
+	// mtuOverride is 0 when the lower endpoint's MTU stands.
+	mtuOverride atomic.Uint32
 }
 
 // Options configures a FaultEndpoint.
@@ -85,8 +98,13 @@ type Options struct {
 
 // New wraps lower in a FaultEndpoint.
 func New(lower stack.LinkEndpoint, opts Options) *FaultEndpoint {
+	clock := opts.Clock
+	if clock == nil {
+		clock = RealClock
+	}
 	return &FaultEndpoint{
 		LinkEndpoint: lower,
+		clock:        clock,
 		deferQ:       newDeferQueue(opts.Clock),
 		reorder:      newReorderBuffer(),
 		onEvent:      opts.OnEvent,
@@ -109,6 +127,103 @@ func (e *FaultEndpoint) WhereEvaluations() int64 { return e.whereEvals.Load() }
 // be applied. Non-zero means a fault the spec asked for did not happen, and
 // the runtime must say so rather than report a clean pass.
 func (e *FaultEndpoint) MutationsSkipped() int64 { return e.mutationsSkipped.Load() }
+
+// SetBandwidth paces one or both directions at bytesPerSec, holding at most
+// maxBacklog worth of traffic before it starts dropping. A rate of 0 clears
+// the shaper for that direction.
+func (e *FaultEndpoint) SetBandwidth(dir Direction, bytesPerSec float64, maxBacklog time.Duration) {
+	set := func(p *atomic.Pointer[shaper]) {
+		if bytesPerSec <= 0 {
+			p.Store(nil)
+			return
+		}
+		p.Store(newShaper(bytesPerSec, maxBacklog))
+	}
+	switch dir {
+	case DirC2S:
+		set(&e.shapeC2S)
+	case DirS2C:
+		set(&e.shapeS2C)
+	default:
+		set(&e.shapeC2S)
+		set(&e.shapeS2C)
+	}
+}
+
+// SetMTU overrides the link MTU. Zero restores the lower endpoint's.
+func (e *FaultEndpoint) SetMTU(mtu uint32) { e.mtuOverride.Store(mtu) }
+
+// MTU reports the link MTU, honouring any override.
+//
+// This is what makes mtu() a real small-MTU path rather than a size filter:
+// netstack derives the TCP MSS it advertises and its IP fragmentation
+// threshold from this value, so lowering it makes the peer send smaller
+// segments instead of making oversized ones vanish.
+func (e *FaultEndpoint) MTU() uint32 {
+	if v := e.mtuOverride.Load(); v > 0 {
+		return v
+	}
+	return e.LinkEndpoint.MTU()
+}
+
+// ShaperStatsFor reports what a direction's shaper did, and whether one is
+// installed at all.
+func (e *FaultEndpoint) ShaperStatsFor(dir Direction) (ShaperStats, bool) {
+	var sh *shaper
+	if dir == DirC2S {
+		sh = e.shapeC2S.Load()
+	} else {
+		sh = e.shapeS2C.Load()
+	}
+	if sh == nil {
+		return ShaperStats{}, false
+	}
+	return sh.stats(), true
+}
+
+// ClearShapers removes both bandwidth shapers and any MTU override.
+func (e *FaultEndpoint) ClearShapers() {
+	e.shapeC2S.Store(nil)
+	e.shapeS2C.Store(nil)
+	e.mtuOverride.Store(0)
+}
+
+// paced wraps a release callback with this direction's bandwidth shaper.
+//
+// Applied before the rule pipeline runs, and therefore also when no rules are
+// installed: bandwidth is a property of the link, so a spec that sets a rate
+// and no rules must still see a slow link.
+func (e *FaultEndpoint) paced(dir Direction, release func(*stack.PacketBuffer)) func(*stack.PacketBuffer) {
+	var sh *shaper
+	if dir == DirC2S {
+		sh = e.shapeC2S.Load()
+	} else {
+		sh = e.shapeS2C.Load()
+	}
+	if sh == nil {
+		return release
+	}
+	return func(p *stack.PacketBuffer) {
+		wait, ok := sh.admit(p.Size(), e.clock.Now())
+		if !ok {
+			// Queue full. A real bottleneck drops here, and the drop is the
+			// signal that makes the sender back off.
+			return
+		}
+		if wait <= 0 {
+			release(p)
+			return
+		}
+		held := p.IncRef()
+		if !e.deferQ.schedule(wait, func() {
+			release(held)
+			held.DecRef()
+		}) {
+			release(held)
+			held.DecRef()
+		}
+	}
+}
 
 // Close drains deferred and held packets, then closes the wrapped endpoint.
 // Deferred packets are flushed rather than discarded — silently dropping them
@@ -170,14 +285,14 @@ func (e *FaultEndpoint) DeliverLinkPacket(proto tcpip.NetworkProtocolNumber, pkt
 // would make netstack treat it as backpressure and retry, which is not what
 // "drop" means — the SUT should observe loss, not the sender.
 func (e *FaultEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
-	var forward stack.PacketBufferList
-	defer forward.DecRef()
+	batch := &egressBatch{e: e}
+	defer batch.seal()
 
 	total := pkts.Len()
 	for _, pkt := range pkts.AsSlice() {
 		e.handle(pkt, DirS2C,
 			// forward: on down the wire toward the SUT.
-			func(p *stack.PacketBuffer) { forward.PushBack(p.IncRef()) },
+			batch.release,
 			// reverse: up into the local stack, so netstack sees the peer
 			// (the SUT) as having sent it.
 			func(p *stack.PacketBuffer) {
@@ -187,14 +302,58 @@ func (e *FaultEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Er
 			},
 		)
 	}
-	if forward.Len() == 0 {
-		return total, nil
-	}
-	n, err := e.LinkEndpoint.WritePackets(forward)
-	if err != nil {
-		return n, err
-	}
 	return total, nil
+}
+
+// egressBatch routes a released packet either into the current write batch or,
+// once that batch is gone, straight down the wire.
+//
+// The distinction is the difference between delaying a packet and losing it.
+// Actions that hold a packet — delay, reorder, and bandwidth pacing — release
+// it later, from the defer queue's timer goroutine, long after WritePackets
+// has returned. The previous implementation gave `release` a closure appending
+// to a local list that was written once the loop finished and DecRef'd on
+// return, so every late release appended to a list nobody would ever write:
+// `packet_delay(dir="s2c")` was a silent drop wearing a delay's name. Both
+// delay tests drove the ingress path, where release goes straight to the
+// dispatcher, so nothing caught it.
+type egressBatch struct {
+	e *FaultEndpoint
+
+	mu     sync.Mutex
+	list   stack.PacketBufferList
+	sealed bool
+}
+
+// release is safe to call from any goroutine at any time, including after
+// seal.
+func (b *egressBatch) release(p *stack.PacketBuffer) {
+	b.mu.Lock()
+	if !b.sealed {
+		b.list.PushBack(p.IncRef())
+		b.mu.Unlock()
+		return
+	}
+	b.mu.Unlock()
+	// The batch is closed; this packet was held past the write. Send it on its
+	// own rather than dropping it.
+	b.e.writeDown(p)
+}
+
+// seal writes whatever the batch accumulated and marks it closed, so any
+// later release takes the direct path.
+func (b *egressBatch) seal() {
+	b.mu.Lock()
+	b.sealed = true
+	list := b.list
+	b.list = stack.PacketBufferList{}
+	b.mu.Unlock()
+
+	defer list.DecRef()
+	if list.Len() == 0 {
+		return
+	}
+	b.e.LinkEndpoint.WritePackets(list)
 }
 
 // handle runs one packet through the rule pipeline.
@@ -207,6 +366,10 @@ func (e *FaultEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Er
 // Unparseable packets pass through untouched: a rule cannot meaningfully match
 // what we could not parse.
 func (e *FaultEndpoint) handle(pkt *stack.PacketBuffer, dir Direction, release, reverse func(*stack.PacketBuffer)) {
+	// Shaping wraps release before anything else, so it applies even on the
+	// no-rules fast path below. bandwidth() describes the link, not a packet.
+	release = e.paced(dir, release)
+
 	rs := e.rules.Load()
 	if rs == nil || len(rs.rules) == 0 || e.stopped.Load() {
 		release(pkt)

--- a/internal/netfault/gateway.go
+++ b/internal/netfault/gateway.go
@@ -355,3 +355,54 @@ func sortStrings(s []string) {
 		}
 	}
 }
+
+// SetBandwidth paces the link at rate (a human string like "1mbit" or
+// "2MB/s"), in the given direction, holding at most maxBacklog before it
+// drops. An empty rate clears the shaper.
+//
+// Link-scoped by design, not per-triple: bandwidth describes the path, and
+// there is one TUN link under one FaultEndpoint. Scoping it per interface
+// would imply per-interface capacity the gateway does not have — better to be
+// honest about what the model is than to offer a knob that lies.
+func (g *Gateway) SetBandwidth(rate string, dir Direction, maxBacklog time.Duration) error {
+	ep := g.Endpoint()
+	if ep == nil {
+		return fmt.Errorf("bandwidth: gateway is not started")
+	}
+	if rate == "" {
+		ep.SetBandwidth(dir, 0, 0)
+		return nil
+	}
+	bps, err := ParseRate(rate)
+	if err != nil {
+		return fmt.Errorf("bandwidth: %w", err)
+	}
+	ep.SetBandwidth(dir, bps, maxBacklog)
+	return nil
+}
+
+// SetMTU overrides the link MTU; 0 restores the underlying device's.
+func (g *Gateway) SetMTU(mtu uint32) error {
+	ep := g.Endpoint()
+	if ep == nil {
+		return fmt.Errorf("mtu: gateway is not started")
+	}
+	ep.SetMTU(mtu)
+	return nil
+}
+
+// ShaperStats reports what a direction's shaper did, and whether one exists.
+func (g *Gateway) ShaperStats(dir Direction) (ShaperStats, bool) {
+	ep := g.Endpoint()
+	if ep == nil {
+		return ShaperStats{}, false
+	}
+	return ep.ShaperStatsFor(dir)
+}
+
+// ClearShapers removes both bandwidth shapers and any MTU override.
+func (g *Gateway) ClearShapers() {
+	if ep := g.Endpoint(); ep != nil {
+		ep.ClearShapers()
+	}
+}

--- a/internal/netfault/gateway.go
+++ b/internal/netfault/gateway.go
@@ -4,13 +4,33 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"time"
 )
 
+// DevicePrefix starts every TUN interface name Faultbox creates.
+//
+// It exists so orphans are identifiable: a run killed by SIGKILL, an OOM, or a
+// panic cannot clean up after itself, and the only way to recover the host is
+// to recognise the leftovers. See reapOrphanDevices.
+const DevicePrefix = "fbox"
+
+// deviceNameFor builds the per-process TUN name.
+//
+// Linux caps interface names at IFNAMSIZ-1 = 15 bytes. "fbox" plus a 7-digit
+// pid (the kernel default pid_max is 4194304) is 11, so this cannot truncate.
+// The earlier name — a constant "faultbox0" — is why v0.14.0 had two separate
+// failure modes: concurrent runs on one host collided, and a leaked device
+// broke every later run with an EBUSY naming a device the user had never
+// heard of. A per-process name makes a leak clutter rather than a stoppage.
+func deviceNameFor(pid int) string {
+	return fmt.Sprintf("%s%d", DevicePrefix, pid)
+}
+
 // GatewayConfig configures the packet gateway.
 type GatewayConfig struct {
-	// Device is the TUN interface name. Defaults to "faultbox0".
+	// Device is the TUN interface name. Defaults to "fbox<pid>".
 	Device string
 	// Subnet is the address space the gateway owns. Defaults to DefaultSubnet.
 	Subnet string
@@ -25,7 +45,7 @@ type GatewayConfig struct {
 func (c *GatewayConfig) withDefaults() GatewayConfig {
 	out := *c
 	if out.Device == "" {
-		out.Device = "faultbox0"
+		out.Device = deviceNameFor(os.Getpid())
 	}
 	if out.Subnet == "" {
 		out.Subnet = DefaultSubnet

--- a/internal/netfault/gateway_linux.go
+++ b/internal/netfault/gateway_linux.go
@@ -174,12 +174,21 @@ func (l *linuxGateway) close() error {
 // ensureDevice creates and configures the TUN interface, reporting whether it
 // created it (so teardown only removes what it made).
 func (l *linuxGateway) ensureDevice(g *Gateway) (created bool, err error) {
+	// Sweep orphans before claiming a name. Cheap, and it is the only thing
+	// that recovers a host where a previous run was SIGKILLed.
+	reapOrphanDevices()
+
 	if _, e := net.InterfaceByName(g.cfg.Device); e == nil {
-		// Already present — reuse it, and leave it alone on teardown.
-		if err := run("ip", "link", "set", g.cfg.Device, "up"); err != nil {
-			return false, err
+		// The name is per-process, so a device already holding it is a
+		// leftover from an earlier process that had this pid — we have not
+		// created ours yet. v0.14.0 adopted such a device and left it alone on
+		// teardown; that is how a stale device with stale addresses survived
+		// to break the next run with EBUSY. Replace it instead.
+		if err := run("ip", "link", "del", g.cfg.Device); err != nil {
+			return false, fmt.Errorf(
+				"stale TUN %s exists and could not be removed (needs CAP_NET_ADMIN): %w",
+				g.cfg.Device, err)
 		}
-		return false, nil
 	}
 	if err := run("ip", "tuntap", "add", "dev", g.cfg.Device, "mode", "tun"); err != nil {
 		return false, fmt.Errorf("create TUN %s (needs CAP_NET_ADMIN): %w", g.cfg.Device, err)

--- a/internal/netfault/gateway_linux_test.go
+++ b/internal/netfault/gateway_linux_test.go
@@ -29,7 +29,14 @@ func requireRoot(t *testing.T) {
 }
 
 // testGateway builds a gateway on a uniquely-named device so concurrent or
-// interrupted runs cannot collide on faultbox0.
+// interrupted test runs cannot collide.
+//
+// This helper has always done this; the production default did not until
+// v0.14.1, which is the whole bug — the hazard was understood well enough to
+// work around in tests and shipped anyway in the code users run. The prefix
+// stays distinct from DevicePrefix so reapOrphanDevices, which deletes
+// fbox<pid> devices belonging to dead processes, cannot remove a device a
+// concurrent test is using.
 func testGateway(t *testing.T, cfg GatewayConfig) *Gateway {
 	t.Helper()
 	if cfg.Device == "" {

--- a/internal/netfault/gateway_test.go
+++ b/internal/netfault/gateway_test.go
@@ -1,6 +1,7 @@
 package netfault
 
 import (
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -116,8 +117,10 @@ func TestAllocatorExhaustionIsAnError(t *testing.T) {
 
 func TestGatewayDefaults(t *testing.T) {
 	g, _ := NewGateway(GatewayConfig{})
-	if g.Device() != "faultbox0" {
-		t.Errorf("Device = %q, want faultbox0", g.Device())
+	// v0.14.1: per-process, not the shared "faultbox0". A constant name meant
+	// concurrent runs collided and one leaked device broke every later run.
+	if want := deviceNameFor(os.Getpid()); g.Device() != want {
+		t.Errorf("Device = %q, want %q", g.Device(), want)
 	}
 	if g.Subnet() != DefaultSubnet {
 		t.Errorf("Subnet = %q, want %q", g.Subnet(), DefaultSubnet)

--- a/internal/netfault/helpers_test.go
+++ b/internal/netfault/helpers_test.go
@@ -3,6 +3,7 @@ package netfault
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -237,8 +238,13 @@ type fakeClock struct {
 type fakeTimer struct {
 	deadline time.Time
 	fn       func()
-	stopped  bool
-	seq      int
+	// stopped is atomic because the deferQueue goroutine calls Stop()
+	// concurrently with the test goroutine calling Advance(), which reads it
+	// under the clock's mutex. Guarding only one side of that pair is not
+	// guarding it: -race caught this intermittently, so CI would have too,
+	// eventually and at the least convenient moment.
+	stopped atomic.Bool
+	seq     int
 }
 
 func newFakeClock() *fakeClock {
@@ -260,9 +266,9 @@ func (c *fakeClock) AfterFunc(d time.Duration, fn func()) Timer {
 }
 
 func (t *fakeTimer) Stop() bool {
-	was := t.stopped
-	t.stopped = true
-	return !was
+	// Swap, not load-then-store: two concurrent Stop()s must not both report
+	// that they were the one to stop the timer.
+	return !t.stopped.Swap(true)
 }
 
 // Advance moves the clock and fires due timers in (deadline, seq) order.
@@ -273,9 +279,9 @@ func (c *fakeClock) Advance(d time.Duration) {
 	var due []*fakeTimer
 	var keep []*fakeTimer
 	for _, t := range c.timers {
-		if !t.stopped && !t.deadline.After(now) {
+		if !t.stopped.Load() && !t.deadline.After(now) {
 			due = append(due, t)
-		} else if !t.stopped {
+		} else if !t.stopped.Load() {
 			keep = append(keep, t)
 		}
 	}

--- a/internal/netfault/packetview.go
+++ b/internal/netfault/packetview.go
@@ -20,6 +20,10 @@ const (
 	DirC2S Direction = iota
 	// DirS2C is Faultbox → SUT (egress out of netstack).
 	DirS2C
+	// DirBoth selects both directions. It is never the direction OF a packet
+	// — Parse only ever yields DirC2S or DirS2C — only a selector for the
+	// link shapers, which are configured per direction or for the whole link.
+	DirBoth
 )
 
 func (d Direction) String() string {

--- a/internal/netfault/reap_linux.go
+++ b/internal/netfault/reap_linux.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+package netfault
+
+import (
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Orphan TUN devices, and why reaping them is not optional.
+//
+// A gateway removes its device on the normal teardown path, and v0.14.1 also
+// removes it on SIGINT/SIGTERM. Neither covers SIGKILL, an OOM kill, or a
+// panic in the wrong goroutine — and a TUN device created with `ip tuntap add`
+// is persistent, so it outlives the process unconditionally.
+//
+// In v0.14.0 the device name was the constant "faultbox0", which turned that
+// leak into a host-level outage: every later packet-fault run failed with
+//
+//	start packet gateway: TUNSETIFF faultbox0: device or resource busy
+//
+// naming a device the user had never heard of, with no documented recovery.
+// Worse, the failure is silent in the way that matters — the run continues,
+// installs its packet rules into a gateway that is not there, and every fault
+// quietly affects nothing. (v0.14.0's unwired-gateway check is what stops that
+// being reported as a pass.)
+//
+// Per-process names (fbox<pid>) make a leak harmless rather than fatal. This
+// sweep is the second half: it removes the litter, so a machine recovers on
+// its own instead of needing `ip link delete` from someone who knows.
+
+// reapOrphanDevices removes every fbox<pid> TUN device whose owning process is
+// gone. Devices belonging to live processes are left alone — concurrent runs
+// are legitimate, and that is the whole point of per-process naming.
+//
+// Best-effort by design: a device that cannot be enumerated or removed is
+// logged and skipped, never fatal. Failing to tidy up after a previous run is
+// not a reason to refuse this one.
+func reapOrphanDevices() {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		slog.Debug("packet gateway: could not enumerate interfaces for orphan sweep",
+			"error", err.Error())
+		return
+	}
+	self := os.Getpid()
+	for _, ifc := range ifaces {
+		pid, ok := parseDeviceName(ifc.Name)
+		if !ok || pid == self {
+			continue
+		}
+		if processAlive(pid) {
+			// A concurrent Faultbox run owns this one.
+			continue
+		}
+		if err := run("ip", "link", "del", ifc.Name); err != nil {
+			slog.Warn("packet gateway: could not remove orphaned TUN device",
+				"device", ifc.Name, "owner_pid", pid, "error", err.Error())
+			continue
+		}
+		slog.Info("packet gateway: removed orphaned TUN device left by an earlier run",
+			"device", ifc.Name, "owner_pid", pid)
+	}
+}
+
+// parseDeviceName extracts the owning pid from an "fbox<pid>" interface name.
+//
+// The prefix check alone is not enough: an unrelated interface could begin
+// with "fbox", and deleting someone else's network device because its name
+// looked familiar would be a far worse bug than the leak this fixes. Requiring
+// the remainder to parse as a positive integer is what makes the name a claim
+// of ownership rather than a coincidence.
+func parseDeviceName(name string) (pid int, ok bool) {
+	rest, found := strings.CutPrefix(name, DevicePrefix)
+	if !found || rest == "" {
+		return 0, false
+	}
+	// Digits only. strconv.Atoi accepts a leading sign, so "fbox+1" would
+	// otherwise parse as pid 1 and we would claim ownership of an interface we
+	// could not have created. Being strict here is the difference between
+	// tidying our own litter and deleting a stranger's device.
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	pid, err := strconv.Atoi(rest)
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// processAlive reports whether pid is a live process.
+//
+// /proc is the authority here rather than kill(pid, 0): the sweep may run as
+// root, where signalling any pid succeeds regardless of who owns it, and a
+// false "alive" would leave orphans forever.
+func processAlive(pid int) bool {
+	_, err := os.Stat("/proc/" + strconv.Itoa(pid))
+	return err == nil
+}

--- a/internal/netfault/reap_linux_test.go
+++ b/internal/netfault/reap_linux_test.go
@@ -1,0 +1,125 @@
+//go:build linux
+
+package netfault
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// parseDeviceName is the guard between "tidy up our litter" and "delete a
+// stranger's network device because the name looked familiar". Its negative
+// cases matter more than its positive one.
+func TestParseDeviceName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantPID int
+		wantOK  bool
+	}{
+		{"fbox1234", 1234, true},
+		{"fbox1", 1, true},
+		{"fbox4194304", 4194304, true}, // kernel default pid_max
+
+		// Not ours, or not provably ours.
+		{"fbox", 0, false},      // prefix with no pid
+		{"fbox0", 0, false},     // pid 0 is not a real owner
+		{"fbox-12", 0, false},   // not a bare integer
+		{"fboxabc", 0, false},   // ditto
+		{"fbox12a", 0, false},   // trailing junk
+		{"fbox 12", 0, false},   // whitespace
+		{"eth0", 0, false},      // unrelated
+		{"lo", 0, false},        // unrelated
+		{"faultbox0", 0, false}, // v0.14.0's name: no pid, so not reapable
+		{"myfbox12", 0, false},  // prefix must be at the start
+		{"fbox-1", 0, false},    // negative-looking
+		{"fbox+1", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pid, ok := parseDeviceName(tc.name)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && pid != tc.wantPID {
+				t.Errorf("pid = %d, want %d", pid, tc.wantPID)
+			}
+		})
+	}
+}
+
+// Round-trip: whatever deviceNameFor builds, parseDeviceName must claim.
+// If these two ever disagree, every device Faultbox creates becomes
+// unreapable and the leak is back with no symptom until a host fills up.
+func TestDeviceNameRoundTrip(t *testing.T) {
+	for _, pid := range []int{1, 42, 9999, 4194304, os.Getpid()} {
+		name := deviceNameFor(pid)
+		got, ok := parseDeviceName(name)
+		if !ok {
+			t.Errorf("deviceNameFor(%d) = %q, which parseDeviceName rejects", pid, name)
+			continue
+		}
+		if got != pid {
+			t.Errorf("round trip for %d gave %d (name %q)", pid, got, name)
+		}
+	}
+}
+
+// Linux caps interface names at IFNAMSIZ-1 = 15 bytes. A truncated name would
+// silently belong to a different pid.
+func TestDeviceNameFitsIFNAMSIZ(t *testing.T) {
+	const maxIfName = 15
+	for _, pid := range []int{1, 4194304, 999999999} {
+		if n := len(deviceNameFor(pid)); n > maxIfName {
+			t.Errorf("deviceNameFor(%d) is %d bytes, over the %d-byte limit", pid, n, maxIfName)
+		}
+	}
+}
+
+func TestProcessAlive(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("the running test process must be reported alive")
+	}
+
+	// A reaped child is the closest thing to a guaranteed-dead pid.
+	cmd := exec.Command("/bin/true")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not spawn a child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Skipf("child did not exit cleanly: %v", err)
+	}
+	if processAlive(pid) {
+		t.Errorf("pid %d exited and was reaped, but is reported alive", pid)
+	}
+}
+
+// The default must be per-process. A shared constant is what made a leaked
+// device fatal for every later run in v0.14.0.
+func TestDefaultDeviceIsPerProcess(t *testing.T) {
+	cfg := (&GatewayConfig{}).withDefaults()
+	if want := deviceNameFor(os.Getpid()); cfg.Device != want {
+		t.Errorf("default device = %q, want %q", cfg.Device, want)
+	}
+	if cfg.Device == "faultbox0" {
+		t.Error("default device is still the v0.14.0 shared constant")
+	}
+	// An explicit name still wins.
+	explicit := (&GatewayConfig{Device: "fbox999"}).withDefaults()
+	if explicit.Device != "fbox999" {
+		t.Errorf("explicit device overridden: got %q", explicit.Device)
+	}
+}
+
+// reapOrphanDevices must never touch a device whose owner is alive — that is
+// what makes concurrent runs on one host safe. Without CAP_NET_ADMIN it can
+// still be called; it just finds nothing to remove and must not panic.
+func TestReapOrphanDevices_LeavesLiveOwnersAlone(t *testing.T) {
+	self := deviceNameFor(os.Getpid())
+	if pid, ok := parseDeviceName(self); !ok || !processAlive(pid) {
+		t.Fatalf("own device name %q must parse to this live process", self)
+	}
+	// Must be safe to call regardless of privileges or existing interfaces.
+	reapOrphanDevices()
+}

--- a/internal/netfault/shape.go
+++ b/internal/netfault/shape.go
@@ -1,0 +1,177 @@
+package netfault
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Link shapers: bandwidth() and mtu().
+//
+// These are not per-packet rules and deliberately take no matcher (RFC-054
+// §"Deferred to v0.14.1"). A rule answers "what should happen to packets that
+// look like this"; a shaper answers "what kind of link is this", which is a
+// property of the path, not of any packet crossing it.
+//
+// That distinction is why they were held back from v0.14.0 rather than bolted
+// onto the match-and-act pipeline. mtu() in particular: approximating it with
+// packet_drop(len_gt=N) drops oversized packets, which looks like a black hole
+// and behaves like nothing real — a genuine small-MTU path makes TCP negotiate
+// a smaller MSS and makes IP fragment, and the interesting bugs live in that
+// behaviour, not in the loss.
+
+// DefaultShaperBacklog bounds how much traffic a bandwidth() shaper will hold
+// before it starts discarding.
+//
+// A rate limiter with an unbounded queue is not a slow link, it is a memory
+// leak with latency: a sender that outruns the configured rate would be
+// buffered forever and never observe congestion. Real bottlenecks have finite
+// queues and drop when they fill, which is what makes a congestion-control
+// bug reproducible. Expressed as time rather than bytes so it means the same
+// thing at 1 Mbit and at 1 Gbit.
+const DefaultShaperBacklog = 250 * time.Millisecond
+
+// ParseRate converts a human rate to bytes per second.
+//
+// Bit units (the networking convention, and what "1mbps" means to everyone who
+// has configured a link) and byte units are both accepted, but byte units must
+// say so explicitly with "/s" — "1MB/s" is eight times "1mbit" and guessing
+// between them from letter case alone would be a silent factor-of-eight error.
+func ParseRate(s string) (bytesPerSec float64, err error) {
+	raw := strings.TrimSpace(s)
+	if raw == "" {
+		return 0, fmt.Errorf("rate is empty; want e.g. \"1mbit\", \"512kbps\" or \"2MB/s\"")
+	}
+	lower := strings.ToLower(raw)
+
+	// Longest suffixes first: "mbps" must not match the "bps" arm.
+	units := []struct {
+		suffix string
+		mult   float64 // to bits per second
+	}{
+		{"gbps", 1e9}, {"gbit", 1e9},
+		{"mbps", 1e6}, {"mbit", 1e6},
+		{"kbps", 1e3}, {"kbit", 1e3},
+		{"bps", 1}, {"bit", 1},
+	}
+	byteUnits := []struct {
+		suffix string
+		mult   float64 // to bytes per second
+	}{
+		{"gb/s", 1e9}, {"mb/s", 1e6}, {"kb/s", 1e3}, {"b/s", 1},
+	}
+
+	for _, u := range byteUnits {
+		if num, ok := strings.CutSuffix(lower, u.suffix); ok {
+			v, e := parsePositiveFloat(num)
+			if e != nil {
+				return 0, fmt.Errorf("rate %q: %w", raw, e)
+			}
+			return v * u.mult, nil
+		}
+	}
+	for _, u := range units {
+		if num, ok := strings.CutSuffix(lower, u.suffix); ok {
+			v, e := parsePositiveFloat(num)
+			if e != nil {
+				return 0, fmt.Errorf("rate %q: %w", raw, e)
+			}
+			return v * u.mult / 8, nil
+		}
+	}
+	return 0, fmt.Errorf(
+		"rate %q has no unit; want bits (\"1mbit\", \"512kbps\", \"1gbit\") "+
+			"or bytes (\"2MB/s\", \"64kB/s\")", raw)
+}
+
+func parsePositiveFloat(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("missing a number before the unit")
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", s)
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("must be positive, got %g", v)
+	}
+	return v, nil
+}
+
+// shaper paces one direction of the link.
+//
+// The model is a single server draining at bytesPerSec: each admitted packet
+// occupies the link for size/rate seconds, and the next packet leaves when the
+// one before it has finished. nextFree is that finish time, so the wait for an
+// arriving packet is simply how far nextFree is in the future — which is also
+// the current queue depth, expressed as time. One field, no separate byte
+// counter to keep in sync, and the backlog bound falls out of the same value.
+type shaper struct {
+	mu          sync.Mutex
+	bytesPerSec float64
+	maxBacklog  time.Duration
+	nextFree    time.Time
+
+	admitted atomic.Int64
+	dropped  atomic.Int64
+	// backlogPeak records the deepest queue observed, so a spec author can
+	// tell "the link was saturated" from "the link was irrelevant".
+	backlogPeakNanos atomic.Int64
+}
+
+func newShaper(bytesPerSec float64, maxBacklog time.Duration) *shaper {
+	if maxBacklog <= 0 {
+		maxBacklog = DefaultShaperBacklog
+	}
+	return &shaper{bytesPerSec: bytesPerSec, maxBacklog: maxBacklog}
+}
+
+// admit reserves link time for a packet of size bytes.
+//
+// Returns how long the packet must wait before it may be released, and whether
+// it was admitted at all: a packet arriving at a full queue is dropped, which
+// is what a real bottleneck does and what makes the sender notice.
+func (s *shaper) admit(size int, now time.Time) (wait time.Duration, ok bool) {
+	if size <= 0 {
+		return 0, true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.nextFree.Before(now) {
+		// Link went idle; no backlog to inherit.
+		s.nextFree = now
+	}
+	backlog := s.nextFree.Sub(now)
+	if backlog > s.maxBacklog {
+		s.dropped.Add(1)
+		return 0, false
+	}
+	if backlog.Nanoseconds() > s.backlogPeakNanos.Load() {
+		s.backlogPeakNanos.Store(backlog.Nanoseconds())
+	}
+	txTime := time.Duration(float64(size) / s.bytesPerSec * float64(time.Second))
+	s.nextFree = s.nextFree.Add(txTime)
+	s.admitted.Add(1)
+	return backlog, true
+}
+
+// Stats reports what the shaper did, so a run can distinguish a link that was
+// merely configured from one that actually bit.
+type ShaperStats struct {
+	Admitted    int64
+	Dropped     int64
+	PeakBacklog time.Duration
+}
+
+func (s *shaper) stats() ShaperStats {
+	return ShaperStats{
+		Admitted:    s.admitted.Load(),
+		Dropped:     s.dropped.Load(),
+		PeakBacklog: time.Duration(s.backlogPeakNanos.Load()),
+	}
+}

--- a/internal/netfault/shape_test.go
+++ b/internal/netfault/shape_test.go
@@ -1,0 +1,261 @@
+package netfault
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+)
+
+func TestParseRate(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64 // bytes per second
+	}{
+		// Bit units: the networking convention.
+		{"1bit", 0.125},
+		{"8bit", 1},
+		{"1kbit", 125},
+		{"1kbps", 125},
+		{"1mbit", 125000},
+		{"1mbps", 125000},
+		{"1Mbps", 125000}, // case-insensitive
+		{"1gbit", 125e6},
+		{"512kbps", 64000},
+		{"2.5mbit", 312500},
+		{" 1mbit ", 125000}, // surrounding space
+
+		// Byte units must say "/s" explicitly.
+		{"1B/s", 1},
+		{"1kB/s", 1e3},
+		{"2MB/s", 2e6},
+		{"1GB/s", 1e9},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseRate(tc.in)
+			if err != nil {
+				t.Fatalf("ParseRate(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseRate(%q) = %g B/s, want %g", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// "1MB/s" is eight times "1mbit". Guessing between them from letter case would
+// be a silent factor-of-eight error, so an unsuffixed number must be refused.
+func TestParseRate_Rejects(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantSub string
+	}{
+		{"", "empty"},
+		{"1000000", "no unit"},       // ambiguous: bits or bytes?
+		{"1", "no unit"},             //
+		{"fast", "no unit"},          //
+		{"mbit", "missing a number"}, // unit with no number
+		{"0mbit", "must be positive"},
+		{"-5mbit", "must be positive"},
+		{"abcmbit", "not a number"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			_, err := ParseRate(tc.in)
+			if err == nil {
+				t.Fatalf("ParseRate(%q) should have failed", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error should mention %q; got %q", tc.wantSub, err.Error())
+			}
+		})
+	}
+}
+
+// The first packet on an idle link goes out immediately; the next waits for
+// the first to finish transmitting.
+func TestShaper_PacesSerially(t *testing.T) {
+	// 1000 B/s → a 100-byte packet occupies the link for 100ms.
+	sh := newShaper(1000, time.Second)
+	now := time.Unix(0, 0)
+
+	wait, ok := sh.admit(100, now)
+	if !ok || wait != 0 {
+		t.Fatalf("first packet on an idle link: wait=%v ok=%v, want 0/true", wait, ok)
+	}
+	wait, ok = sh.admit(100, now)
+	if !ok || wait != 100*time.Millisecond {
+		t.Fatalf("second packet: wait=%v ok=%v, want 100ms/true", wait, ok)
+	}
+	wait, ok = sh.admit(100, now)
+	if !ok || wait != 200*time.Millisecond {
+		t.Fatalf("third packet: wait=%v ok=%v, want 200ms/true", wait, ok)
+	}
+}
+
+// An idle link must not bank credit indefinitely — the backlog resets to zero
+// rather than going negative and letting a burst through for free.
+func TestShaper_IdleLinkDoesNotBankCredit(t *testing.T) {
+	sh := newShaper(1000, time.Second)
+	now := time.Unix(0, 0)
+
+	if _, ok := sh.admit(100, now); !ok {
+		t.Fatal("first admit failed")
+	}
+	// Long after the link drained.
+	later := now.Add(10 * time.Second)
+	wait, ok := sh.admit(100, later)
+	if !ok || wait != 0 {
+		t.Errorf("after a long idle: wait=%v ok=%v, want 0/true", wait, ok)
+	}
+	// And the one after it queues normally, not from a banked surplus.
+	wait, ok = sh.admit(100, later)
+	if !ok || wait != 100*time.Millisecond {
+		t.Errorf("next packet: wait=%v ok=%v, want 100ms/true", wait, ok)
+	}
+}
+
+// A rate limiter with an unbounded queue is a memory leak with latency: the
+// sender never observes congestion. Real bottlenecks drop, and the drop is
+// what makes a congestion-control bug reproducible.
+func TestShaper_DropsWhenBacklogExceeded(t *testing.T) {
+	sh := newShaper(1000, 250*time.Millisecond) // 250ms of queue
+	now := time.Unix(0, 0)
+
+	// Each 100-byte packet buys 100ms of backlog.
+	for i := 0; i < 3; i++ {
+		if _, ok := sh.admit(100, now); !ok {
+			t.Fatalf("packet %d should have been admitted", i)
+		}
+	}
+	// Backlog is now 300ms > 250ms, so the next one is dropped.
+	if _, ok := sh.admit(100, now); ok {
+		t.Error("packet admitted with the queue over its limit; the shaper must drop")
+	}
+	if got := sh.stats().Dropped; got != 1 {
+		t.Errorf("Dropped = %d, want 1", got)
+	}
+	if got := sh.stats().Admitted; got != 3 {
+		t.Errorf("Admitted = %d, want 3", got)
+	}
+
+	// Once the link drains, it accepts again — a full queue is transient.
+	if _, ok := sh.admit(100, now.Add(time.Second)); !ok {
+		t.Error("shaper must recover once the backlog drains")
+	}
+}
+
+func TestShaper_RecordsPeakBacklog(t *testing.T) {
+	sh := newShaper(1000, time.Second)
+	now := time.Unix(0, 0)
+	for i := 0; i < 4; i++ {
+		sh.admit(100, now)
+	}
+	// Waits were 0, 100ms, 200ms, 300ms — peak observed is 300ms.
+	if got := sh.stats().PeakBacklog; got != 300*time.Millisecond {
+		t.Errorf("PeakBacklog = %v, want 300ms", got)
+	}
+}
+
+func TestShaper_ZeroSizeIsFree(t *testing.T) {
+	sh := newShaper(1000, time.Second)
+	wait, ok := sh.admit(0, time.Unix(0, 0))
+	if !ok || wait != 0 {
+		t.Errorf("a zero-length packet must not consume link time: wait=%v ok=%v", wait, ok)
+	}
+}
+
+func TestDefaultBacklogUsedWhenUnset(t *testing.T) {
+	sh := newShaper(1000, 0)
+	if sh.maxBacklog != DefaultShaperBacklog {
+		t.Errorf("maxBacklog = %v, want the default %v", sh.maxBacklog, DefaultShaperBacklog)
+	}
+}
+
+// ─── endpoint-level ────────────────────────────────────────────────────────
+
+// mtu() must change what netstack believes the link is, not merely filter
+// oversized packets. MTU() is what netstack reads to pick a TCP MSS and an IP
+// fragmentation threshold.
+func TestEndpointMTUOverride(t *testing.T) {
+	fe, _, lower := newTestEndpoint(t, Options{})
+	base := lower.MTU()
+	if got := fe.MTU(); got != base {
+		t.Fatalf("unshaped MTU = %d, want the lower endpoint's %d", got, base)
+	}
+
+	fe.SetMTU(576)
+	if got := fe.MTU(); got != 576 {
+		t.Errorf("MTU after override = %d, want 576", got)
+	}
+
+	fe.SetMTU(0)
+	if got := fe.MTU(); got != base {
+		t.Errorf("MTU after clearing = %d, want the lower endpoint's %d", got, base)
+	}
+}
+
+// Bandwidth must apply with no rules installed: it describes the link, not a
+// packet. The no-rules fast path is exactly where a naive implementation would
+// skip it.
+func TestBandwidthAppliesWithNoRules(t *testing.T) {
+	clock := newFakeClock()
+	fe, _, lower := newTestEndpoint(t, Options{Clock: clock})
+	// No SetRules call at all.
+
+	// 1000 B/s. defaultPkt is small, so give each packet a known cost by
+	// checking relative ordering rather than exact byte math.
+	fe.SetBandwidth(DirS2C, 1000, time.Second)
+
+	writeOne(fe, makePacket(defaultPkt()))
+	if got := lower.count(); got != 1 {
+		t.Fatalf("first packet on an idle link should go straight out, got %d", got)
+	}
+
+	writeOne(fe, makePacket(defaultPkt()))
+	if got := lower.count(); got != 1 {
+		t.Fatalf("second packet should have been paced, but %d were written", got)
+	}
+	clock.Advance(time.Second)
+	if !waitFor(t, 2*time.Second, func() bool { return lower.count() == 2 }) {
+		t.Fatalf("paced packet never released (count=%d)", lower.count())
+	}
+}
+
+func TestBandwidthDirectionIsRespected(t *testing.T) {
+	clock := newFakeClock()
+	fe, disp, _ := newTestEndpoint(t, Options{Clock: clock})
+	// Shape only egress; ingress must stay at full speed.
+	fe.SetBandwidth(DirS2C, 1000, time.Second)
+
+	for i := 0; i < 5; i++ {
+		fe.DeliverNetworkPacket(header.IPv4ProtocolNumber, makePacket(defaultPkt()))
+	}
+	if got := disp.count(); got != 5 {
+		t.Errorf("ingress delivered %d of 5; an s2c shaper must not pace c2s", got)
+	}
+}
+
+func TestClearShapersRestoresTheLink(t *testing.T) {
+	fe, _, lower := newTestEndpoint(t, Options{})
+	base := lower.MTU()
+
+	fe.SetBandwidth(DirBoth, 1000, time.Second)
+	fe.SetMTU(576)
+	if _, ok := fe.ShaperStatsFor(DirS2C); !ok {
+		t.Fatal("expected an s2c shaper to be installed")
+	}
+
+	fe.ClearShapers()
+	if _, ok := fe.ShaperStatsFor(DirS2C); ok {
+		t.Error("s2c shaper survived ClearShapers")
+	}
+	if _, ok := fe.ShaperStatsFor(DirC2S); ok {
+		t.Error("c2s shaper survived ClearShapers")
+	}
+	if got := fe.MTU(); got != base {
+		t.Errorf("MTU = %d after ClearShapers, want %d", got, base)
+	}
+}

--- a/internal/plan/enumerate.go
+++ b/internal/plan/enumerate.go
@@ -65,12 +65,20 @@ func buildTests(rt *star.Runtime) []PlanTest {
 	seen := make(map[string]bool)
 	var tests []PlanTest
 
+	// choose() axes are discovered statically (star.ChooseAxesByTest). The
+	// runtime discovers them by executing a body, which `plan` cannot do, so
+	// without this every choose()-driven test counted as one instance and
+	// --check-cost was blind to the main fan-out construct.
+	chooseAxes := rt.ChooseAxesByTest()
+
 	for _, name := range sortedStrings(defNames) {
-		tests = append(tests, PlanTest{
+		entry := PlanTest{
 			Name:      name,
 			Kind:      KindDef,
 			Instances: 1,
-		})
+		}
+		applyChooseAxes(&entry, chooseAxes[name])
+		tests = append(tests, entry)
 		seen[name] = true
 	}
 
@@ -312,12 +320,41 @@ func buildTopology(rt *star.Runtime) PlanTopology {
 	return PlanTopology{Services: out}
 }
 
+// applyChooseAxes multiplies a test's instance count by its choose() fan-out
+// and records the axes so the rendered tree shows where the cost comes from.
+//
+// Estimated is set when any axis had an option list the scanner could not read
+// (a computed list, a variable). The count is then a floor, and every renderer
+// must say so — a cost gate that silently rounds down is how the missing
+// feature read as a working one for two releases.
+func applyChooseAxes(entry *PlanTest, axes []star.ChooseAxis) {
+	if len(axes) == 0 {
+		return
+	}
+	planAxes := make([]PlanAxis, 0, len(axes))
+	for _, a := range axes {
+		planAxes = append(planAxes, PlanAxis{Name: a.Name, Values: a.Values, Estimated: !a.Known})
+	}
+	entry.Instances *= star.ChooseLeafCount(axes)
+	entry.Compositions = append(entry.Compositions, PlanComposition{
+		Kind: CompositionChoose,
+		Axes: planAxes,
+	})
+	if !star.ChooseAxesComplete(axes) {
+		entry.Estimated = true
+	}
+}
+
 func computeTotals(tests []PlanTest) PlanTotals {
 	n := 0
+	estimated := false
 	for _, t := range tests {
 		n += t.Instances
+		if t.Estimated {
+			estimated = true
+		}
 	}
-	return PlanTotals{Instances: n}
+	return PlanTotals{Instances: n, Estimated: estimated}
 }
 
 // sortedKeys is the generic map-key sorter used throughout this file.

--- a/internal/plan/enumerate_test.go
+++ b/internal/plan/enumerate_test.go
@@ -307,3 +307,100 @@ def test_x(): return None
 		}
 	}
 }
+
+// A choose()-driven test must contribute its full fan-out to the plan tree.
+// Before v0.14.1 the runtime discovered axes by executing a body, which `plan`
+// cannot do, so every such test counted as one instance — the exploration spec
+// that runs 24 leaves reported "Total: 2 plan instances", and
+// --check-cost --max-instances was blind to the construct most likely to blow
+// a budget.
+func TestEnumerate_ChooseAxesCountTowardInstances(t *testing.T) {
+	rt := newRuntime(t)
+	src := `
+def test_transfer():
+    a = choose("warmup", [0, 10, 40])
+    b = choose("gap", ["0ms", "400ms", "1200ms"])
+    c = choose("hold", ["100ms", "900ms"])
+
+def test_snapshot():
+    d = choose("behind", [25, 120, 400])
+    e = choose("snap_when", ["during", "after"])
+
+def test_plain():
+    assert_true(True, "")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	pt := Enumerate(rt)
+
+	byName := map[string]PlanTest{}
+	for _, tst := range pt.Tests {
+		byName[tst.Name] = tst
+	}
+	if got := byName["test_transfer"].Instances; got != 18 {
+		t.Errorf("test_transfer instances = %d, want 18", got)
+	}
+	if got := byName["test_snapshot"].Instances; got != 6 {
+		t.Errorf("test_snapshot instances = %d, want 6", got)
+	}
+	if got := byName["test_plain"].Instances; got != 1 {
+		t.Errorf("test_plain instances = %d, want 1", got)
+	}
+	if pt.Totals.Instances != 25 {
+		t.Errorf("total instances = %d, want 25 (18+6+1)", pt.Totals.Instances)
+	}
+	if pt.Totals.Estimated {
+		t.Error("all option lists are literal; the total must not be flagged as an estimate")
+	}
+
+	// The axes must be recorded, not just counted — the rendered tree shows
+	// the user where the cost comes from.
+	comps := byName["test_transfer"].Compositions
+	if len(comps) != 1 || comps[0].Kind != CompositionChoose {
+		t.Fatalf("expected one choose composition, got %+v", comps)
+	}
+	if len(comps[0].Axes) != 3 {
+		t.Errorf("expected 3 axes, got %d", len(comps[0].Axes))
+	}
+}
+
+// A computed option list must widen the total to a lower bound rather than
+// contribute a silent factor of 1. A cost gate that rounds down is trusted and
+// wrong, which is worse than absent.
+func TestEnumerate_ComputedChooseListMarksEstimate(t *testing.T) {
+	rt := newRuntime(t)
+	src := `
+OPTS = [1, 2, 3, 4]
+def test_dyn():
+    a = choose("dyn", OPTS)
+    b = choose("lit", ["x", "y"])
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	pt := Enumerate(rt)
+	if !pt.Totals.Estimated {
+		t.Error("totals must be flagged estimated when an axis is not statically readable")
+	}
+	if pt.Totals.Instances != 2 {
+		t.Errorf("instances = %d, want 2 (lower bound: 1 unknown x 2 literal)", pt.Totals.Instances)
+	}
+	var found bool
+	for _, c := range pt.Tests[0].Compositions {
+		for _, ax := range c.Axes {
+			if ax.Name == "dyn" {
+				found = true
+				if !ax.Estimated {
+					t.Error("the unreadable axis must be marked Estimated")
+				}
+				if len(ax.Values) != 0 {
+					t.Errorf("an unreadable axis must not claim values, got %v", ax.Values)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("the computed axis should still appear in the tree")
+	}
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -85,6 +85,12 @@ type PlanTest struct {
 	// duration string form ("30s"). Empty for legacy tests, which run
 	// under the 3-minute infrastructure ceiling only.
 	Timeout string `json:"timeout,omitempty"`
+	// Estimated marks Instances as a LOWER BOUND, not an exact count. Set
+	// when a choose() axis had an option list static analysis could not read
+	// (a computed list, a variable). Renderers must show it; a cost estimate
+	// that hides its own uncertainty is how the pre-v0.14.1 plan tree read as
+	// authoritative while reporting 2 instances for a 24-leaf spec.
+	Estimated bool `json:"estimated,omitempty"`
 }
 
 // PlanTestKind is the discriminator for PlanTest entries.
@@ -120,7 +126,7 @@ type PlanCompositionKind string
 const (
 	// CompositionFaultMatrix — fault_matrix's scenarios × faults cross product.
 	CompositionFaultMatrix PlanCompositionKind = "fault_matrix"
-	// CompositionChoose — reserved for RFC-043's choose(); not emitted in v0.13.0-rc1.
+	// CompositionChoose — RFC-043's choose(), discovered by static analysis.
 	CompositionChoose PlanCompositionKind = "choose"
 )
 
@@ -130,6 +136,10 @@ const (
 type PlanAxis struct {
 	Name   string   `json:"name"`
 	Values []string `json:"values"`
+	// Estimated marks an axis whose option list static analysis could not
+	// read. Values is then empty — which must NOT be rendered as "[]", since
+	// an empty list reads as "zero options" when it means "unknown size".
+	Estimated bool `json:"estimated,omitempty"`
 }
 
 // PlanTotals summarizes the cross-product cost across the plan tree.
@@ -137,6 +147,9 @@ type PlanAxis struct {
 // counters (RFC-042 §5.9) land with rc2.
 type PlanTotals struct {
 	Instances int `json:"instances"`
+	// Estimated is true when any test's Instances is a lower bound — see
+	// PlanTest.Estimated. Cost gates should treat the total as ">=".
+	Estimated bool `json:"estimated,omitempty"`
 }
 
 // PlanTopology snapshots services. Dependency edges + their coverage

--- a/internal/star/assume_sandbox.go
+++ b/internal/star/assume_sandbox.go
@@ -52,6 +52,7 @@ var assumeSandboxDenylist = map[string]string{
 	// (top-level assume) or the body-entry path (per-test assume).
 	"await_stable": "await_* primitives block the test body and cannot be called from a predicate",
 	"await_event":  "await_* primitives block the test body and cannot be called from a predicate",
+	"sleep":        "sleep() blocks the test body and cannot be called from a predicate",
 
 	// Assertion builtins — predicates signal failure via their bool
 	// return value, not via assert_*.

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -162,6 +162,11 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		// the per-test context; no own timeout.
 		"await_stable": starlark.NewBuiltin("await_stable", rt.builtinAwaitStable),
 		"await_event":  starlark.NewBuiltin("await_event", rt.builtinAwaitEvent),
+		// Unconditional wall-clock wait. Both await_* forms are
+		// conditional on the SUT, and neither can hold a fault open
+		// for a fixed time — an active fault emits the very events
+		// that stop await_stable quiescing. See sleep.go.
+		"sleep": starlark.NewBuiltin("sleep", rt.builtinSleep),
 		// Declarative test definition (RFC-041 §8.6). Augments the
 		// def test_*() function-style declaration with per-test
 		// timeout, expect=, setup=, and terminate_when= temporal

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -167,6 +167,10 @@ func (rt *Runtime) builtins() starlark.StringDict {
 		// for a fixed time — an active fault emits the very events
 		// that stop await_stable quiescing. See sleep.go.
 		"sleep": starlark.NewBuiltin("sleep", rt.builtinSleep),
+		// Link shapers (RFC-054, deferred from v0.14.0). No matcher: these
+		// describe the link, not any packet crossing it. See shaper.go.
+		"bandwidth": starlark.NewBuiltin("bandwidth", rt.builtinBandwidth),
+		"mtu":       starlark.NewBuiltin("mtu", rt.builtinMTU),
 		// Declarative test definition (RFC-041 §8.6). Augments the
 		// def test_*() function-style declaration with per-test
 		// timeout, expect=, setup=, and terminate_when= temporal

--- a/internal/star/cancel_test.go
+++ b/internal/star/cancel_test.go
@@ -1,0 +1,97 @@
+package star
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// An interrupted suite must stop, not race through the remainder.
+//
+// Before this, RunAll had no cancellation check anywhere in its loop. On
+// Ctrl-C or SIGTERM the context was cancelled but the walk continued: every
+// remaining test started its services, inherited an already-dead context,
+// failed instantly, and was recorded as INCONCLUSIVE. An 18-leaf timing search
+// interrupted after one leaf reported "1 passed, 17 inconclusive" — seventeen
+// verdicts for tests that never ran.
+func TestRunAll_CancelledBeforeStartRunsNothing(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def test_one():
+    assert_true(True, "")
+
+def test_two():
+    assert_true(True, "")
+
+def test_three():
+    assert_true(True, "")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // interrupted before the first test gets a chance
+
+	result, err := rt.RunAll(ctx, RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+
+	if result.Matched != 3 {
+		t.Errorf("Matched = %d, want 3 (discovery is unaffected by cancellation)", result.Matched)
+	}
+	if result.Aborted != 3 {
+		t.Errorf("Aborted = %d, want 3", result.Aborted)
+	}
+	// The important half: a cancelled run must not manufacture verdicts.
+	if result.Pass != 0 || result.Fail != 0 || result.Inconclusive != 0 {
+		t.Errorf("cancelled suite produced verdicts: pass=%d fail=%d inconclusive=%d; want all 0",
+			result.Pass, result.Fail, result.Inconclusive)
+	}
+	if len(result.Tests) != 0 {
+		t.Errorf("cancelled suite recorded %d test results; want 0", len(result.Tests))
+	}
+}
+
+// Aborted must stay distinct from Inconclusive. Both mean "no verdict", but
+// they need different responses: inconclusive is a property of the test (it
+// timed out with pending expectations), aborted is a property of the run
+// (someone stopped it). Folding them together would let an interrupted CI job
+// look like a flaky suite.
+func TestSuiteResult_AbortedIsNotInconclusive(t *testing.T) {
+	var s SuiteResult
+	s.Aborted = 4
+	if s.Inconclusive != 0 {
+		t.Fatal("Aborted must not increment Inconclusive")
+	}
+}
+
+// A spec with no tests must not report an abort just because nothing ran.
+func TestRunAll_LiveContextDoesNotAbort(t *testing.T) {
+	rt := New(testLogger())
+	if err := rt.LoadString("spec.star", "def test_ok():\n    assert_true(True, \"\")\n"); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	result, err := rt.RunAll(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if result.Aborted != 0 {
+		t.Errorf("Aborted = %d on an uninterrupted run, want 0", result.Aborted)
+	}
+	if result.Pass != 1 {
+		t.Errorf("Pass = %d, want 1 — the test should actually have run", result.Pass)
+	}
+}
+
+// The summary wording is load-bearing: "not run" is the claim, and it must not
+// be reachable by any phrasing that implies a measured outcome.
+func TestAbortedSummaryWording(t *testing.T) {
+	for _, banned := range []string{"inconclusive", "failed", "passed"} {
+		const phrase = "not run (interrupted)"
+		if strings.Contains(phrase, banned) {
+			t.Errorf("abort wording %q contains %q, which implies a verdict", phrase, banned)
+		}
+	}
+}

--- a/internal/star/chooseaxes.go
+++ b/internal/star/chooseaxes.go
@@ -1,0 +1,214 @@
+package star
+
+import (
+	"fmt"
+	"sort"
+
+	"go.starlark.net/syntax"
+)
+
+// Static discovery of choose() axes, and why `faultbox plan` needs it.
+//
+// The plan tree is static analysis: it loads the spec and walks the declared
+// tests without launching services or executing bodies. choose() axes are
+// discovered the other way round — runTestFanout executes the body once
+// against a synthetic discovery leaf and collects the choose() calls that
+// actually ran. The two approaches cannot meet: a body calls into services, so
+// `plan` cannot execute it.
+//
+// The consequence shipped in v0.13.0 and survived until v0.14.1: `plan`
+// reported "Total: 2 plan instances" for a spec that runs 24 leaves. That is
+// not merely imprecise — `--check-cost --max-instances N` exists to catch
+// fan-out blowups before they run, and it was blind to the single construct
+// most likely to cause one. A cost gate that under-reports is worse than no
+// cost gate, because it is trusted.
+//
+// So: parse the spec and read the choose() calls out of the AST. This gives
+// the right answer whenever the option list is a literal, which is the
+// overwhelmingly common form. Where it is not, the axis is reported with an
+// unknown cardinality rather than silently assumed to be 1 — an estimate that
+// is honest about its gaps is useful; one that quietly rounds down is how the
+// original bug read as a working feature.
+
+// ChooseAxis is one statically-discovered choose() axis.
+type ChooseAxis struct {
+	// Name is the axis label from choose("name", [...]). Anonymous
+	// choose([...]) calls get a positional placeholder, since they still
+	// multiply the leaf count even though assume() cannot reference them.
+	Name string
+	// Values are the stringified options, empty when Known is false.
+	Values []string
+	// Known reports whether the option list was a literal the scanner could
+	// read. When false, Cardinality is a floor of 1 and the axis is rendered
+	// with a "?" so the total is visibly a lower bound.
+	Known bool
+}
+
+// Cardinality is the number of leaves this axis multiplies by.
+func (a ChooseAxis) Cardinality() int {
+	if !a.Known || len(a.Values) == 0 {
+		return 1
+	}
+	return len(a.Values)
+}
+
+// ChooseAxesByTest maps a test function name to the choose() axes reachable
+// from its body, keyed by the discoverable "test_" name.
+//
+// Scope is the enclosing top-level def: a choose() inside a helper called by
+// the body is attributed to no test, because static analysis cannot resolve
+// the call graph without executing it. Under-reporting there is deliberate and
+// visible — the alternative is guessing, and a plan tree that invents axes is
+// worse than one that admits it missed some.
+func (rt *Runtime) ChooseAxesByTest() map[string][]ChooseAxis {
+	return chooseAxesInSource(rt.rootSpec, rt.sourceText)
+}
+
+func chooseAxesInSource(filename, src string) map[string][]ChooseAxis {
+	if src == "" {
+		return nil
+	}
+	file, err := syntax.Parse(filename, src, 0)
+	if err != nil {
+		// A spec that does not parse has a canonical error from ExecFile;
+		// the plan tree is not the place to report it a second time.
+		return nil
+	}
+
+	out := make(map[string][]ChooseAxis)
+	for _, stmt := range file.Stmts {
+		def, ok := stmt.(*syntax.DefStmt)
+		if !ok {
+			continue
+		}
+		axes := chooseAxesInNode(def)
+		if len(axes) > 0 {
+			out[def.Name.Name] = axes
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// chooseAxesInNode collects choose() calls in source order. Order matters:
+// enumerateLeaves fans out in axis order, so a plan tree that reordered them
+// would print a different leaf sequence than the run produces.
+func chooseAxesInNode(root syntax.Node) []ChooseAxis {
+	var axes []ChooseAxis
+	anon := 0
+	syntax.Walk(root, func(n syntax.Node) bool {
+		call, ok := n.(*syntax.CallExpr)
+		if !ok {
+			return true
+		}
+		callee, ok := call.Fn.(*syntax.Ident)
+		if !ok || callee.Name != "choose" {
+			return true
+		}
+		axis := ChooseAxis{}
+		switch len(call.Args) {
+		case 1:
+			// choose([...]) — anonymous, still multiplies the leaf count.
+			anon++
+			axis.Name = fmt.Sprintf("choose#%d", anon)
+			axis.Values, axis.Known = literalOptions(call.Args[0])
+		case 2:
+			// choose("name", [...])
+			name, ok := stringLiteral(call.Args[0])
+			if !ok {
+				anon++
+				name = fmt.Sprintf("choose#%d", anon)
+			}
+			axis.Name = name
+			axis.Values, axis.Known = literalOptions(call.Args[1])
+		default:
+			// Malformed; the runtime reports it properly at load time.
+			return true
+		}
+		axes = append(axes, axis)
+		return true
+	})
+	return axes
+}
+
+// literalOptions reads a list literal's elements. Non-literal elements are
+// stringified structurally where possible so the plan tree still shows the
+// right cardinality — the count is what a cost gate needs; the labels are for
+// humans.
+func literalOptions(n syntax.Node) (values []string, known bool) {
+	list, ok := n.(*syntax.ListExpr)
+	if !ok {
+		return nil, false
+	}
+	for _, el := range list.List {
+		values = append(values, literalString(el))
+	}
+	return values, true
+}
+
+func stringLiteral(n syntax.Node) (string, bool) {
+	lit, ok := n.(*syntax.Literal)
+	if !ok {
+		return "", false
+	}
+	s, ok := lit.Value.(string)
+	return s, ok
+}
+
+// literalString renders one option for display. Anything that is not a plain
+// literal becomes "<expr>": it occupies a slot in the cross product, which is
+// what the count depends on, but its value is not knowable without executing.
+func literalString(n syntax.Node) string {
+	if lit, ok := n.(*syntax.Literal); ok {
+		switch v := lit.Value.(type) {
+		case string:
+			return v
+		default:
+			return fmt.Sprint(v)
+		}
+	}
+	if id, ok := n.(*syntax.Ident); ok {
+		switch id.Name {
+		case "True", "False", "None":
+			return id.Name
+		}
+		return id.Name
+	}
+	return "<expr>"
+}
+
+// ChooseLeafCount is the number of leaves the axes fan out to — the product of
+// their cardinalities, or 1 when there are none.
+func ChooseLeafCount(axes []ChooseAxis) int {
+	n := 1
+	for _, a := range axes {
+		n *= a.Cardinality()
+	}
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// ChooseAxesComplete reports whether every axis had a readable option list. A
+// false here is what a renderer turns into "at least N" rather than "N".
+func ChooseAxesComplete(axes []ChooseAxis) bool {
+	for _, a := range axes {
+		if !a.Known {
+			return false
+		}
+	}
+	return true
+}
+
+// sortedAxisNames is a test/debug helper kept next to the type it describes.
+func sortedAxisNames(axes []ChooseAxis) []string {
+	names := make([]string, 0, len(axes))
+	for _, a := range axes {
+		names = append(names, a.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/star/chooseaxes_test.go
+++ b/internal/star/chooseaxes_test.go
@@ -1,0 +1,151 @@
+package star
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestChooseAxes_LiteralLists(t *testing.T) {
+	src := `
+def test_timing():
+    warmup = choose("warmup", [0, 10, 40])
+    gap    = choose("gap", ["0ms", "400ms", "1200ms"])
+    hold   = choose("hold", ["100ms", "900ms"])
+`
+	axes := chooseAxesInSource("spec.star", src)["test_timing"]
+	if len(axes) != 3 {
+		t.Fatalf("got %d axes, want 3: %v", len(axes), sortedAxisNames(axes))
+	}
+	// Source order, not sorted: enumerateLeaves fans out in axis order, so a
+	// reordered plan tree would print a different leaf sequence than the run.
+	if got := []string{axes[0].Name, axes[1].Name, axes[2].Name}; !reflect.DeepEqual(
+		got, []string{"warmup", "gap", "hold"}) {
+		t.Errorf("axis order = %v, want [warmup gap hold]", got)
+	}
+	if n := ChooseLeafCount(axes); n != 18 {
+		t.Errorf("leaf count = %d, want 18 (3*3*2)", n)
+	}
+	if !ChooseAxesComplete(axes) {
+		t.Error("all option lists are literals; the result should not be an estimate")
+	}
+	if got := axes[1].Values; !reflect.DeepEqual(got, []string{"0ms", "400ms", "1200ms"}) {
+		t.Errorf("gap values = %v", got)
+	}
+}
+
+// The count is what a cost gate depends on, so a computed list must widen the
+// estimate rather than silently contribute a factor of 1 that looks exact.
+func TestChooseAxes_ComputedListIsEstimated(t *testing.T) {
+	src := `
+OPTS = [1, 2, 3]
+def test_dyn():
+    a = choose("dyn", OPTS)
+    b = choose("lit", ["x", "y"])
+`
+	axes := chooseAxesInSource("spec.star", src)["test_dyn"]
+	if len(axes) != 2 {
+		t.Fatalf("got %d axes, want 2", len(axes))
+	}
+	if axes[0].Known {
+		t.Error("an axis over a variable must not claim a known option list")
+	}
+	if !axes[1].Known {
+		t.Error("a literal list must be readable")
+	}
+	if ChooseAxesComplete(axes) {
+		t.Error("a spec with one unreadable axis must report as estimated")
+	}
+	// Floor of 1 for the unknown axis: 1 * 2.
+	if n := ChooseLeafCount(axes); n != 2 {
+		t.Errorf("leaf count = %d, want 2 (lower bound)", n)
+	}
+}
+
+// Anonymous choose([...]) still multiplies the leaf count even though assume()
+// cannot name it. Dropping it would under-report the cost.
+func TestChooseAxes_AnonymousStillCounts(t *testing.T) {
+	src := `
+def test_anon():
+    a = choose([1, 2, 3])
+    b = choose([True, False])
+`
+	axes := chooseAxesInSource("spec.star", src)["test_anon"]
+	if len(axes) != 2 {
+		t.Fatalf("got %d axes, want 2", len(axes))
+	}
+	if n := ChooseLeafCount(axes); n != 6 {
+		t.Errorf("leaf count = %d, want 6", n)
+	}
+	for _, a := range axes {
+		if a.Name == "" {
+			t.Error("anonymous axes still need a display label")
+		}
+	}
+}
+
+func TestChooseAxes_NoChooseCalls(t *testing.T) {
+	src := `
+def test_plain():
+    assert_true(True, "")
+`
+	if got := chooseAxesInSource("spec.star", src); len(got) != 0 {
+		t.Errorf("a spec without choose() should yield no axes, got %v", got)
+	}
+	if n := ChooseLeafCount(nil); n != 1 {
+		t.Errorf("no axes must mean one leaf, got %d", n)
+	}
+}
+
+// A choose() inside a helper is attributed to no test: static analysis cannot
+// resolve the call graph without executing it. Under-reporting here is
+// deliberate — the alternative is inventing axes.
+func TestChooseAxes_HelperCallsNotAttributed(t *testing.T) {
+	src := `
+def helper():
+    return choose("hidden", [1, 2])
+
+def test_uses_helper():
+    x = helper()
+`
+	axes := chooseAxesInSource("spec.star", src)
+	if len(axes["test_uses_helper"]) != 0 {
+		t.Errorf("choose() in a helper must not be attributed to the caller, got %v",
+			axes["test_uses_helper"])
+	}
+	if len(axes["helper"]) != 1 {
+		t.Errorf("the helper itself should still record its axis, got %v", axes["helper"])
+	}
+}
+
+// A spec that does not parse must not panic or invent axes — the canonical
+// syntax error comes from ExecFile.
+func TestChooseAxes_UnparseableSourceIsSilent(t *testing.T) {
+	if got := chooseAxesInSource("spec.star", "def test_x(:\n"); got != nil {
+		t.Errorf("unparseable source should yield nil, got %v", got)
+	}
+	if got := chooseAxesInSource("spec.star", ""); got != nil {
+		t.Errorf("empty source should yield nil, got %v", got)
+	}
+}
+
+// End-to-end through the runtime, which is how plan.Enumerate reaches it.
+func TestChooseAxesByTest_ThroughRuntime(t *testing.T) {
+	rt := New(testLogger())
+	src := `
+def test_a():
+    x = choose("k", ["p", "q"])
+
+def test_b():
+    assert_true(True, "")
+`
+	if err := rt.LoadString("spec.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	byTest := rt.ChooseAxesByTest()
+	if n := ChooseLeafCount(byTest["test_a"]); n != 2 {
+		t.Errorf("test_a leaf count = %d, want 2", n)
+	}
+	if n := ChooseLeafCount(byTest["test_b"]); n != 1 {
+		t.Errorf("test_b leaf count = %d, want 1", n)
+	}
+}

--- a/internal/star/monitor_sandbox.go
+++ b/internal/star/monitor_sandbox.go
@@ -57,6 +57,7 @@ var monitorSandboxDenylist = map[string]string{
 	// Body-blocking primitives (PR 5) — would deadlock the event-log subscriber.
 	"await_stable": "await_* primitives block the test body and cannot be called from a monitor",
 	"await_event":  "await_* primitives block the test body and cannot be called from a monitor",
+	"sleep":        "sleep() blocks the event-log subscriber and cannot be called from a monitor",
 
 	// Determinism / trace family — config or runtime-mutating.
 	"determinism": "determinism() is a spec-load declaration",

--- a/internal/star/packetgateway_wire.go
+++ b/internal/star/packetgateway_wire.go
@@ -83,6 +83,16 @@ func (rt *Runtime) ensurePacketGateway() (*netfault.Gateway, error) {
 	return gw, nil
 }
 
+// packetGatewayHandle returns the running gateway, or nil when none is up.
+// Unlike ensurePacketGateway it never starts one — teardown paths must not
+// create a TUN device on their way out.
+func (rt *Runtime) packetGatewayHandle() *netfault.Gateway {
+	st := rt.packetGW
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.gw
+}
+
 // gatewaySeed returns the spec seed for probabilistic packet rules, or 0 when
 // the spec did not set one — matching how the rest of the runtime treats an
 // unset seed.

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -187,6 +187,17 @@ type SuiteResult struct {
 	// the way out is marked partial so downstream tools (and humans)
 	// know not to interpret silence as success. Issue #76.
 	Crash *CrashInfo `json:"crash,omitempty"`
+
+	// Aborted counts tests that were never attempted because the run was
+	// cancelled — Ctrl-C, SIGTERM, or a CI job timeout.
+	//
+	// They are NOT counted as Inconclusive. A cancelled run used to walk the
+	// whole remaining plan, starting and stopping services for each test only
+	// for its already-dead context to fail it instantly; an 18-leaf search
+	// interrupted after one leaf reported "1 passed, 17 inconclusive". Those
+	// 17 were not indeterminate results, they were results that do not exist,
+	// and recording them as verdicts overstates what the run measured.
+	Aborted int `json:"aborted,omitempty"`
 }
 
 // CrashInfo captures what was known at the moment a panic
@@ -928,6 +939,22 @@ func matchTestFilter(testName, filter string, matrixBases map[string]bool) bool 
 	return false
 }
 
+// Close releases process-level resources the runtime owns — today, the packet
+// gateway's TUN device.
+//
+// RunAll tears the gateway down alongside the services it fronted, so on the
+// happy path this is a no-op. It exists for the paths RunAll does not finish:
+// a cancelled context (SIGINT/SIGTERM), a spec that errored mid-suite, or
+// reuse=True services that deliberately kept their gateway alive past the last
+// test. A TUN device created with `ip tuntap add` is persistent — it outlives
+// the process unconditionally — so "nobody ran the teardown" does not mean a
+// tidy exit, it means a device left on the host.
+//
+// Idempotent, and safe to defer immediately after New().
+func (rt *Runtime) Close() {
+	rt.closePacketGateway()
+}
+
 // RunAll executes all (or filtered) test functions.
 func (rt *Runtime) RunAll(ctx context.Context, cfg RunConfig) (*SuiteResult, error) {
 	start := time.Now()
@@ -959,14 +986,29 @@ func (rt *Runtime) RunAll(ctx context.Context, cfg RunConfig) (*SuiteResult, err
 	// Auto-calculate permutation count for --explore=all without --runs.
 	autoExplore := cfg.ExploreMode == "all" && cfg.Runs <= 0
 
+	// cancelled reports whether the run has been interrupted. Checked between
+	// tests and between leaves so Ctrl-C / SIGTERM stops the suite instead of
+	// racing through the remainder: every derived per-test context is already
+	// dead, so each would start services, fail instantly, and be recorded as a
+	// verdict that was never measured.
+	cancelled := func() bool { return ctx.Err() != nil }
+
 	for _, name := range tests {
 		if cfg.Filter != "" && !matchTestFilter(name, cfg.Filter, matrixBases) {
 			continue
 		}
 		suite.Matched++
+		if cancelled() {
+			suite.Aborted++
+			continue
+		}
 
 		testRuns := runs
 		for run := 0; run < testRuns; run++ {
+			if cancelled() {
+				suite.Aborted++
+				break
+			}
 			// Determine seed for this run.
 			var seed uint64
 			if cfg.Seed != nil {
@@ -993,7 +1035,8 @@ func (rt *Runtime) RunAll(ctx context.Context, cfg RunConfig) (*SuiteResult, err
 			// is produced and each goes through the per-result switch
 			// below independently (each leaf gets its own pass/fail
 			// counter and Seed stamp).
-			leafResults := rt.runTestFanout(ctx, name)
+			leafResults, skippedLeaves := rt.runTestFanout(ctx, name)
+			suite.Aborted += skippedLeaves
 			if len(leafResults) == 0 {
 				// runTestFanout always returns at least one result;
 				// this branch is defensive only.
@@ -1198,7 +1241,11 @@ func (rt *Runtime) runTestSafelyLeaf(ctx context.Context, name string, leaf *Pla
 // missing axes silently fall back to FirstOption inside Selected.
 // This is the documented rc2 boundary — RFC-042 §8.8 covers the
 // majority case where the axes are leaf-independent.
-func (rt *Runtime) runTestFanout(ctx context.Context, name string) []TestResult {
+// runTestFanout returns the per-leaf results plus the number of leaves that
+// were skipped because the run was cancelled. The caller adds `skipped` to
+// SuiteResult.Aborted: an interrupted 18-leaf search that silently reported on
+// 2 leaves would read as a complete run of a small suite.
+func (rt *Runtime) runTestFanout(ctx context.Context, name string) (results []TestResult, skipped int) {
 	rt.resetBodyChoices()
 	rt.resetBodyProbFaults()
 	rt.resetBodyParallelSites()
@@ -1232,11 +1279,11 @@ func (rt *Runtime) runTestFanout(ctx context.Context, name string) []TestResult 
 		// that don't use choose() / exhaustive probability= /
 		// interleavings= fan-out.
 		tr0.LeafID = ""
-		return []TestResult{tr0}
+		return []TestResult{tr0}, 0
 	}
 
 	leaves := enumerateLeaves(axes, probAxes, parAxes)
-	results := make([]TestResult, 0, len(leaves))
+	results = make([]TestResult, 0, len(leaves))
 	// Always re-execute leaf 0 with its explicit axis assignment.
 	// The discovery run produced tr0 against a synthetic IsDiscovery
 	// leaf with no axes pinned and assume= evaluation suppressed; the
@@ -1252,13 +1299,21 @@ func (rt *Runtime) runTestFanout(ctx context.Context, name string) []TestResult 
 	leaf := leaves[0]
 	results = append(results, rt.runTestSafelyLeaf(ctx, name, &leaf))
 	for i := 1; i < len(leaves); i++ {
+		// A fan-out is where an interrupted run does the most damage: the
+		// remaining leaves would each start services against an already-dead
+		// context and be recorded as verdicts nobody measured. Stop instead;
+		// RunAll counts the shortfall as Aborted.
+		if ctx.Err() != nil {
+			skipped = len(leaves) - i
+			break
+		}
 		rt.resetBodyChoices()
 		rt.resetBodyProbFaults()
 		rt.resetBodyParallelSites()
 		leaf := leaves[i]
 		results = append(results, rt.runTestSafelyLeaf(ctx, name, &leaf))
 	}
-	return results
+	return results, skipped
 }
 
 // RunTest executes a single test function with fresh services under

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -441,6 +441,11 @@ type Runtime struct {
 
 	// fsObs holds the seccheck sink and per-service trace sessions.
 	fsObs *fsObservation
+	// shapersActive records whether bandwidth()/mtu() installed anything, so
+	// teardown can clear it without touching the gateway when they did not.
+	// One test's slow link must not become the next test's baseline.
+	shapersActive atomic.Bool
+
 	// specUsesWatch records whether any test calls watch(). Filesystem
 	// observation requires runsc, so a spec that never watches must not be
 	// forced onto it — the runsc requirement follows the feature, not the
@@ -3091,6 +3096,10 @@ func (rt *Runtime) stopServices() {
 	// Any partition left open by partition_start() is removed here, so it
 	// cannot leak into the next test.
 	rt.clearPartitions()
+
+	// Same for link shapers: a bandwidth() or mtu() from one test must not
+	// silently become the next test's baseline.
+	rt.clearShapers()
 
 	// Clear active faults.
 	rt.faultsMu.Lock()

--- a/internal/star/shaper.go
+++ b/internal/star/shaper.go
@@ -1,0 +1,173 @@
+package star
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/faultbox/Faultbox/internal/netfault"
+	"go.starlark.net/starlark"
+)
+
+// bandwidth() and mtu() — link-scoped shapers (RFC-054, deferred from v0.14.0).
+//
+// Unlike every packet_* builtin these take no matcher, because they do not
+// describe packets. A rule says "what happens to packets that look like this";
+// a shaper says "what kind of link is this". The distinction is not cosmetic:
+// approximating mtu() as packet_drop(len_gt=N) — which is what v0.14.0's
+// scenario 8 had to do — drops oversized packets, which looks like a black
+// hole and behaves like nothing real. An actual small-MTU path makes TCP
+// negotiate a smaller MSS and makes IP fragment, and that behaviour is where
+// the interesting bugs are.
+//
+// Both are gateway-wide. There is one TUN link under one FaultEndpoint, so
+// per-interface capacity is not something the gateway has to give; offering a
+// per-target knob would be offering one that lies.
+
+// builtinBandwidth implements bandwidth(rate=, dir="both", queue="250ms").
+func (rt *Runtime) builtinBandwidth(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var rate, dirStr, queueStr string
+	dirStr = "both"
+	if err := starlark.UnpackArgs("bandwidth", args, kwargs,
+		"rate", &rate,
+		"dir?", &dirStr,
+		"queue?", &queueStr,
+	); err != nil {
+		return nil, err
+	}
+	if err := rt.requireShaperRuntime("bandwidth"); err != nil {
+		return nil, err
+	}
+	dir, err := parseShaperDir("bandwidth", dirStr)
+	if err != nil {
+		return nil, err
+	}
+	// Validate the rate here rather than inside the gateway, so a typo is a
+	// spec error naming the accepted forms instead of a silently unshaped link.
+	bps, err := netfault.ParseRate(rate)
+	if err != nil {
+		return nil, fmt.Errorf("bandwidth(): %w", err)
+	}
+	backlog := netfault.DefaultShaperBacklog
+	if queueStr != "" {
+		d, err := parseStarDuration(queueStr)
+		if err != nil {
+			return nil, fmt.Errorf("bandwidth() bad queue %q: %w", queueStr, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("bandwidth() queue must be positive, got %q", queueStr)
+		}
+		backlog = d
+	}
+
+	gw, err := rt.ensurePacketGateway()
+	if err != nil {
+		return nil, fmt.Errorf("bandwidth(): %w", err)
+	}
+	if gw == nil {
+		return nil, fmt.Errorf("bandwidth(): no packet gateway is active")
+	}
+	if err := gw.SetBandwidth(rate, dir, backlog); err != nil {
+		return nil, err
+	}
+	rt.shapersActive.Store(true)
+	rt.events.Emit("bandwidth_applied", "", map[string]string{
+		"rate":        rate,
+		"bytes_per_s": fmt.Sprintf("%.0f", bps),
+		"dir":         dirStr,
+		"queue":       backlog.String(),
+	})
+	return starlark.None, nil
+}
+
+// builtinMTU implements mtu(size=).
+func (rt *Runtime) builtinMTU(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var size int
+	if err := starlark.UnpackArgs("mtu", args, kwargs, "size", &size); err != nil {
+		return nil, err
+	}
+	if err := rt.requireShaperRuntime("mtu"); err != nil {
+		return nil, err
+	}
+	// 68 is the IPv4 minimum every host must handle (RFC 791). Below it the
+	// stack cannot fragment a datagram at all, so the link would not be "small
+	// MTU", it would be broken in a way no real network is.
+	const minIPv4MTU = 68
+	if size < minIPv4MTU {
+		return nil, fmt.Errorf(
+			"mtu(size=%d) is below the IPv4 minimum of %d; a path that small cannot "+
+				"carry a fragmented datagram and does not model any real network",
+			size, minIPv4MTU)
+	}
+
+	gw, err := rt.ensurePacketGateway()
+	if err != nil {
+		return nil, fmt.Errorf("mtu(): %w", err)
+	}
+	if gw == nil {
+		return nil, fmt.Errorf("mtu(): no packet gateway is active")
+	}
+	if err := gw.SetMTU(uint32(size)); err != nil {
+		return nil, err
+	}
+	rt.shapersActive.Store(true)
+	rt.events.Emit("mtu_applied", "", map[string]string{"size": fmt.Sprintf("%d", size)})
+	return starlark.None, nil
+}
+
+func parseShaperDir(builtin, s string) (netfault.Direction, error) {
+	switch s {
+	case "both", "":
+		return netfault.DirBoth, nil
+	case "c2s":
+		return netfault.DirC2S, nil
+	case "s2c":
+		return netfault.DirS2C, nil
+	}
+	return 0, fmt.Errorf("%s() dir must be \"c2s\", \"s2c\" or \"both\", got %q", builtin, s)
+}
+
+// requireShaperRuntime refuses rather than silently doing nothing.
+//
+// Same reasoning as partition(): a shaper that quietly no-ops leaves the test
+// passing against a link that was never slow, which is worse than an error
+// because the run still looks like evidence.
+func (rt *Runtime) requireShaperRuntime(builtin string) error {
+	rt.mu.Lock()
+	runtimeName := rt.detRuntime
+	rt.mu.Unlock()
+	if runtimeSupportsPacketFaults(runtimeName) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s() needs the packet gateway, but this spec runs on runtime=%q; "+
+			"add determinism(runtime=%q) at the top of the spec",
+		builtin, runtimeName, DeterminismRuntimeGVisor)
+}
+
+// clearShapers removes link shapers at test end so one test's slow link cannot
+// silently become the next test's baseline.
+func (rt *Runtime) clearShapers() {
+	if !rt.shapersActive.Swap(false) {
+		return
+	}
+	gw := rt.packetGatewayHandle()
+	if gw == nil {
+		return
+	}
+	// Report what the shaper actually did before dropping it. "The link was
+	// configured slow" and "the link was the bottleneck" are different claims,
+	// and only the second is evidence.
+	for _, d := range []netfault.Direction{netfault.DirC2S, netfault.DirS2C} {
+		st, ok := gw.ShaperStats(d)
+		if !ok {
+			continue
+		}
+		rt.events.Emit("bandwidth_stats", "", map[string]string{
+			"dir":          d.String(),
+			"admitted":     fmt.Sprintf("%d", st.Admitted),
+			"dropped":      fmt.Sprintf("%d", st.Dropped),
+			"peak_backlog": st.PeakBacklog.Round(time.Millisecond).String(),
+		})
+	}
+	gw.ClearShapers()
+}

--- a/internal/star/shaper_test.go
+++ b/internal/star/shaper_test.go
@@ -1,0 +1,155 @@
+package star
+
+import (
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+// A shaper on the default runtime must ERROR, not silently do nothing.
+//
+// Same reasoning as partition(): a bandwidth() that quietly no-ops leaves the
+// test passing against a link that was never slow, and the run still looks
+// like evidence. Refusing is the only outcome that cannot be misread.
+func TestShapers_RefuseOnDefaultRuntime(t *testing.T) {
+	cases := []struct {
+		name string
+		spec string
+	}{
+		{"bandwidth", `
+def test_x():
+    bandwidth(rate = "1mbit")
+`},
+		{"mtu", `
+def test_x():
+    mtu(size = 576)
+`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := New(testLogger())
+			if err := rt.LoadString("spec.star", tc.spec); err != nil {
+				t.Fatalf("LoadString: %v", err)
+			}
+			rt.inTest.Store(true)
+			defer rt.inTest.Store(false)
+
+			var err error
+			if tc.name == "bandwidth" {
+				_, err = rt.builtinBandwidth(nil, nil, nil, kwargsOf("rate", "1mbit"))
+			} else {
+				_, err = rt.builtinMTU(nil, nil, nil, kwargsOfInt("size", 576))
+			}
+			if err == nil {
+				t.Fatalf("%s() on runtime=default must error, not no-op", tc.name)
+			}
+			for _, want := range []string{"packet gateway", "gvisor"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error should mention %q; got %q", want, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestBandwidth_RejectsBadArguments(t *testing.T) {
+	rt := newGvisorRuntime(t)
+	cases := []struct {
+		name    string
+		kwargs  []starlarkKV
+		wantSub string
+	}{
+		{"unitless rate", []starlarkKV{{"rate", "1000000"}}, "no unit"},
+		{"nonsense rate", []starlarkKV{{"rate", "quick"}}, "no unit"},
+		{"zero rate", []starlarkKV{{"rate", "0mbit"}}, "must be positive"},
+		{"bad direction", []starlarkKV{{"rate", "1mbit"}, {"dir", "up"}}, "dir must be"},
+		{"bad queue", []starlarkKV{{"rate", "1mbit"}, {"queue", "soon"}}, "bad queue"},
+		{"zero queue", []starlarkKV{{"rate", "1mbit"}, {"queue", "0s"}}, "must be positive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rt.builtinBandwidth(nil, nil, nil, kvsToKwargs(tc.kwargs))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error should contain %q; got %q", tc.wantSub, err.Error())
+			}
+		})
+	}
+}
+
+// An MTU below the IPv4 minimum cannot carry a fragmented datagram. Accepting
+// it would model no real network while looking like a configured one.
+func TestMTU_RejectsBelowIPv4Minimum(t *testing.T) {
+	rt := newGvisorRuntime(t)
+	for _, size := range []int{0, 1, 67, -100} {
+		_, err := rt.builtinMTU(nil, nil, nil, kwargsOfInt("size", size))
+		if err == nil {
+			t.Errorf("mtu(size=%d) should be rejected", size)
+			continue
+		}
+		if !strings.Contains(err.Error(), "IPv4 minimum") {
+			t.Errorf("mtu(size=%d): error should explain the floor; got %q", size, err.Error())
+		}
+	}
+}
+
+// The rate is validated in the builtin, before the gateway is touched, so a
+// typo is a spec error rather than a silently unshaped link.
+func TestBandwidth_RateValidatedBeforeGatewayStart(t *testing.T) {
+	rt := newGvisorRuntime(t)
+	_, err := rt.builtinBandwidth(nil, nil, nil, kwargsOf("rate", "1zbit"))
+	if err == nil {
+		t.Fatal("an unknown unit must be rejected")
+	}
+	// If validation had been left to the gateway, the failure on a host with
+	// no CAP_NET_ADMIN would be about the TUN device instead of the typo.
+	if strings.Contains(err.Error(), "CAP_NET_ADMIN") || strings.Contains(err.Error(), "TUN") {
+		t.Errorf("rate typo reported as a gateway problem: %q", err.Error())
+	}
+}
+
+// clearShapers must be safe when nothing was installed and when no gateway
+// ever started — it runs on every test teardown.
+func TestClearShapers_SafeWhenUnused(t *testing.T) {
+	rt := New(testLogger())
+	rt.clearShapers() // never installed
+	rt.shapersActive.Store(true)
+	rt.clearShapers() // flagged, but no gateway exists
+	if rt.shapersActive.Load() {
+		t.Error("clearShapers must reset the flag even when there is no gateway")
+	}
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+type starlarkKV struct{ k, v string }
+
+func newGvisorRuntime(t *testing.T) *Runtime {
+	t.Helper()
+	rt := New(testLogger())
+	if err := rt.LoadString("spec.star", "determinism(runtime = \"gvisor\")\n"); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	rt.inTest.Store(true)
+	t.Cleanup(func() { rt.inTest.Store(false) })
+	return rt
+}
+
+func kwargsOf(k, v string) []starlark.Tuple {
+	return []starlark.Tuple{{starlark.String(k), starlark.String(v)}}
+}
+
+func kwargsOfInt(k string, v int) []starlark.Tuple {
+	return []starlark.Tuple{{starlark.String(k), starlark.MakeInt(v)}}
+}
+
+func kvsToKwargs(kvs []starlarkKV) []starlark.Tuple {
+	out := make([]starlark.Tuple, 0, len(kvs))
+	for _, kv := range kvs {
+		out = append(out, starlark.Tuple{starlark.String(kv.k), starlark.String(kv.v)})
+	}
+	return out
+}

--- a/internal/star/sleep.go
+++ b/internal/star/sleep.go
@@ -1,0 +1,105 @@
+package star
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+// sleep() — a wall-clock wait that does not care what the event log is doing.
+//
+// Faultbox already had two ways to wait, and both are conditional on the SUT:
+// await_stable() returns when the event log goes quiet, await_event() when a
+// matching event arrives. Neither can express "hold this fault for 400ms",
+// and await_stable fails at it in the one situation the wait is for.
+//
+// A fault under test generates the events that prevent quiescence. Measured on
+// a 3-node hashicorp/raft cluster with a partition installed: 6681 events in a
+// single three-minute window, longest quiet gap 338ms. Every dropped packet
+// and every failed heartbeat resets the quiescence timer, so an
+// await_stable(quiescence_window="900ms") could never return — it blocked
+// until the per-test deadline and the leaf reported INCONCLUSIVE. Twelve of
+// eighteen exploration leaves died that way, burning 36 minutes to produce no
+// signal. The longer the delay asked for, the more certain it never arrives,
+// which is exactly inverted from what a timing knob needs.
+//
+// ignore= does not rescue it: the noise is the SUT's own stdout, which is also
+// what a spec legitimately waits on.
+//
+// Full measurement in docs/design/2026-07-28-timing-exploration-experiment.md.
+
+// sleepFor blocks for d, or until ctx is cancelled.
+//
+// A zero duration returns immediately rather than erroring. This is deliberate
+// and differs from awaitStable, which rejects a non-positive window: the point
+// of sleep() is to be a choose() axis, and "no delay" is the natural baseline
+// for such an axis. `choose("gap", ["0ms", "400ms", "1200ms"])` should compare
+// three delays, not silently abort a third of the leaves.
+func sleepFor(ctx context.Context, d time.Duration) error {
+	if d < 0 {
+		return fmt.Errorf("duration must not be negative, got %s", d)
+	}
+	if d == 0 {
+		return nil
+	}
+
+	// Fail fast rather than sleeping into the test deadline. A spec that asks
+	// to wait longer than the test can possibly run should be told which two
+	// numbers disagree, not spend the whole budget and report a bare timeout —
+	// that is precisely the diagnosis that cost 36 minutes to make by hand.
+	if dl, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(dl); d > remaining {
+			return fmt.Errorf(
+				"sleep(%s) is longer than the test's remaining budget (%s); "+
+					"the test would time out mid-wait and report INCONCLUSIVE rather than fail",
+				d, remaining.Round(time.Millisecond))
+		}
+	}
+
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// builtinSleep implements sleep(duration, clock="wall").
+//
+// Signature mirrors await_stable's: a duration string plus the reserved
+// clock= kwarg, so the two read alike at a call site and the eventual virtual
+// clock (RFC-040 L3) lands on both at once.
+//
+// No event is emitted. A sleep is supervisor-side, not something the SUT did,
+// and emitting one would reset the quiescence timer of any await_stable in a
+// parallel() branch — reintroducing, from the inside, the interference this
+// primitive exists to escape.
+func (rt *Runtime) builtinSleep(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !rt.inTest.Load() {
+		return nil, fmt.Errorf("sleep() may only be called inside a test body; " +
+			"got call at module top level (or inside setup=)")
+	}
+	var durStr string
+	clockStr := "wall"
+	if err := starlark.UnpackArgs("sleep", args, kwargs,
+		"duration", &durStr,
+		"clock?", &clockStr,
+	); err != nil {
+		return nil, err
+	}
+	if err := checkReservedClockKwarg(clockStr); err != nil {
+		return nil, err
+	}
+	d, err := parseStarDuration(durStr)
+	if err != nil {
+		return nil, fmt.Errorf("sleep() bad duration %q: %w", durStr, err)
+	}
+	if err := sleepFor(rt.testContext(), d); err != nil {
+		return nil, fmt.Errorf("sleep: %w", err)
+	}
+	return starlark.None, nil
+}

--- a/internal/star/sleep_test.go
+++ b/internal/star/sleep_test.go
@@ -1,0 +1,201 @@
+package star
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+func TestSleepFor_WaitsTheFullDuration(t *testing.T) {
+	start := time.Now()
+	if err := sleepFor(context.Background(), 40*time.Millisecond); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("returned too early: %v (want >= 40ms)", elapsed)
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("returned too late: %v", elapsed)
+	}
+}
+
+// The whole point of sleep(): unlike await_stable, a busy event log must not
+// shorten OR extend the wait. This is the regression guard for the failure
+// measured in docs/design/2026-07-28-timing-exploration-experiment.md, where
+// a partition's own events kept await_stable from ever quiescing.
+func TestSleepFor_UnaffectedByEventTraffic(t *testing.T) {
+	log := NewEventLog()
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		tick := time.NewTicker(2 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				log.Emit("noise", "svc", nil)
+			}
+		}
+	}()
+
+	start := time.Now()
+	if err := sleepFor(context.Background(), 60*time.Millisecond); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	elapsed := time.Since(start)
+	// awaitStable with a 60ms window would never return here: events arrive
+	// every 2ms. sleepFor must be indifferent.
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("event traffic extended the wait: %v (want ~60ms)", elapsed)
+	}
+}
+
+// Zero is a no-op, not an error — deliberately unlike awaitStable, so that
+// choose("gap", ["0ms", "400ms"]) compares two delays instead of aborting
+// half the leaves.
+func TestSleepFor_ZeroReturnsImmediately(t *testing.T) {
+	start := time.Now()
+	if err := sleepFor(context.Background(), 0); err != nil {
+		t.Fatalf("zero duration must be a no-op, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Errorf("zero duration should return immediately, took %v", elapsed)
+	}
+}
+
+func TestSleepFor_NegativeIsAnError(t *testing.T) {
+	err := sleepFor(context.Background(), -1*time.Second)
+	if err == nil {
+		t.Fatal("negative duration must error")
+	}
+	if !strings.Contains(err.Error(), "negative") {
+		t.Errorf("error should name the problem; got %q", err.Error())
+	}
+}
+
+func TestSleepFor_CancellationReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	err := sleepFor(ctx, 10*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("cancellation should be prompt, took %v", elapsed)
+	}
+}
+
+// A sleep longer than the test's remaining budget is refused up front rather
+// than run into the deadline. Sleeping into a timeout reports INCONCLUSIVE
+// with no hint which two numbers disagreed — the diagnosis that cost 36
+// minutes of wall clock to make by hand.
+func TestSleepFor_RefusesToOutliveTheTestBudget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := sleepFor(ctx, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected an error when the sleep exceeds the remaining budget")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("should fail fast, not by running into the deadline; got %v", err)
+	}
+	for _, want := range []string{"remaining budget", "INCONCLUSIVE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q; got %q", want, err.Error())
+		}
+	}
+	if elapsed := time.Since(start); elapsed > 40*time.Millisecond {
+		t.Errorf("should have failed immediately, took %v", elapsed)
+	}
+}
+
+func TestSleepBuiltin_RejectedAtTopLevel(t *testing.T) {
+	rt := New(testLogger())
+	err := rt.LoadString("spec.star", `sleep("10ms")`)
+	if err == nil {
+		t.Fatal("sleep() at module top level must error")
+	}
+	if !strings.Contains(err.Error(), "inside a test body") {
+		t.Errorf("error should say where sleep() is allowed; got %q", err.Error())
+	}
+}
+
+func TestSleepBuiltin_ParsesArgs(t *testing.T) {
+	rt := New(testLogger())
+	rt.inTest.Store(true)
+	defer rt.inTest.Store(false)
+
+	// Positional and keyword forms both work.
+	for _, args := range []struct {
+		name   string
+		args   starlark.Tuple
+		kwargs []starlark.Tuple
+	}{
+		{"positional", starlark.Tuple{starlark.String("1ms")}, nil},
+		{"keyword", nil, []starlark.Tuple{{starlark.String("duration"), starlark.String("1ms")}}},
+	} {
+		if _, err := rt.builtinSleep(nil, nil, args.args, args.kwargs); err != nil {
+			t.Errorf("%s form: %v", args.name, err)
+		}
+	}
+}
+
+func TestSleepBuiltin_BadInputs(t *testing.T) {
+	rt := New(testLogger())
+	rt.inTest.Store(true)
+	defer rt.inTest.Store(false)
+
+	cases := []struct {
+		name    string
+		args    starlark.Tuple
+		kwargs  []starlark.Tuple
+		wantSub string
+	}{
+		{
+			name:    "unparseable duration",
+			args:    starlark.Tuple{starlark.String("soon")},
+			wantSub: "bad duration",
+		},
+		{
+			name:    "negative duration",
+			args:    starlark.Tuple{starlark.String("-5s")},
+			wantSub: "negative",
+		},
+		{
+			name:    "virtual clock is reserved",
+			args:    starlark.Tuple{starlark.String("1ms")},
+			kwargs:  []starlark.Tuple{{starlark.String("clock"), starlark.String("virtual")}},
+			wantSub: "gVisor",
+		},
+		{
+			name:    "unknown clock",
+			args:    starlark.Tuple{starlark.String("1ms")},
+			kwargs:  []starlark.Tuple{{starlark.String("clock"), starlark.String("monotonic")}},
+			wantSub: "must be",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rt.builtinSleep(nil, nil, tc.args, tc.kwargs)
+			if err == nil {
+				t.Fatalf("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error should contain %q; got %q", tc.wantSub, err.Error())
+			}
+		})
+	}
+}

--- a/poc/gvisor-rfc054/shapers.star
+++ b/poc/gvisor-rfc054/shapers.star
@@ -1,0 +1,113 @@
+# Link shapers: bandwidth() and mtu() (RFC-054, v0.14.1).
+#
+#     sudo faultbox test poc/gvisor-rfc054/shapers.star
+#
+# Requires Linux with CAP_NET_ADMIN. On macOS: limactl shell faultbox-dev.
+#
+# These are the two v0.14.0 deferrals. Unlike every packet_* builtin they take
+# no matcher, because they describe the link rather than any packet crossing
+# it.
+#
+# WHAT THESE TESTS ASSERT, AND WHAT THEY DELIBERATELY DO NOT
+#
+# Each test asserts two things: the shaper was applied (a bandwidth_applied /
+# mtu_applied event exists) and traffic still flows through it. Neither is a
+# timing assertion. Faultbox has no clock primitive a spec can read, and a
+# wall-clock threshold in a test is really an assertion about how loaded the
+# machine was — the lesson from the Raft snapshot false positive
+# (docs/design/2026-07-28-raft-mesh-results.md §4.0).
+#
+# The quantitative behaviour — that a 100-byte packet at 1000 B/s waits exactly
+# 100ms, that the queue drops when it exceeds its backlog bound — is verified
+# in internal/netfault/shape_test.go against a fake clock, where the numbers
+# are exact and the test cannot flake.
+#
+# "The link still carries traffic" is the assertion that matters here, because
+# the failure mode being guarded against is a shaper that black-holes the
+# connection instead of slowing it.
+
+determinism(runtime = "gvisor")
+
+db = service("db", "/tmp/mock-db",
+    interface("main", "tcp", 5432),
+    env = {"PORT": "5432"},
+    healthcheck = tcp("localhost:5432"),
+)
+
+api = service("api", "/tmp/mock-api",
+    interface("public", "http", 8080),
+    env = {"PORT": "8080", "DB_ADDR": db.main.addr},
+    depends_on = [db],
+    healthcheck = http("localhost:8080/health"),
+)
+
+
+def hit_api(n = 6):
+    """Drive real api → db traffic across the gateway.
+
+    Only /data/ dials the DB; a path that never reaches it would leave the
+    shaper with nothing to shape while the test still passed.
+    """
+    ok = 0
+    for i in range(n):
+        api.post(path = "/data/k%d" % i, body = "value-%d" % i)
+        if api.get(path = "/data/k%d" % i).status == 200:
+            ok += 1
+    return ok
+
+
+def applied(kind):
+    return len(events(where = lambda e: e.type == kind))
+
+
+# --- Baseline ---------------------------------------------------------
+
+def test_unshaped_baseline():
+    """No shaper — the comparison point for the two below."""
+    assert_true(hit_api() > 0, "baseline traffic did not reach the DB")
+    assert_true(applied("bandwidth_applied") == 0,
+        "no bandwidth() was called, but a bandwidth_applied event exists")
+
+
+# --- bandwidth() ------------------------------------------------------
+
+def test_bandwidth_slows_without_breaking():
+    """A 64kbit link must still carry the workload.
+
+    The failure being guarded against is a shaper that discards instead of
+    paces — a link that is "slow" by virtue of dropping everything.
+    """
+    bandwidth(rate = "64kbit")
+    assert_true(applied("bandwidth_applied") == 1,
+        "bandwidth() did not record that it was applied")
+    assert_true(hit_api() > 0,
+        "no request completed under a 64kbit shaper — the link is dropping, not pacing")
+
+
+def test_bandwidth_one_direction():
+    """dir= shapes one leg only; the reverse path stays at full speed."""
+    bandwidth(rate = "128kbit", dir = "s2c")
+    assert_true(hit_api() > 0, "traffic stopped under a one-way shaper")
+
+
+# --- mtu() ------------------------------------------------------------
+
+def test_mtu_shrinks_segments_without_loss():
+    """A 576-byte path must still carry traffic.
+
+    This is the distinction from v0.14.0's packet_drop(len_gt=576)
+    approximation. That dropped oversized packets, which looks like a black
+    hole and behaves like nothing real; a genuine small-MTU path makes TCP
+    negotiate a smaller MSS, so the request still succeeds.
+    """
+    mtu(size = 576)
+    assert_true(applied("mtu_applied") == 1, "mtu() did not record that it was applied")
+    assert_true(hit_api() > 0,
+        "no request completed under mtu=576 — a small MTU should shrink segments, not drop them")
+
+
+def test_shapers_compose():
+    """Both at once: a slow, small-MTU path is a normal thing to model."""
+    bandwidth(rate = "256kbit")
+    mtu(size = 1200)
+    assert_true(hit_api() > 0, "traffic stopped when both shapers were active")

--- a/poc/raft-cluster/explore.star
+++ b/poc/raft-cluster/explore.star
@@ -1,0 +1,223 @@
+# Fault-TIMING exploration against hashicorp/raft main @ 4c8f61ac.
+#
+#   sudo faultbox test poc/raft-cluster/explore.star --explore all
+#
+# Companion to faultbox.star, which is the fast regression suite: five tests,
+# one fault schedule each, ~7s total. This file is the opposite trade — two
+# tests, many leaves, minutes not seconds.
+#
+# WHY THIS EXISTS
+#
+# The v0.14.0 Raft write-up reported "45 runs, not reproduced" for Antithesis
+# bugs 2 and 3. That was true and almost meaningless: --runs N varies a seed,
+# faultbox.star consumes no seed, so all 45 runs executed ONE fault schedule
+# and differed only in OS scheduling. See
+# docs/design/2026-07-28-raft-mesh-results.md §4.2.
+#
+# Both target bugs are races. What has to vary is not the seed but *when the
+# fault lands relative to what the cluster is doing*:
+#
+#   bug 2  the transfer goroutine must be mid-replication exactly as the
+#          leader steps down for lack of quorum
+#   bug 3  the follower's log must be in a particular state when the
+#          snapshot arrives
+#
+# HOW, WITH NO NEW PRIMITIVES
+#
+# choose() + --explore already fan a test into one leaf per combination
+# (RFC-043 §5.2). The two knobs that matter are expressible today:
+#
+#   work volume   submit(choose(...))                      — cluster state
+#   wall clock    await_stable(quiescence_window=choose(…)) — elapsed time
+#
+# await_stable is not a sleep; it blocks until the event log is quiet for the
+# window, so it is a *floor* on elapsed time, not an exact delay. That is the
+# right shape here anyway — the question is whether the leader has noticed it
+# lost quorum yet, and that is what quiescence measures.
+
+determinism(runtime = "gvisor")
+
+BIN = "/tmp/raft-node"
+
+
+def node(name, raft_port, admin_port, bootstrap = False):
+    env = {
+        "NODE_ID":   name,
+        "PEER_IDS":  "node1,node2,node3",
+        "RAFT_BIND": "127.0.0.1:%d" % raft_port,
+        "HTTP_BIND": "127.0.0.1:%d" % admin_port,
+    }
+    if bootstrap:
+        env["BOOTSTRAP"] = "1"
+    return service(name, BIN,
+        interface("raft", "tcp", raft_port),
+        interface("admin", "http", admin_port),
+        env = env,
+        healthcheck = http("localhost:%d/health" % admin_port, timeout = "20s"),
+        observe = [observe.stdout(decoder = decoder("json"))],
+    )
+
+
+node1 = node("node1", 8301, 8401, bootstrap = True)
+node2 = node("node2", 8302, 8402)
+node3 = node("node3", 8303, 8403)
+
+NODES = [node1, node2, node3]
+
+
+def _record(event, state):
+    if event.count in state:
+        return state
+    new = dict(state)
+    new[event.count] = event.hash
+    return new
+
+
+monitor("state_machine_safety",
+    on         = match.event(type = "stdout", event = "fsm.apply"),
+    state_init = {},
+    update     = _record,
+    check      = lambda event, state: state[event.count] == event.hash,
+)
+
+
+def wait_leader():
+    for n in NODES:
+        if n.admin.get(path = "/wait_leader").status == 200:
+            return True
+    return False
+
+
+def submit(n):
+    accepted = 0
+    for i in range(n):
+        done = False
+        for attempt in range(4):
+            for nd in NODES:
+                if nd.admin.post(path = "/apply", body = "cmd-%d-%d" % (i, attempt)).status == 200:
+                    accepted += 1
+                    done = True
+                    break
+            if done:
+                break
+    return accepted
+
+
+def converged():
+    seen = {}
+    for n in NODES:
+        r = n.admin.get(path = "/state")
+        if r.status != 200:
+            return False
+        seen[r.data.get("hash", "?")] = True
+    return len(seen) == 1
+
+
+# --- Bug 2: leadership transfer racing loss of quorum ------------------
+#
+# 3 x 3 x 2 = 18 leaves.
+#
+# The axis that matters is `gap`: how long the leader has been cut off when
+# /transfer arrives.
+#
+#   "0ms"    transfer while the leader still believes it has quorum
+#   "400ms"  transfer around LeaderLeaseTimeout — the contended window
+#   "1200ms" transfer well after the leader has stepped down
+#
+# `warmup` sets how much log there is to replicate (an empty log gives the
+# transfer nothing to block on). `hold` decides whether the partition outlives
+# the transfer attempt or clears under it.
+
+def test_transfer_timing():
+    warmup = choose("warmup", [0, 10, 40])
+    # NOT "0ms": await_stable rejects a non-positive quiescence window
+    # ("window must be > 0"), which aborts the leaf as INCONCLUSIVE rather
+    # than running it. 50ms is the shortest honest "immediately".
+    gap  = choose("gap", ["50ms", "400ms", "1200ms"])
+    hold = choose("hold", ["100ms", "900ms"])
+
+    tag = "warmup=%d gap=%s hold=%s" % (warmup, gap, hold)
+
+    assert_true(wait_leader(), "cluster never elected a leader [%s]" % tag)
+    if warmup > 0:
+        submit(warmup)
+
+    partition_start(node1, node2)
+    partition_start(node1, node3)
+
+    await_stable(quiescence_window = gap)
+    node1.admin.post(path = "/transfer")
+    await_stable(quiescence_window = hold)
+
+    partition_stop(node1, node2)
+    partition_stop(node1, node3)
+
+    recovered = wait_leader()
+    await_stable(quiescence_window = "1s")
+
+    accepted = submit(10)
+    print("transfer: %s recovered=%s accepted=%d" % (tag, recovered, accepted))
+
+    # A liveness assertion is only meaningful with a convergence window, and
+    # "no node accepted a command" has several boring causes. Dump enough to
+    # tell them apart before believing this is Antithesis bug 2.
+    if accepted == 0:
+        for n in NODES:
+            r = n.admin.get(path = "/state")
+            print("  DIAG %s: status=%d body=%s" % (n.name, r.status, r.body))
+        rejects = events(where = lambda e: e.type == "stdout" and
+            e.fields.get("event") == "apply.rejected")
+        print("  DIAG apply.rejected count=%d" % len(rejects))
+        for e in rejects[-5:]:
+            print("  DIAG reject: %s" % e.fields.get("error", "?"))
+
+    assert_true(accepted > 0,
+        "cluster accepted no commands after a transfer that raced a partition " +
+        "[%s] — candidate Antithesis bug 2 (transfer-in-progress flag never cleared)" % tag)
+
+
+# --- Bug 3: InstallSnapshot leaving stale log entries ------------------
+#
+# 3 x 2 = 6 leaves.
+#
+# `behind` sets how far the isolated follower falls; SnapshotThreshold is 16,
+# so 25 already forces InstallSnapshot and 400 forces several. `snap_when`
+# decides whether the snapshot is taken while the follower is still cut off
+# or after it has started catching up — Raft rule 7 is about what the follower
+# does with its existing log, so the interesting case is the one where it HAS
+# one that overlaps.
+
+def test_snapshot_timing():
+    behind    = choose("behind", [25, 120, 400])
+    snap_when = choose("snap_when", ["during", "after"])
+
+    assert_true(wait_leader(), "cluster never elected a leader")
+
+    partition_start(node1, node3)
+    partition_start(node2, node3)
+    submit(behind)
+
+    if snap_when == "during":
+        node1.admin.post(path = "/snapshot")
+
+    partition_stop(node1, node3)
+    partition_stop(node2, node3)
+
+    if snap_when == "after":
+        node1.admin.post(path = "/snapshot")
+
+    assert_true(wait_leader(), "cluster never recovered a leader")
+
+    ok = False
+    for round in range(6):
+        submit(2)
+        await_stable(quiescence_window = "1s")
+        if converged():
+            print("snapshot: behind=%d snap=%s converged round=%d" % (behind, snap_when, round))
+            ok = True
+            break
+
+    assert_true(ok,
+        "node3 never caught up after rejoining (behind=%d snap=%s), across 6 " % (behind, snap_when) +
+        "rounds with 1s quiescence each — the leader is re-sending snapshots " +
+        "in a loop (Antithesis bug 3)")

--- a/poc/raft-cluster/explore.star
+++ b/poc/raft-cluster/explore.star
@@ -22,18 +22,22 @@
 #   bug 3  the follower's log must be in a particular state when the
 #          snapshot arrives
 #
-# HOW, WITH NO NEW PRIMITIVES
+# HOW
 #
-# choose() + --explore already fan a test into one leaf per combination
-# (RFC-043 §5.2). The two knobs that matter are expressible today:
+# choose() + --explore fan a test into one leaf per combination (RFC-043
+# §5.2). The two knobs that matter:
 #
-#   work volume   submit(choose(...))                      — cluster state
-#   wall clock    await_stable(quiescence_window=choose(…)) — elapsed time
+#   work volume   submit(choose(...))   — how much log/state exists
+#   wall clock    sleep(choose(...))    — how long the fault is held
 #
-# await_stable is not a sleep; it blocks until the event log is quiet for the
-# window, so it is a *floor* on elapsed time, not an exact delay. That is the
-# right shape here anyway — the question is whether the leader has noticed it
-# lost quorum yet, and that is what quiescence measures.
+# The first worked from v0.14.0. The second did NOT: the only wall-clock
+# primitive was await_stable(), which returns on quiescence — and an active
+# partition emits an event per dropped packet, so the log never quiesces.
+# Measured here: 6681 events in one three-minute leaf, longest quiet gap
+# 338ms. Twelve of these eighteen leaves blocked until the test deadline and
+# reported INCONCLUSIVE, burning 36 minutes for no signal. v0.14.1 adds
+# sleep() for exactly this. See
+# docs/design/2026-07-28-timing-exploration-experiment.md.
 
 determinism(runtime = "gvisor")
 
@@ -130,10 +134,13 @@ def converged():
 
 def test_transfer_timing():
     warmup = choose("warmup", [0, 10, 40])
-    # NOT "0ms": await_stable rejects a non-positive quiescence window
-    # ("window must be > 0"), which aborts the leaf as INCONCLUSIVE rather
-    # than running it. 50ms is the shortest honest "immediately".
-    gap  = choose("gap", ["50ms", "400ms", "1200ms"])
+    # sleep(), not await_stable(): the partition installed below emits an
+    # event per dropped packet, and every raft retry adds more, so the event
+    # log never quiesces. Measured: max quiet gap 338ms under partition, so
+    # await_stable(quiescence_window="900ms") blocked until the 3-minute test
+    # deadline. 12 of these 18 leaves died that way before sleep() existed.
+    # "0ms" is a legal sleep and the right baseline for this axis.
+    gap  = choose("gap", ["0ms", "400ms", "1200ms"])
     hold = choose("hold", ["100ms", "900ms"])
 
     tag = "warmup=%d gap=%s hold=%s" % (warmup, gap, hold)
@@ -145,9 +152,9 @@ def test_transfer_timing():
     partition_start(node1, node2)
     partition_start(node1, node3)
 
-    await_stable(quiescence_window = gap)
+    sleep(gap)
     node1.admin.post(path = "/transfer")
-    await_stable(quiescence_window = hold)
+    sleep(hold)
 
     partition_stop(node1, node2)
     partition_stop(node1, node3)


### PR DESCRIPTION
Follow-up to #145. Draft — landing incrementally, each item verified against the case that motivated it.

v0.14.0 shipped packet faults and a Raft harness that could express partitions but not search *when* they land. This branch closes that, and fixes what the first real search exposed.

## Landed

### `sleep(duration, clock="wall")`

Faultbox had two ways to wait and both were conditional on the SUT:
`await_stable()` returns on quiescence, `await_event()` on a matching event.
Neither can hold a fault open for a fixed time — and `await_stable` fails at it
in exactly the situation the wait is for, because **an active fault emits the
events that prevent quiescence.**

Measured on a 3-node `hashicorp/raft` cluster under partition: **6681 events in
three minutes, longest quiet gap 338 ms.** Every window above ~340 ms blocked
until the per-test deadline and reported INCONCLUSIVE.

Verified on the case that motivated it — same 18-leaf timing search, only
`await_stable(gap)` → `sleep(gap)`:

```
BEFORE   6 passed, 0 failed, 12 inconclusive     36 minutes
AFTER   18 passed, 0 failed                      ~2 minutes
```

Every leaf ran and the unwired-gateway guard stayed silent, so the partitions
were real. `hashicorp/raft` still did not fail — but this is the first run of
which that statement means anything.

Notable choices: `sleep("0ms")` is a no-op rather than an error (the primary use
is a `choose()` axis and "no delay" is its baseline); a sleep longer than the
remaining test budget is refused up front naming both numbers; it emits no
event, so it cannot reset an `await_stable` in a `parallel()` branch.

### Data race in netfault's test `fakeClock` (from v0.14.0)

The deferQueue goroutine called `Stop()` while the test goroutine read
`stopped` under the clock mutex. It did **not** fire during the v0.14.0 release
gate and did fire here — CI would have hit it eventually.

## Queued

- **TUN device leak** — `faultbox0` survives `SIGTERM` and bricks every later
  packet-fault run on the host. Three layers: unique device name (makes a leak
  harmless and fixes concurrent runs), `SIGTERM` handling, startup reap of
  orphaned devices.
- **`faultbox plan` cannot see `choose()` axes** — reports 2 instances for a
  spec that runs 24 leaves, so `--check-cost` is blind to the main fan-out
  construct. Plus: timeout verdicts drop their `Reason`, so 36 minutes of hangs
  render as a bare `12 inconclusive`.
- **`bandwidth()` / `mtu()`** — deferred from v0.14.0.
- **`watch()`** via runsc `-pod-init-config`.

## Testing

`go build` + `go vet` + `go test -race -count=1 ./...` — 22 ok, **0 failures**.
Raft timing search re-run end-to-end in Lima on kernel 6.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
