### PR TITLE
RFC-055: client() — contract-driven callers as first-class trace actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,11 @@ Next-version work is tracked in
   that declares no contract of its own inherits it, choosing the loader by
   extension (`.yaml`/`.yml`/`.json` → OpenAPI, `.pb`/`.desc`/`.protoset` →
   descriptor set).
-- `events()` now returns `client_call`, `client_return`, and
-  `contract_violation` events. `step_send` / `step_recv` remain excluded —
-  admitting them would silently change what `events()` returns for existing
-  specs.
+- The **dict-filter** form of `events()` (`events(service=…)`) now returns
+  `client_call`, `client_return`, and `contract_violation` events.
+  `step_send` / `step_recv` remain excluded there — admitting them would
+  silently change what existing specs see. The `where=` form has had no type
+  gate since v0.14.1 and already returns every family.
 - HTTP `step_recv` events carry a `content_type` field, and the HTTP protocol
   plugin accepts `HEAD` / `OPTIONS` (an OpenAPI document may declare them).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,78 @@ Per-release "What's new" pages live on the site at
 Next-version work is tracked in
 [GitHub Issues](https://github.com/faultbox/Faultbox/issues).
 
+### Added
+
+- **Contract-driven clients — `client()`
+  ([RFC-055](docs/rfcs/0055-clients.md), [#149](https://github.com/faultbox/Faultbox/issues/149)).**
+  A new topology entity that turns an OpenAPI 3.x document or a protobuf
+  `FileDescriptorSet` into a **named caller** bound to a service interface,
+  with its operations generated as callable attributes:
+
+  ```python
+  orders = service("orders", interface("public", "http", 8080), image = "orders:2.1")
+  mobile = client("mobile-app", target = orders.public, openapi = "./orders.yaml",
+                  validate = "response")
+
+  def test_order_flow():
+      r = mobile.get_order(order_id = 42)     # no path, no verb, no field names
+  ```
+
+  This is the caller-side inversion of the loaders RFC-021 and RFC-023 already
+  shipped for mocks — the same document can drive a `mock_service()` (callee)
+  and a `client()` (caller).
+
+  - **Clients are first-class trace actors.** Calls emit `client_call` /
+    `client_return` on the *client's* own swim lane with its own vector-clock
+    participant, so three named callers against one API render as three lanes
+    instead of one anonymous `test` driver. The events work as
+    [temporal anchors](docs/temporal.md) with no new matcher syntax:
+    `match.event(type="client_return", client="gRPC-Courier", success="false")`.
+  - **Contract conformance is assertable.** `validate="response"` checks each
+    response against the schema declared for its status code and records the
+    verdict on `resp.contract_ok` / `resp.contract_error`, emitting a
+    `contract_violation` event. It deliberately does **not** raise — a contract
+    violation under fault is usually the finding, not a harness error. An
+    undeclared status code counts as a violation, which is how the undocumented
+    degraded path surfaces.
+  - **Composes with everything.** Client calls dial through the same proxy
+    resolution as step methods, so `fault(iface, ...)` applies unchanged; TLS
+    (RFC-038) and remote targets (RFC-036) are inherited from the interface.
+    Clients are trace actors, not processes — they take no seccomp filter and
+    are never a fault target.
+  - `faultbox inspect --clients <spec.star>` prints each client's generated
+    operation table.
+  - `Response` gains `.client`, `.operation`, `.contract_ok`, `.contract_error`.
+
+  v1 is unary-only (streaming gRPC methods are skipped, the rest of the
+  descriptor set still loads), stateless per call, and does not synthesize
+  request data. See [spec-language.md](docs/spec-language.md#contract-driven-clients-rfc-055).
+
+### Changed
+
+- `interface(name, protocol, port, spec=)` is now **read**. The kwarg has been
+  parsed and stored since early versions with nothing consuming it; a `client()`
+  that declares no contract of its own inherits it, choosing the loader by
+  extension (`.yaml`/`.yml`/`.json` → OpenAPI, `.pb`/`.desc`/`.protoset` →
+  descriptor set).
+- `events()` now returns `client_call`, `client_return`, and
+  `contract_violation` events. `step_send` / `step_recv` remain excluded —
+  admitting them would silently change what `events()` returns for existing
+  specs.
+- HTTP `step_recv` events carry a `content_type` field, and the HTTP protocol
+  plugin accepts `HEAD` / `OPTIONS` (an OpenAPI document may declare them).
+
+### Fixed
+
+- `mock_service(openapi=)` and `mock_service(descriptors=)` resolved relative
+  paths against the process working directory rather than the spec's own
+  directory, so `"./api.yaml"` only loaded when `faultbox` happened to run from
+  the directory containing the spec. Both now resolve spec-relative, matching
+  `load_file()`, `build=`, and `client()`.
+- `service()` and `client()` now reject a name already taken by the other.
+  Both are trace actors keyed by name, so sharing one silently folded two
+  participants into a single lane and vector clock.
+
 ## [0.14.1] - 2026-07-29
 
 Searching fault *timing*, and fixing what that search exposed.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Bundle records remotes used; `faultbox replay` warns. Connectivity setup
 (Telepresence, kubectl port-forward, in-cluster, VPN) documented in
 [docs/guides/connectivity.md](docs/guides/connectivity.md).
 
+**Contract-driven clients** (RFC-055) -- `client("mobile-app", target=orders.public,
+openapi="./orders.yaml")` turns an OpenAPI 3.x document or a protobuf
+`FileDescriptorSet` into a **named caller** whose operations are generated from
+the contract: `api.get_order(order_id=42)`, no paths or field names in your spec.
+Each client is its own actor in the trace — its own swim lane and vector-clock
+participant — so a run with a mobile app, a partner integration, and an admin
+tool tells you *which* caller saw the failure. `validate="response"` checks each
+response against the schema the service publishes, catching degraded-but-invalid
+payloads and undeclared status codes without you guessing the field.
+`faultbox inspect --clients` lists what you can call.
+
 **Recipe library** -- curated failure wrappers ship embedded in the binary.
 `load("@faultbox/recipes/mongodb.star", "mongodb")` gets you `mongodb.disk_full()`,
 `mongodb.replica_unavailable()`, and more — no filesystem setup needed.
@@ -95,6 +106,10 @@ Four layers, composable in one spec:
 | **Protocol (request)** | Per-method rules on the wire — e.g., gRPC `UNAVAILABLE` for `/svc/Method`, HTTP 503 for `POST /orders`, Postgres query-level denies, Kafka publish failures | transparent proxy in front of the upstream; 15 protocols today |
 | **Protocol (response)** | Rewrite status, body, or headers the upstream returns — corrupt a Postgres SELECT result, flip a Redis INCR to wrong value, drop a Kafka offset | same proxy, response-side rules |
 | **Mock** | Canned response from a scripted mock service, no real dep | `mock_service()` — HTTP, HTTP/2, gRPC, JWKS, and more |
+
+The same contract drives both boundaries: `mock_service(openapi=…)` generates the
+dependency you can't run, `client(openapi=…)` generates the caller that drives
+your service.
 
 Plus: `monitor()` Starlark callbacks over the event log, `assert_eventually()`
 temporal assertions, `expect_success` / `expect_error_within` / `expect_hang`
@@ -181,6 +196,7 @@ make demo
 | [Temporal Properties](docs/temporal.md) | `eventually` / `always` / `monitor` / `await_*` / `test()` (RFC-041) |
 | [Plan & Coverage](docs/exploration.md) | `faultbox plan`, `plan.json`, coverage, suggestions (RFC-042) |
 | [Non-deterministic Operators](docs/nondeterministic-operators.md) | `choose()` / `nondet()` / `halt()` / `assume()` (RFC-043) |
+| [Contract-Driven Clients](docs/tutorial/05-advanced/28-contract-clients.md) | `client()` — typed callers from OpenAPI / protobuf, named trace actors (RFC-055) |
 
 ### Tutorial Structure
 
@@ -190,7 +206,8 @@ make demo
 | [1: First Taste](docs/tutorial/01-first-taste/) | 1-2 | First fault, first test |
 | [2: Syscall-Level](docs/tutorial/02-syscall-level/) | 3-6 | Fault injection, traces, concurrency, monitors |
 | [3: Protocol-Level](docs/tutorial/03-protocol-level/) | 7-8 | HTTP/Redis faults, database faults |
-| [4: Advanced](docs/tutorial/04-advanced/) | 9-12 | Containers, scenarios, event sources, named ops |
+| [4: Safety](docs/tutorial/04-safety/) | 14-16, 24-26 | Invariants, monitors, partitions, determinism, plan fan-out |
+| [5: Advanced](docs/tutorial/05-advanced/) | 9-13, 17-23, 28 | Containers, scenarios, mocks, clients, bundles, reports |
 
 ## How It Works
 

--- a/cmd/faultbox/inspect_clients.go
+++ b/cmd/faultbox/inspect_clients.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/faultbox/Faultbox/internal/logging"
+	"github.com/faultbox/Faultbox/internal/star"
+)
+
+// printSpecClients implements `faultbox inspect --clients <spec.star>`
+// (RFC-055 Phase 4).
+//
+// A generated client's whole value proposition is that you don't have to
+// read the contract to call the API — which only holds if there's a way to
+// see what the generated surface actually is. This is that way, and it's
+// what the "no operation X" error points users at.
+func printSpecClients(w io.Writer, specFile string) int {
+	logger := logging.New(logging.Config{Level: slog.LevelWarn})
+	rt := star.New(logger)
+	if err := rt.LoadFile(specFile); err != nil {
+		fmt.Fprintf(os.Stderr, "error loading %s: %v\n", specFile, err)
+		return 1
+	}
+
+	names := rt.ClientNames()
+	if len(names) == 0 {
+		fmt.Fprintf(w, "%s declares no clients.\n\n", specFile)
+		fmt.Fprintln(w, "Declare one with:")
+		fmt.Fprintln(w, `  api = client("mobile-app", target = orders.public, openapi = "./orders.yaml")`)
+		return 0
+	}
+
+	for i, name := range names {
+		c, ok := rt.Client(name)
+		if !ok {
+			continue
+		}
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		printOneClient(w, c)
+	}
+	return 0
+}
+
+func printOneClient(w io.Writer, c *star.ClientVal) {
+	fmt.Fprintf(w, "%s\n", c.Name)
+	fmt.Fprintf(w, "  target:    %s.%s (%s)\n",
+		c.Target.Service.Name, c.Target.Interface.Name, c.Target.Interface.Protocol)
+	fmt.Fprintf(w, "  contract:  %s\n", c.Table.Contract.String())
+	fmt.Fprintf(w, "  validate:  %s\n", c.Validate)
+	if c.BasePath != "" {
+		fmt.Fprintf(w, "  base_path: %s\n", c.BasePath)
+	}
+	if len(c.Headers) > 0 {
+		keys := make([]string, 0, len(c.Headers))
+		for k := range c.Headers {
+			keys = append(keys, k)
+		}
+		fmt.Fprintf(w, "  headers:   %s\n", strings.Join(sortedStrings(keys), ", "))
+	}
+
+	ops := c.Table.Operations()
+	fmt.Fprintf(w, "  operations (%d):\n", len(ops))
+
+	// Two columns: the call you'd write, and the wire target it maps to.
+	// Width is computed rather than fixed so a long operation name doesn't
+	// push the wire column off into the weeds.
+	width := 0
+	for _, op := range ops {
+		if n := len(op.SignatureHint()); n > width {
+			width = n
+		}
+	}
+	if width > 56 {
+		width = 56
+	}
+	for _, op := range ops {
+		sig := op.SignatureHint()
+		pad := width - len(sig)
+		if pad < 1 {
+			pad = 1
+		}
+		fmt.Fprintf(w, "    %s%s  %s\n", sig, strings.Repeat(" ", pad), op.Wire())
+	}
+}
+
+func sortedStrings(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/cmd/faultbox/inspect_clients_test.go
+++ b/cmd/faultbox/inspect_clients_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const clientsTestContract = `
+openapi: 3.0.3
+info:
+  title: Orders
+  version: 1.4.0
+paths:
+  /orders:
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {type: object}
+      responses:
+        "201": {description: created}
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        "200": {description: ok}
+`
+
+func writeClientSpec(t *testing.T, starBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "orders.yaml"), []byte(clientsTestContract), 0o644); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	specPath := filepath.Join(dir, "faultbox.star")
+	if err := os.WriteFile(specPath, []byte(starBody), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	return specPath
+}
+
+func TestInspectClients_PrintsOperationTable(t *testing.T) {
+	spec := writeClientSpec(t, `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "./orders.yaml",
+             headers = {"X-Client": "ios"}, validate = "response")
+`)
+
+	var buf bytes.Buffer
+	if code := printSpecClients(&buf, spec); code != 0 {
+		t.Fatalf("printSpecClients exit code = %d, want 0\n%s", code, buf.String())
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"mobile-app",
+		"orders.public (http)",
+		"validate:  response",
+		"X-Client",
+		"operations (2):",
+		"create_order(body)",
+		"POST /orders",
+		"get_order(order_id)",
+		"GET /orders/{orderId}",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestInspectClients_NoClientsIsNotAnError(t *testing.T) {
+	spec := writeClientSpec(t, `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+`)
+
+	var buf bytes.Buffer
+	if code := printSpecClients(&buf, spec); code != 0 {
+		t.Fatalf("exit code = %d, want 0 — a spec with no clients is a normal state", code)
+	}
+	if !strings.Contains(buf.String(), "declares no clients") {
+		t.Errorf("expected a helpful no-clients message, got:\n%s", buf.String())
+	}
+	// The message should show how to declare one rather than just saying no.
+	if !strings.Contains(buf.String(), "client(") {
+		t.Errorf("no-clients message should show the declaration form, got:\n%s", buf.String())
+	}
+}
+
+func TestInspectClients_BadSpecExitsNonZero(t *testing.T) {
+	spec := writeClientSpec(t, `this is not starlark(((`)
+	var buf bytes.Buffer
+	if code := printSpecClients(&buf, spec); code == 0 {
+		t.Error("expected a non-zero exit for a spec that fails to load")
+	}
+}

--- a/cmd/faultbox/main.go
+++ b/cmd/faultbox/main.go
@@ -2517,9 +2517,12 @@ func faultboxVersion() string {
 func inspectCmd(args []string) int {
 	var extractDir string
 	var bundlePath, fileArg string
+	var clients bool
 
 	for len(args) > 0 {
 		switch {
+		case args[0] == "--clients":
+			clients = true
 		case strings.HasPrefix(args[0], "--extract="):
 			extractDir = strings.TrimPrefix(args[0], "--extract=")
 		case args[0] == "--extract" && len(args) > 1:
@@ -2542,6 +2545,22 @@ func inspectCmd(args []string) int {
 			return 1
 		}
 		args = args[1:]
+	}
+
+	// --clients inspects a .star spec rather than a bundle: the generated
+	// operation table is a property of the contract, not of a run.
+	if clients {
+		if bundlePath == "" {
+			fmt.Fprintln(os.Stderr, "faultbox inspect --clients: spec path required")
+			printInspectUsage()
+			return 1
+		}
+		if extractDir != "" || fileArg != "" {
+			fmt.Fprintln(os.Stderr, "faultbox inspect --clients takes a spec path only")
+			printInspectUsage()
+			return 1
+		}
+		return printSpecClients(os.Stdout, bundlePath)
 	}
 
 	if bundlePath == "" {
@@ -2687,11 +2706,13 @@ USAGE
   faultbox inspect <bundle.fb>                    # summary + file list
   faultbox inspect <bundle.fb> <path-in-archive>  # dump one file to stdout
   faultbox inspect <bundle.fb> --extract <dir>    # extract all to dir
+  faultbox inspect --clients <spec.star>          # generated client operations
 
 EXAMPLES
   faultbox inspect run-2026-04-22-42.fb
   faultbox inspect run-2026-04-22-42.fb manifest.json | jq .summary
   faultbox inspect run-2026-04-22-42.fb --extract ./unpacked/
+  faultbox inspect --clients faultbox.star
 `
 	fmt.Fprint(os.Stderr, usage)
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -194,6 +194,7 @@ instead). See [bundles.md](bundles.md) for the archive layout.
 faultbox inspect <bundle.fb>                    # summary + file list
 faultbox inspect <bundle.fb> <path-in-archive>  # dump one file to stdout
 faultbox inspect <bundle.fb> --extract <dir>    # extract all to dir
+faultbox inspect --clients <spec.star>          # generated client operations
 ```
 
 **Summary mode** prints a scannable header (producer version, run
@@ -206,6 +207,22 @@ the archive file list.
 **Extract mode** writes every file to a directory, preserving the
 `spec/`, `services/` substructure and setting `replay.sh` executable.
 
+**Clients mode** (RFC-055) takes a `.star` spec rather than a bundle and
+prints each [`client()`](spec-language.md#clientname-target-openapi-descriptors-)'s
+generated operation table — the call you would write next to the wire
+target it maps to. This is the answer to "what can I call?", and it's
+where an unknown-operation error points you.
+
+```
+mobile-app
+  target:    orders.public (http)
+  contract:  openapi:./orders.openapi.yaml@1.4.0
+  validate:  response
+  operations (2):
+    create_order(body)     POST /orders
+    get_order(order_id)    GET /orders/{orderId}
+```
+
 **Examples:**
 
 ```bash
@@ -213,6 +230,7 @@ faultbox inspect run-2026-04-22-42.fb
 faultbox inspect run-*.fb manifest.json | jq '.summary'
 faultbox inspect run-*.fb trace.json | jq '.tests[0].diagnostics'
 faultbox inspect run-*.fb --extract ./unpacked/
+faultbox inspect --clients faultbox.star
 ```
 
 **Version banner:** if the bundle was produced by a different

--- a/docs/feature-manifest.md
+++ b/docs/feature-manifest.md
@@ -67,6 +67,8 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 | Kafka mock (kfake) | 2 | testops corpus (kafka_basic, mock_demo) | 🟢 | |
 | MongoDB mock | 2 | testops corpus (mongo_basic, mock_demo) | 🟢 | |
 | gRPC mock | 2 | included in mock_demo | 🟡 | No isolated corpus entry |
+| `client()` — contract-driven callers (RFC-055) | 2 | `internal/protocol/{client_contract,openapi_client,grpc_client}_test.go` (naming, collisions, binding, conformance) + `internal/star/client{,_trace}_test.go` (spec load, events, clocks, HTTP + gRPC end-to-end against the real mocks) | 🟡 | Go coverage is thorough on the critical path; no testops golden yet, so trace-shape regressions across releases are unguarded |
+| Client contract validation (`validate=response`/`strict`) | 2 | Unit tests for schema mismatch, undeclared status, gRPC unknown fields; `poc/client-rfc055` end-to-end | 🟡 | OpenAPI 3.0 only (3.1 untested); JSON bodies only |
 | Stdlib recipes (embedded .star) | 2 | 13 shipped, tested via protocol unit tests | 🟡 | No regression against recipe contents |
 | `monitor()` / `partition()` / `nondet()` / `events()` | 2 | No dedicated coverage | 🔴 | Covered only if a corpus spec uses them |
 | Named operations `op()` | 2 | Unit tests | 🟡 | |
@@ -138,7 +140,7 @@ Protocol-level fault proxy rewrites wire-level responses. Critical because this 
 ## Summary counts
 
 - Critical (Tier 1): 15 rows, **100% green**. 🎉
-- Supported (Tier 2): 22 rows, **~55% green**.
+- Supported (Tier 2): 24 rows, **~55% green**.
 - Experimental (Tier 3): 8 rows, **~0% green** — expected; these are checklist-gated.
 
 PR #64 (proxy teardown, closes #57 + #61) + PR #62 (openat matching,

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,10 @@ Fault injection for distributed systems using Linux seccomp-notify.
 
 ## Reference
 
-- [Spec Language](spec-language.md) -- Complete Starlark API: services, faults, assertions, protocols
+- [Spec Language](spec-language.md) -- Complete Starlark API: services, clients, faults, assertions, protocols
 - [CLI Reference](cli-reference.md) -- All commands and flags
 - [Error Codes](errno-reference.md) -- Errno values for syscall fault injection
+- [Contract-Driven Clients](tutorial/05-advanced/28-contract-clients.md) -- Generate typed callers from OpenAPI / protobuf; named actors in the trace
 
 ## Design
 

--- a/docs/rfcs/0055-clients.md
+++ b/docs/rfcs/0055-clients.md
@@ -1,9 +1,10 @@
 # RFC-055: `client()` — Contract-Driven Callers as First-Class Trace Actors
 
-- **Status:** Accepted — implementation in progress on `epic/rfc-055-clients`
+- **Status:** Implemented — all four phases shipped on `epic/rfc-055-clients`
 - **Target:** v0.15.0 (candidate; independent of the v0.14.0 gVisor epic)
 - **Created:** 2026-07-28
 - **Accepted:** 2026-07-29 — all eight open questions resolved per strawman
+- **Implemented:** 2026-07-29 — Phases 1–4 (see "What shipped" below)
 - **Discussion:** TBD
 - **Depends on:** RFC-021 (OpenAPI ingestion — v0.9.3), RFC-023 (proto descriptor ingestion — v0.9.0), RFC-024 (proxy datapath — v0.9.5)
 - **Relates to:** RFC-041 (temporal anchors), RFC-050 (`load()` traffic driver), RFC-052 (agent-first surface)
@@ -636,6 +637,45 @@ Revisit only if someone needs to inject syscall faults into the caller.
 - End-to-end: a `poc/` spec driving a `mock_service(openapi=)` with a
   `client(openapi=)` over the *same* document, under a proxy fault, asserting
   the contract violation is detected.
+
+## What shipped
+
+| Phase | Landed |
+|---|---|
+| 1 | `internal/protocol/client_contract.go` (OperationTable, naming, collisions, suggestions), `openapi_client.go` (operation walk, request binding, request/response conformance), `grpc_client.go` (descriptor walk, dynamicpb encode, unary invoke, typed decode). `http.go` accepts HEAD/OPTIONS and reports the response content type. |
+| 2 | `internal/star/client.go` (ClientVal, OperationVal, call path, `before=` hook, event emission), `client_builtins.go` (the builtin, contract resolution, name validation). `Response` gains `.client` / `.operation` / `.contract_ok` / `.contract_error`. `registerService` returns an error so names can't collide. |
+| 3 | `report.go` anchorTypes, `app.js` (`isCallEvent`/`isSendEvent`/`isRecvEvent` replacing ten inline checks), `results.go` normalized trace, `recentAssertionContext`, dotted `event_type` in `events.go`. |
+| 4 | `faultbox inspect --clients`, `docs/spec-language.md` §Contract-Driven Clients, `docs/cli-reference.md`, `poc/client-rfc055/`. |
+
+### Deviations from the design above
+
+- **`events()` needed widening.** §5.6 assumed client events would be
+  queryable. They were not: `events()` filtered to a hard-coded four types
+  (`syscall`, `stdout`, `topic`, `wal`), so `step_send`/`step_recv` had
+  never been visible to it either. Client types were added;
+  `step_send`/`step_recv` deliberately were not, because admitting them
+  would silently change what `events()` returns for every spec written
+  before now.
+- **A pre-existing path bug surfaced.** `mock_service(openapi=)` and
+  `(descriptors=)` resolved against the process CWD, not the spec
+  directory, so `"./api.yaml"` only worked when `faultbox` ran from the
+  spec's own directory. Fixed to match `load_file()`, `build=`, and the
+  new `client()`.
+- **`grpcProtocol.ExecuteStep` was already non-functional for typed
+  services.** It invokes with raw `[]byte` against grpc-go's proto codec,
+  which only accepts `proto.Message`. Clients do not go through it; they
+  invoke with dynamicpb messages, which is what makes typed calls work.
+  The existing `call()` step method is left as-is — untangling it is not
+  this RFC's business, but it should not be mistaken for a working path.
+- **`before=` is HTTP-only.** The hook reads `headers` and `body` off the
+  returned dict; gRPC calls take client-level and per-call headers but do
+  not run the hook. No design reason, just unbuilt — the auth use case the
+  hook exists for is HTTP-shaped.
+- **Reserved-parameter collisions are load-time errors, not silent
+  renames.** A contract parameter normalizing to `body`, `headers`, or
+  `timeout` can't be bound by name, so the table build fails and points at
+  `client.call(name, params={...})`. This wasn't spelled out in §5.3 and is
+  the reason `call()` takes an explicit `params=` dict.
 
 ## References
 

--- a/docs/rfcs/0055-clients.md
+++ b/docs/rfcs/0055-clients.md
@@ -1,0 +1,650 @@
+# RFC-055: `client()` — Contract-Driven Callers as First-Class Trace Actors
+
+- **Status:** Accepted — implementation in progress on `epic/rfc-055-clients`
+- **Target:** v0.15.0 (candidate; independent of the v0.14.0 gVisor epic)
+- **Created:** 2026-07-28
+- **Accepted:** 2026-07-29 — all eight open questions resolved per strawman
+- **Discussion:** TBD
+- **Depends on:** RFC-021 (OpenAPI ingestion — v0.9.3), RFC-023 (proto descriptor ingestion — v0.9.0), RFC-024 (proxy datapath — v0.9.5)
+- **Relates to:** RFC-041 (temporal anchors), RFC-050 (`load()` traffic driver), RFC-052 (agent-first surface)
+
+## Summary
+
+Add a new topology entity — **`client()`** — that turns a machine-readable
+API contract (OpenAPI 3.x or a protobuf `FileDescriptorSet`) into a
+**named, typed caller** bound to a service interface, and makes that caller
+a **first-class actor in the trace**: its own swim lane, its own vector
+clock, its own event types, and its own anchors for temporal properties.
+
+```python
+courier = service("courier", image = "courier:latest",
+    interface("main", "grpc", 9090, spec = "./proto/courier.pb"))
+
+# One line replaces hand-written wire calls.
+gcourier = client("gRPC-Courier", target = courier.main)
+
+def test_courier_degrades(t):
+    with fault(courier.main, grpc_unavailable()):
+        r = gcourier.get_order(order_id = 42)      # generated from the contract
+        assert_true(not r.ok)
+```
+
+Trace, with no extra instrumentation:
+
+```
+#12  gRPC-Courier  client_call.courier    get_order(order_id=42)          {gRPC-Courier: 3, test: 5}
+#13  courier       syscall.read           allow
+#14  courier       proxy_fault_applied    grpc UNAVAILABLE
+#15  gRPC-Courier  client_return.courier  get_order → UNAVAILABLE (14ms)  {gRPC-Courier: 4, courier: 22}
+```
+
+Today the same test is `courier.main.call(method="/courier.v1.CourierService/GetOrder", body='{"order_id":42}')`
+and appears in the trace as an anonymous `step_send.courier` from the
+generic `test` lane.
+
+## Motivation
+
+### The spec language is contract-blind on the caller side
+
+Faultbox already ingests API contracts — but only to *serve* them.
+RFC-021 generates HTTP mock routes from OpenAPI; RFC-023 generates typed
+gRPC mock responses from a `FileDescriptorSet`. Both are **callee**-side.
+
+On the **caller** side, spec authors hand-assemble every request:
+
+```python
+resp = api.public.post(path = "/v1/orders", body = '{"item_id": "sku-1", "qty": 2}')
+resp = courier.main.call(method = "/courier.v1.CourierService/GetOrder", body = '{"order_id": 42}')
+```
+
+That means the spec author must know, and keep in sync by hand: the exact
+path template, the HTTP verb, required vs optional fields, the JSON field
+names (`order_id` vs `orderId`), the full gRPC method path including
+package. None of it is checked. A typo in a path produces a 404 that looks
+exactly like the failure the test is trying to detect, and a field-name
+typo in a proto request silently marshals to a zero value.
+
+This is the same drift problem RFC-021 identified for mocks —
+*"every manually-authored route is a place the mock and the real contract
+can diverge silently"* — just pointed the other way. We solved it once for
+the mock. The caller still has it.
+
+### The trace can't tell you who called
+
+Every driver-initiated call today is emitted as `step_send` / `step_recv`
+with `service = "test"` (`internal/star/runtime.go:4167`). Consequences:
+
+- **One lane for all callers.** A scenario with a mobile client, a partner
+  integration, and an admin tool driving the same API renders as one
+  undifferentiated `test` lane. You cannot ask "did the *partner* client
+  see the error, or only the *admin* one?"
+- **No causal identity.** The vector clock has a single `test` participant,
+  so ShiViz shows one driver process regardless of how many logical callers
+  the scenario models.
+- **Anchors are positional, not semantic.** `match.event(type="step_send", target="courier")`
+  matches *any* call to courier. There is no stable name for "the moment
+  gRPC-Courier asked for order 42".
+
+The user-visible symptom: reading a failing trace requires re-reading the
+spec to work out which of the six `step_send.courier` events was the one
+that mattered.
+
+### Contract-aware assertions are impossible today
+
+Because the runtime has no schema for the response, a test can only assert
+on what the author hard-codes (`resp.status == 503`). It cannot assert the
+much more interesting property:
+
+> Under fault, the service still returned a response that **conforms to its
+> published contract.**
+
+Degraded responses that are *schema-invalid* — a 200 with a null in a
+non-nullable field, a proto response missing a required oneof — are a
+recurring real-world failure mode and are precisely what fault injection
+should surface. With the contract loaded on the caller side, this becomes
+a one-kwarg check (`validate = "response"`).
+
+### Why now
+
+- Both ingestion paths already exist in-tree and are proven
+  (`internal/protocol/openapi.go`, `internal/protocol/grpc_descriptors.go`).
+  This RFC is mostly *reuse and inversion*, not new parsing.
+- `interface(spec = ...)` has been parsed and stored since early versions
+  and is **read by nothing** (`internal/star/types.go:202`). It is a dangling
+  hook that this RFC either fills or should retire.
+- RFC-050 needs a traffic driver (`load(...)`). A named client is the
+  natural thing to drive load *with*; shipping `load()` first would mean
+  inventing an anonymous request generator and then retrofitting identity.
+- RFC-052 (agent-first surface): a generated client is a typed tool
+  surface. An agent writing a spec can enumerate `get_order(order_id=...)`
+  instead of guessing paths and JSON field names.
+
+### What happens if we don't
+
+Spec authors keep transcribing contracts by hand; traces stay anonymous on
+the driver side; contract-conformance-under-fault stays unassertable; and
+`load()` lands with no identity model, which is much harder to add later
+than to design in now.
+
+## Current state
+
+| Concern | Today | Where |
+|---|---|---|
+| OpenAPI ingestion | Implemented, mock-side only | `internal/protocol/openapi.go` (`LoadOpenAPI`, `findOperation`, `ValidateRequest`) |
+| Proto descriptor ingestion | Implemented, mock-side only | `internal/protocol/grpc_descriptors.go` (`LoadDescriptorSet`, `ResolveMethod`) |
+| Typed proto encoding | Implemented, mock-side only | `internal/protocol/grpc_typed_encoder.go` (`JSONToTypedMessage`) |
+| Driver-initiated calls | Untyped step methods | `Runtime.executeStep` (`internal/star/runtime.go:4120`) |
+| Driver identity in trace | Hard-coded `"test"` | `rt.events.Emit("step_send", "test", …)` |
+| Lane assignment | Keyed on `ev.service` | `internal/report/app.js` |
+| Event matching | `match.event(type=, service=, **fields)` — arbitrary fields | `internal/star/match.go:143` |
+| `interface(spec=)` | Parsed, stored, **never read** | `internal/star/builtins.go:549`, `types.go:202` |
+
+Two facts shape the design:
+
+1. **Lanes and vector clocks are already keyed on the event's `service`
+   string** — nothing requires it to be a real process. Emitting with
+   `service = "<client name>"` gets a lane and a clock participant for free.
+2. **`executeStep` already routes through the proxy when one is up**
+   (`rt.proxyMgr.GetProxyAddr`). A client that reuses that path inherits
+   protocol-level fault injection, TLS (RFC-038), and remote targets
+   (RFC-036) with no new datapath.
+
+## Proposed design
+
+### 5.1 — The entity
+
+```python
+client(
+    name,                       # required — trace identity, must be unique
+    target = <InterfaceRef>,    # required — service interface to call
+    openapi = "./api.yaml",     # OpenAPI 3.x document           } exactly
+    descriptors = "./svc.pb",   # protoc FileDescriptorSet        } one, or
+                                #   inherited from interface(spec=)
+    grpc_service = "pkg.OrderService",  # required if the set declares >1 service
+    base_path = "/v1",          # optional prefix prepended to OpenAPI paths
+    headers = {...},            # static headers applied to every call
+    before = lambda req: req,   # per-call hook (auth tokens, correlation ids)
+    validate = "off",           # "off" | "request" | "response" | "strict"
+    timeout = "5s",             # per-call deadline
+) -> Client
+```
+
+`Client` is a Starlark `HasAttrs` value whose attributes are the operations
+resolved from the contract. Attribute access on an unknown name is a
+load-time-quality error with a suggestion:
+
+```
+client "gRPC-Courier" has no operation "get_orders"
+  (did you mean "get_order"? — 14 operations available, see `faultbox inspect --clients`)
+```
+
+### 5.2 — Operation naming
+
+Deterministic, documented, one canonical name per operation.
+
+**OpenAPI.** `operationId` → snake_case (`getOrder` → `get_order`,
+`GetOrderByID` → `get_order_by_id`). When `operationId` is absent —
+common in real specs — synthesize from method + path:
+`GET /orders/{id}/items` → `get_orders_id_items`. Path parameters
+contribute their name, not a placeholder, so the synthesized name is
+stable under path-template edits that only rename literals.
+
+**gRPC.** proto method name → snake_case (`GetOrder` → `get_order`).
+Service selection via `grpc_service=`; omitting it when the descriptor set
+declares more than one service is a load-time error that lists candidates.
+
+**Collisions** (two operations normalizing to the same name) are a
+**load-time error** naming both source operations. We do not silently
+disambiguate — a spec that can't name its own operations unambiguously
+should say which one it means:
+
+```python
+gcourier = client("gRPC-Courier", target = courier.main,
+    rename = {"getOrderV2": "get_order_v2"})
+```
+
+**Escape hatch.** `c.call("<raw operationId or /pkg.Svc/Method>", **params)`
+invokes by contract-native name, bypassing normalization. Same tracing,
+same validation.
+
+### 5.3 — Call semantics
+
+Parameters are passed as kwargs and bound by name against the contract.
+
+**OpenAPI** — the generated signature partitions kwargs by the operation's
+declared parameter locations:
+
+```python
+r = api.get_order(
+    order_id = 42,                    # → path param {orderId}
+    include = "items",                # → query param
+    headers = {"X-Tenant": "acme"},   # → merged over client-level headers
+)
+r = api.create_order(body = {"item_id": "sku-1", "qty": 2})   # → requestBody
+```
+
+Unknown kwargs are an error (consistent with v0.13.2's strict-kwarg
+direction — see `df781ca`). Missing *required* parameters are an error.
+`body=` accepts a Starlark dict (JSON-encoded) or a string (sent verbatim).
+
+**gRPC** — kwargs are request-message fields, encoded via `dynamicpb`
+through the existing `JSONToTypedMessage` path. Unknown fields error with
+a nearest-name suggestion (the mirror of RFC-023's D-4/Phase-4 error work).
+
+**Return value** is the existing `Response` type, extended:
+
+| Property | Type | Notes |
+|---|---|---|
+| `.status` / `.body` / `.data` / `.ok` / `.error` / `.duration_ms` | — | unchanged |
+| `.operation` | `string` | canonical operation name |
+| `.client` | `string` | client name |
+| `.contract_ok` | `bool` | `True` when the response conformed (or validation off) |
+| `.contract_error` | `string` | first conformance failure, `""` when clean |
+
+Reusing `Response` (rather than a new `ClientResponse`) keeps every
+existing assertion, recipe, and `expect_*` predicate working against client
+calls unchanged.
+
+### 5.4 — Validation modes
+
+| `validate=` | Behaviour |
+|---|---|
+| `"off"` (default) | No schema checks. Byte-identical behaviour to today's step methods. |
+| `"request"` | Outgoing request validated against the contract **before** it is sent; failure is a spec error (your test is wrong). |
+| `"response"` | Response validated against the declared schema for its status code; failure records `contract_ok = False` and emits a `contract_violation` event — **does not** raise. |
+| `"strict"` | Both, and a response violation raises. |
+
+The `"response"` default-to-non-raising is deliberate: a contract violation
+under fault is usually **the finding**, not a harness error. It should land
+in the trace as evidence and let the test's own assertions decide.
+
+Unknown status codes (a 503 the OpenAPI document never declared) count as
+a conformance failure under `"response"` — that is exactly the "undocumented
+degraded path" this is meant to catch.
+
+### 5.5 — Trace model (the core of this RFC)
+
+Two new event types, emitted with `service = <client name>`:
+
+| Event | `event_type` | When |
+|---|---|---|
+| `client_call` | `client_call.<target-service>` | Immediately before the request goes out |
+| `client_return` | `client_return.<target-service>` | Immediately after the response (or transport failure) |
+| `contract_violation` | `contract_violation.<target-service>` | Response failed schema conformance (validate ≥ `"response"`) |
+
+**Fields** (shared schema with `step_send`/`step_recv` wherever the concept
+already exists, so report/assertion/bundle code paths need one allowlist
+entry, not a parallel implementation):
+
+```
+client_call:   client, target, interface, protocol, operation, contract,
+               params (truncated), path|method_path, spec, summary
+client_return: client, target, operation, status_code, grpc_code,
+               duration_ms, success, error, body (non-2xx only, 2KB cap),
+               contract_ok, contract_error, spec, summary
+```
+
+`contract` carries the contract source identity (document path + `info.version`
+for OpenAPI, file + service FQN for proto) so a trace records *which version
+of the contract* the run was checked against.
+
+**Vector clocks.** The client is a genuine participant, so the merge chain
+grows one hop at each end:
+
+```
+test ──merge──► gRPC-Courier ──merge──► courier      (on call)
+test ◄──merge── gRPC-Courier ◄──merge── courier      (on return)
+```
+
+The `test → client` merge on the way out is load-bearing: without it the
+client's lane is causally disconnected from the test body in ShiViz and
+appears as an independent process that spontaneously emits requests.
+
+**Swim lane.** `internal/report/app.js` groups by `ev.service`, so a named
+client gets its own lane with no renderer change. Lane label is the client
+name; a badge distinguishes driver-side lanes from service lanes.
+
+**Bundle downsampling.** `internal/report/report.go`'s keep-set must include
+`client_call` / `client_return` / `contract_violation` alongside
+`step_send` / `step_recv`. These are anchors — dropping them at the default
+downsample level would defeat the feature.
+
+### 5.6 — Anchors and temporal properties
+
+Client events are ordinary events, so `match.event(type=, service=, **fields)`
+(`internal/star/match.go:143`) matches them **with no matcher changes**:
+
+```python
+courier_asked = match.event(type = "client_call",
+                            client = "gRPC-Courier", operation = "get_order")
+courier_failed = match.event(type = "client_return",
+                             client = "gRPC-Courier", operation = "get_order",
+                             success = "false")
+
+test("courier_recovers",
+    body = drive,
+    expect = [
+        # RFC-041: nothing else observes a failure after the client's first success
+        always(no_dropped_orders, between = (courier_asked, courier_failed)),
+        eventually(lambda tr: tr.count(courier_asked) >= 3, anchor = courier_asked),
+    ],
+)
+```
+
+That is the property the motivation asks for: *"gRPC-Courier called
+get_order, and Courier returned a failure"* is now a named, matchable,
+anchorable fact rather than a positional guess.
+
+Two ergonomic additions, both thin sugar over the above (see OQ-3):
+
+- `match.call(client = c, operation = "get_order", ok = False)` — reads
+  better than a four-kwarg `match.event`.
+- `c.get_order.calls` / `.returns` — pre-built matchers hanging off the
+  generated operation attribute, so an anchor is spelled once.
+
+### 5.7 — Interaction with existing subsystems
+
+| Subsystem | Interaction |
+|---|---|
+| **Proxy faults (RFC-024/034)** | Free. Client calls dial `rt.proxyMgr.GetProxyAddr(...)` exactly as `executeStep` does, so `fault(iface, http_500(), …)` applies unchanged. |
+| **Syscall faults** | Unaffected. The client is not a process; it installs no filter and is never a fault target. `fault(<client>, …)` is a load-time error naming the mistake. |
+| **TLS (RFC-038)** | Free — inherited from the target interface's `tls=`. |
+| **Remote services (RFC-036)** | Free — a client against a remote interface dials the remote endpoint. This is arguably the *best* client use case: real cluster pod, contract-driven caller, no image needed. |
+| **Mock services (RFC-017/021/023)** | Symmetric. The same OpenAPI document can drive a mock (callee) and a client (caller); a `client` → `mock_service` pair is a fully contract-checked loop useful for testing Faultbox itself. |
+| **Determinism (RFC-040)** | L1-neutral. No new nondeterminism: parameters are explicit, no synthesis, no random data in v1. Contract loading happens at spec load. |
+| **`faultbox inspect`** | New `--clients` section listing each client, its contract, and its generated operation table — the discoverability answer for "what can I call?". |
+| **RFC-050 `load()`** | Future: `load(client = gcourier, op = "get_order", rate = "50/s")`. Identity model designed here so `load()` doesn't have to invent one. |
+
+### 5.8 — Filling the `interface(spec=)` hook
+
+`interface(name, protocol, port, spec=)` stores a contract path that
+nothing reads. This RFC makes it live: a client whose `openapi=` /
+`descriptors=` is omitted inherits the contract from its target interface,
+selecting the loader by file extension (`.yaml`/`.yml`/`.json` → OpenAPI,
+`.pb`/`.desc` → descriptor set) with the protocol as a cross-check.
+
+```python
+courier = service("courier", image = "courier:latest",
+    interface("main", "grpc", 9090, spec = "./proto/courier.pb"))
+
+gcourier = client("gRPC-Courier", target = courier.main)   # contract inherited
+```
+
+If this RFC is rejected, `interface(spec=)` should be **removed** — a
+parsed-but-ignored kwarg is worse than no kwarg.
+
+## Worked example
+
+```python
+load("@faultbox/recipes/grpc.star", "grpc_faults")
+
+courier = service("courier", image = "courier:1.4",
+    interface("main", "grpc", 9090, spec = "./proto/courier.pb"))
+
+orders = service("orders", image = "orders:2.1",
+    interface("public", "http", 8080, spec = "./openapi/orders.yaml"))
+
+# Two named callers against the same API, different identities.
+mobile  = client("mobile-app", target = orders.public,
+                 headers = {"X-Client": "ios/4.2"}, validate = "response")
+partner = client("partner-api", target = orders.public,
+                 headers = {"X-Client": "partner"}, validate = "strict")
+
+gcourier = client("gRPC-Courier", target = courier.main)
+
+def drive(t):
+    o = mobile.create_order(body = {"item_id": "sku-1", "qty": 2})
+    assert_true(o.ok)
+
+    with fault(courier.main, grpc_faults.unavailable()):
+        r = gcourier.get_order(order_id = o.data["id"])
+        assert_true(not r.ok)
+
+        # Under a failing courier the order API must still honour its contract.
+        status = mobile.get_order(order_id = o.data["id"])
+        assert_true(status.contract_ok,
+                    "degraded response violated contract: " + status.contract_error)
+```
+
+Resulting trace — three distinct driver lanes, each call self-describing:
+
+```
+seq  actor          event                          detail
+ 8   mobile-app     client_call.orders             create_order body={item_id:sku-1,qty:2}
+ 9   orders         syscall.write                  allow  /var/lib/orders/wal
+11   mobile-app     client_return.orders           create_order → 201 (23ms) contract_ok=true
+14   test           fault_applied                  courier.main grpc UNAVAILABLE
+15   gRPC-Courier   client_call.courier            get_order(order_id=1001)
+16   courier        proxy_fault_applied            grpc UNAVAILABLE
+17   gRPC-Courier   client_return.courier          get_order → UNAVAILABLE (11ms)
+18   mobile-app     client_call.orders             get_order(order_id=1001)
+21   mobile-app     client_return.orders           get_order → 200 (140ms)
+22   mobile-app     contract_violation.orders      get_order: /courier_eta: got null, want string
+```
+
+Event #22 is the finding, and it required no assertion to author — only
+`validate="response"` and a contract the service already publishes.
+
+## Impact
+
+- **Breaking changes:** none. `client()` is a new builtin; all existing step
+  methods, events, and matchers are untouched. `interface(spec=)` changes
+  from ignored to meaningful, which can only affect specs that set it
+  *and* declare a client that omits its own contract.
+- **New top-level builtin: one.** RFC-044 rightly pushed back on namespace
+  growth. The cost is accepted here because `client()` is a *topology entity*
+  in the same tier as `service()` and `mock_service()`, not a variant of an
+  existing primitive — and because it retires one dead kwarg. The
+  alternative (§Alternatives, A2) of promoting methods onto `InterfaceRef`
+  adds zero builtins but cannot express identity, which is the point.
+- **Dependencies:** none new. `kin-openapi` (RFC-021) and
+  `google.golang.org/protobuf` (RFC-023) are already required.
+- **Performance:** contract parsing is once per client at spec load —
+  same cost profile as the mock-side loaders. Per-call overhead is one
+  map lookup plus, when validation is on, one schema walk. `validate="off"`
+  is zero added cost over today's step methods.
+- **Security:** new file reads at spec-load time (`openapi=`, `descriptors=`).
+  Identical trust model to `mock_service(openapi=)`. The RFC-021 rule
+  stands: `http://`/`https://` `$ref`s are rejected — `faultbox test` never
+  fetches over the network at load time.
+- **Trace size:** two events per call where there were two before
+  (`step_send`/`step_recv` → `client_call`/`client_return`), plus a
+  violation event only when one occurs. Net-neutral.
+
+## Resolved questions (2026-07-29)
+
+**Every strawman below was accepted as written.** The questions are kept in
+their original form rather than collapsed into a decision table, because the
+reasoning is what implementers need — a bare "replace" tells you nothing
+about why the downstream migration in OQ-1 is the expensive half. Binding
+consequences for implementation:
+
+| OQ | Decision |
+|---|---|
+| 1 | Client calls **replace** `step_send`/`step_recv` for calls made through a client. Downstream consumers (report keep-set, `results.go`, context walk, ShiViz, `--normalize`) migrate in Phase 3. |
+| 2 | The client **is** its own vector-clock participant. `--normalize` fingerprints change only for specs that adopt clients. |
+| 3 | v1 ships **matchers only**. No `match.call(...)` / `c.op.calls` sugar until real specs show how anchors get spelled. |
+| 4 | Missing `operationId` is **synthesized** deterministically per §5.2; the table is discoverable via `faultbox inspect --clients`. |
+| 5 | **Stateless per call** in v1. No cookie jar, no connection reuse, no session pinning. |
+| 6 | Contract validation lives **on the client** in v1. Proxy-side contract checking is a follow-up RFC. |
+| 7 | Auth is **`headers=` + `before=`** only. `before=` composed with `jwt_sign()` covers bearer tokens. |
+| 8 | A client name colliding with a service name is a **hard load-time error**. |
+
+1. **Should client calls *replace* or *coexist with* `step_send`/`step_recv`?**
+   Strawman: replace, for calls made through a client — one call, one pair of
+   events. Emitting both doubles the trace and creates two truths. But every
+   downstream consumer (report keep-set, `results.go` failure context at
+   `internal/star/results.go:575`, `builtins.go:1131` context walk, ShiViz,
+   `--normalize` goldens) has `step_send`/`step_recv` hard-coded and needs a
+   coordinated update. Alternative: keep the existing types and add a
+   `client=` field. Cheaper, but then the lane is still `test` unless we also
+   change the emitted `service`, which is the more invasive half anyway.
+
+2. **Is the client its own vector-clock participant, or a labelled sub-lane
+   of `test`?** Strawman: own participant (§5.5). It makes ShiViz show what
+   is actually being modelled — N logical callers. Cost: `--normalize`
+   fingerprints change for any spec adopting clients (opt-in, so no existing
+   spec breaks), and clock maps grow by one entry per client.
+
+3. **Ship `match.call(...)` and `c.op.calls` sugar in v1, or matchers only?**
+   Strawman: matchers only in v1 (they already work), sugar in v1.1 once we
+   see how anchors are actually spelled in real specs. Avoids adding surface
+   we might get wrong.
+
+4. **OpenAPI operation naming when `operationId` is absent.** The synthesis
+   rule in §5.2 is deterministic but produces long names
+   (`get_orders_id_items`). Alternative: require `operationId` and error
+   otherwise — cleaner names, but rejects a large fraction of real specs.
+   Strawman: synthesize, and surface the generated table in
+   `faultbox inspect --clients` so names are discoverable rather than guessed.
+
+5. **Statefulness.** Cookie jar, connection reuse, HTTP/2 session pinning?
+   Strawman: stateless per call in v1 (matches today's step methods).
+   Session affinity matters for realistic client modelling and for RFC-050
+   load, but it interacts with the proxy's connection accounting
+   (`proxy_conn_open`/`proxy_conn_close`) and deserves its own pass.
+
+6. **Does `validate="response"` belong on the client or on the service?**
+   Contract conformance is arguably a property *of the service*, and
+   declaring it once on `interface(spec=)` would check it for all callers
+   including SUT-internal traffic through the proxy. Strawman: client-side
+   in v1 (that's where the response is decoded and where the schema is
+   already loaded); proxy-side contract checking is a strictly larger
+   feature and a good follow-up RFC.
+
+7. **Auth beyond `headers=` + `before=`.** OAuth2 client-credentials flows,
+   mTLS client certs, token refresh. Strawman: out of scope for v1;
+   `before=` composed with the existing `jwt_sign()` builtin covers the
+   common bearer-token case. Revisit on first customer ask.
+
+8. **Client-name collisions with service names.** Both occupy the same lane
+   and clock namespace. Strawman: hard load-time error. Cheap, and the
+   alternative (silent aliasing of two actors into one lane) is a debugging
+   nightmare.
+
+## Implementation plan
+
+### Phase 1 — Contract → operation table (no Starlark surface)
+
+1. `internal/protocol/openapi_client.go` — walk `OpenAPISpec.Doc` into an
+   `[]Operation{Name, Method, PathTemplate, Params, RequestSchema, ResponsesByStatus}`.
+   Reuses the existing loader; adds naming + collision detection.
+2. `internal/protocol/grpc_client.go` — walk a `protoregistry.Files` into the
+   same `Operation` shape; typed unary invoke plus response→dict decoding
+   (the inverse of `JSONToTypedMessage`).
+3. Response conformance checking for both (OpenAPI: schema-by-status;
+   proto: decode success + unknown-field report).
+
+### Phase 2 — Starlark surface
+
+4. `internal/star/client.go` — `ClientVal` (`HasAttrs`), `OperationVal`
+   (callable), kwarg→parameter binding, near-miss suggestions.
+5. `internal/star/client_builtins.go` — the `client()` builtin, contract
+   selection, `interface(spec=)` inheritance, name-collision validation.
+6. `Response` gains `.operation` / `.client` / `.contract_ok` / `.contract_error`.
+
+### Phase 3 — Trace integration
+
+7. Factor the emit half of `executeStep` into a shared helper so
+   `step_send`/`step_recv` and `client_call`/`client_return` have one
+   source of truth for field construction and truncation.
+8. Client-aware clock merges (§5.5); `contract_violation` emission.
+9. Report: lane label + badge, drill-down rows for operation/params/
+   contract result, keep-set entries in `internal/report/report.go`.
+10. Failure-context walk (`internal/star/builtins.go:1119`) and
+    `results.go:575` learn the new types.
+
+### Phase 4 — DX + docs
+
+11. `faultbox inspect --clients` — per-client operation table.
+12. `docs/spec-language.md`: `Client` type reference, `client()` section,
+    new event types in the Trace Output table.
+13. Tutorial chapter mirroring the mock-services chapter.
+14. `poc/` example spec exercising an OpenAPI client and a gRPC client
+    against the existing demo topology.
+
+### Explicitly out of scope for v1
+
+- **Streaming RPCs** (mirrors RFC-023 resolved-question 1 — wait for a
+  concrete ask).
+- **Load generation / concurrency** — belongs to RFC-050's `load()`.
+- **Request-data synthesis / fuzzing** — would introduce nondeterminism
+  that needs a seeding story; explicit params only in v1.
+- **Other contract formats** — GraphQL, AsyncAPI, Avro, Thrift, WSDL.
+- **Client-side retry / backoff / circuit-breaker emulation.** Tempting
+  (it is how real clients behave under fault) but it is a *behaviour*
+  model, not a contract model, and would blur what the trace attributes
+  to the SUT versus the harness.
+- **Recording real traffic into a client** (HAR/pcap → replay).
+
+## Alternatives considered
+
+**A1 — Do nothing; keep hand-written step calls.** Rejected: it is the
+status quo the motivation describes, and it leaves `interface(spec=)` dead.
+
+**A2 — Promote generated methods onto `InterfaceRef` instead of a new
+entity.** `interface("main", "grpc", 9090, spec="./courier.pb")` would make
+`courier.main.get_order(...)` work with zero new builtins — genuinely
+attractive on namespace grounds. Rejected because it cannot express *caller
+identity*: there is one interface but N logical callers, and the whole
+trace-clarity half of this RFC depends on distinguishing them. It also
+conflates "what this service offers" with "who is calling it". Note the two
+are compatible — if demand appears, `InterfaceRef` promotion can be added
+later as sugar for an implicit default client.
+
+**A3 — Code-generate a `.star` client module from the contract
+(`faultbox generate client`).** Rejected on the same grounds RFC-021
+rejected generated route tables: it reintroduces the drift the feature
+exists to close, and it adds a build step before `faultbox test`.
+
+**A4 — Wrap an existing client generator (openapi-generator, protoc plugins)
+and shell out.** Rejected: third-party runtime dependency, per-language
+toolchains, and it produces code in a language the spec can't call anyway.
+
+**A5 — Keep `step_send`/`step_recv` and add a `client=` field only.**
+Cheapest possible change, and it does give per-client filtering. Rejected as
+the primary design because the lane and the vector clock both key on
+`service`, so the trace would still show every client in the `test` lane —
+which is the actual complaint. Retained as the fallback in OQ-1 if the
+downstream-consumer migration proves larger than estimated.
+
+**A6 — Model the client as a real process (a spawned binary under seccomp).**
+Maximally faithful — the client could then be faulted itself. Rejected for
+v1: it requires shipping a generic contract-driven client *binary*, cross-
+compiling it per platform, and it drags in the whole container/binary
+lifecycle for something whose value is the trace identity, not the isolation.
+Revisit only if someone needs to inject syscall faults into the caller.
+
+## Tests
+
+- `internal/protocol/openapi_client_test.go` — naming (operationId,
+  camelCase, missing-id synthesis, collisions), parameter partitioning
+  (path/query/header/body), required-param enforcement, response
+  conformance by status, undeclared-status handling.
+- `internal/protocol/grpc_client_test.go` — method resolution, field
+  encoding/decoding round-trip, unknown-field suggestion, multi-service
+  descriptor set requiring `grpc_service=`.
+- `internal/star/client_test.go` — `client()` load-time validation
+  (contract inheritance from `interface(spec=)`, name collisions with
+  services, both-contracts-supplied error, syscall-fault targeting refusal),
+  attribute suggestions, kwarg binding errors.
+- `internal/star/client_trace_test.go` — event emission (types, fields,
+  `service` = client name), vector-clock merge chain, `contract_violation`
+  emission, matcher/anchor integration with `always`/`eventually`.
+- `internal/report/` — keep-set retention of client events at each
+  downsample level; lane assignment.
+- End-to-end: a `poc/` spec driving a `mock_service(openapi=)` with a
+  `client(openapi=)` over the *same* document, under a proxy fault, asserting
+  the contract violation is detected.
+
+## References
+
+- RFC-017 (Native Mock Services) — the callee-side entity this mirrors.
+- RFC-021 (OpenAPI-Driven Mock Generation) — OpenAPI loader reused here.
+- RFC-023 (Typed-Proto gRPC Mocks) — descriptor loader + typed encoder reused here.
+- RFC-024 / RFC-034 (Proxy datapath & observability) — the fault path client calls traverse.
+- RFC-036 (Remote Services) — highest-value client target.
+- RFC-041 (Temporal Properties) — the anchor machinery client events plug into.
+- RFC-044 (Spec Language Simplification) — the namespace-growth bar this RFC argues against.
+- RFC-050 (Gray & Metastable Faults) — `load()` consumer of the client identity model.
+- RFC-052 (Agent-First Surface) — generated operations as an agent-facing tool surface.

--- a/docs/rfcs/0055-clients.md
+++ b/docs/rfcs/0055-clients.md
@@ -5,7 +5,7 @@
 - **Created:** 2026-07-28
 - **Accepted:** 2026-07-29 — all eight open questions resolved per strawman
 - **Implemented:** 2026-07-29 — Phases 1–4 (see "What shipped" below)
-- **Discussion:** TBD
+- **Discussion:** [#149](https://github.com/faultbox/Faultbox/issues/149)
 - **Depends on:** RFC-021 (OpenAPI ingestion — v0.9.3), RFC-023 (proto descriptor ingestion — v0.9.0), RFC-024 (proxy datapath — v0.9.5)
 - **Relates to:** RFC-041 (temporal anchors), RFC-050 (`load()` traffic driver), RFC-052 (agent-first surface)
 

--- a/docs/spec-language.md
+++ b/docs/spec-language.md
@@ -114,6 +114,9 @@ Every builtin grouped by what it's for. Use Cmd-F to jump.
 [`regex_decoder`](#event-sources),
 [`monitor`](#monitors).
 
+**Contract-driven clients** (RFC-055) —
+[`client`](#clientname-target-openapi-descriptors-).
+
 **Concurrency primitives** —
 [`parallel`](#concurrency).
 
@@ -459,7 +462,7 @@ selects which plugin handles step methods and healthchecks.
 | `name` | string | **yes** | Your name for this interface (arbitrary) |
 | `protocol` | string | **yes** | Plugin name — determines available methods |
 | `port` | int | **yes** | Port number |
-| `spec` | string | no | Path to protocol spec file (OpenAPI, protobuf, Avro) |
+| `spec` | string | no | Path to a contract file (OpenAPI `.yaml`/`.json`, protobuf `.pb`). Read by [`client()`](#clientname-target-openapi-descriptors-) when it declares no contract of its own. |
 | `tls` | `tls_cert(...)` | no | TLS material for the interface's proxy (RFC-038). See [TLS Support](#tls-support). |
 
 **What's user-defined:** The name is yours. The protocol must match a
@@ -1089,6 +1092,146 @@ nicer call site for protocols where `routes={}` doesn't fit.
 
 See the [Mock Services reference](mock-services.md) for the per-protocol
 matrix, scope, and what mocks deliberately don't do.
+
+---
+
+
+## Contract-Driven Clients (RFC-055)
+
+### `client(name, target=, openapi=, descriptors=, ...)`
+
+Turns an API contract into a **named caller** bound to a service
+interface. Operations become callable attributes; the client becomes its
+own actor in the trace.
+
+```python
+orders  = service("orders", interface("public", "http", 8080), image = "orders:2.1")
+courier = service("courier", interface("main", "grpc", 9090, spec = "./courier.pb"),
+                  image = "courier:1.4")
+
+mobile   = client("mobile-app",   target = orders.public, openapi = "./orders.yaml",
+                  headers = {"X-Client": "ios/4.2"}, validate = "response")
+gcourier = client("gRPC-Courier", target = courier.main)   # contract from interface(spec=)
+
+def test_order_flow():
+    o = mobile.create_order(body = {"item_id": "sku-1", "qty": 2})
+    r = gcourier.get_order(order_id = o.data["id"])
+```
+
+| Param | Notes |
+|---|---|
+| `name` | **Required.** The client's trace identity — its swim lane and vector-clock participant. Must not collide with a service name or with `"test"`. |
+| `target` | **Required.** An `InterfaceRef` (`svc.iface`). Calls route through the interface's proxy when one is up, so protocol faults apply unchanged. |
+| `openapi` | Path to an OpenAPI 3.x document. Resolved relative to the spec file. |
+| `descriptors` | Path to a protoc `FileDescriptorSet` (`--include_imports --descriptor_set_out`). |
+| `grpc_service` | Fully-qualified service name. Required when the descriptor set declares more than one; the error lists the candidates. |
+| `base_path` | Prefix prepended to every OpenAPI path (`"/v1"`). |
+| `headers` | Static headers applied to every call. Per-call `headers=` overrides them. |
+| `before` | `lambda req: {...}` run before each HTTP request. Reads `headers` and `body` off the returned dict — the hook for auth tokens and correlation ids. |
+| `rename` | `{contract_name: canonical_name}`. The documented fix for a name collision. A key matching no operation is an error. |
+| `validate` | `"off"` (default), `"request"`, `"response"`, `"strict"`. See below. |
+| `timeout` | Per-call deadline (`"5s"`). |
+
+Pass exactly one of `openapi=` / `descriptors=`, or omit both and declare
+the contract once on the interface with
+[`interface(..., spec=)`](#interfacename-protocol-port-spec-tls). The loader
+is picked by extension: `.yaml` / `.yml` / `.json` → OpenAPI,
+`.pb` / `.desc` / `.protoset` → descriptor set.
+
+### Operation naming
+
+Contract-native names normalize to snake_case, deterministically:
+
+| Contract | Generated |
+|---|---|
+| `getOrder` | `get_order` |
+| `GetOrderByID` | `get_order_by_id` |
+| `ListOrdersV2` | `list_orders_v2` |
+| `HTTPServer` | `http_server` |
+| *(no `operationId`)* `GET /orders/{orderId}/items` | `get_orders_order_id_items` |
+
+Two operations that normalize to the same name are a **load-time error**
+naming both — fix it with `rename=`. Run
+`faultbox inspect --clients <spec.star>` to see the whole table.
+
+### Calling
+
+Parameters bind by name against the contract. Unknown kwargs are an error
+with a nearest-match suggestion; missing required parameters are an error.
+
+```python
+r = mobile.get_order(order_id = 42, include = "items")   # path + query
+r = mobile.create_order(body = {"item_id": "sku-1"})     # requestBody
+r = gcourier.get_order(order_id = 42)                    # proto request fields
+
+# Escape hatch — call by contract-native name, params in an explicit dict.
+r = mobile.call("getOrder", params = {"order_id": 42})
+```
+
+Returns the same [`Response`](#type-response) as a step method, with four
+extra properties: `.client`, `.operation`, `.contract_ok`, `.contract_error`.
+
+Streaming gRPC methods are skipped when the table is built — v1 is
+unary-only. The rest of the descriptor set still loads.
+
+### Validation modes
+
+| `validate=` | Behaviour |
+|---|---|
+| `"off"` (default) | No schema checks. Identical behaviour to a hand-written step method. |
+| `"request"` | The outgoing request is checked **before** it is sent. A failure raises — your test asked for something the contract doesn't describe. |
+| `"response"` | The response is checked against the schema declared for its status code. A failure sets `.contract_ok = False`, records `.contract_error`, and emits a `contract_violation` event — **it does not raise.** |
+| `"strict"` | Both, and a response violation raises. |
+
+`"response"` deliberately doesn't raise: a contract violation under fault
+is usually *the finding*, not a harness error. It belongs in the trace as
+evidence, with the test's own assertions deciding what it means.
+
+An **undeclared status code** counts as a violation — that's the
+undocumented degraded path this is meant to surface. For gRPC, a non-OK
+status is an *outcome*, not a violation; drift shows up as unknown response
+fields (the server's proto is newer than your contract).
+
+### Clients in the trace
+
+Client events carry `service = <client name>`, which is what the event log
+keys lanes and vector clocks on. Three named callers against one API render
+as three lanes, not one anonymous `test` driver.
+
+```
+seq  actor          event                      detail
+ 8   mobile-app     client_call.orders         create_order body={item_id:sku-1,qty:2}
+11   mobile-app     client_return.orders       create_order → 201 (23ms) contract_ok=true
+15   gRPC-Courier   client_call.courier        get_order(order_id=1001)
+17   gRPC-Courier   client_return.courier      get_order → UNAVAILABLE (11ms)
+22   mobile-app     contract_violation.orders  get_order: /courier_eta: got null, want string
+```
+
+Because they're ordinary events, they work as
+[temporal anchors](#temporal-primitives-rfc-041) with no new matcher syntax,
+and as [`events()`](#event-query) queries:
+
+```python
+courier_failed = match.event(type = "client_return",
+                             client = "gRPC-Courier", operation = "get_order",
+                             success = "false")
+
+test("courier_recovers", body = drive, expect = [
+    always(no_dropped_orders, between = ("body_start", courier_failed)),
+])
+
+bad = events(where = lambda e: e.type == "contract_violation" and e.client == "mobile-app")
+```
+
+### What clients are not
+
+A client is a **trace actor, not a process**. It installs no seccomp
+filter and is never a fault target — `fault(<client>, ...)` is an error.
+Faults go on the *service* it calls, and apply to client traffic exactly as
+they do to step methods.
+
+Determinism-wise clients are neutral: parameters are explicit, nothing is
+synthesized, and contracts load once at spec load.
 
 ---
 
@@ -3457,6 +3600,9 @@ Events use dotted `event_type` for PObserve compatibility:
 | `syscall.fsync` | `fsync` syscall intercepted |
 | `step_send.<service>` | Test driver sent request to service |
 | `step_recv.<service>` | Test driver received response from service |
+| `client_call.<service>` | A `client()` sent a contract-bound request. Emitted on the **client's** lane, not `test`. |
+| `client_return.<service>` | The client received a response (or a transport failure) |
+| `contract_violation.<service>` | A response failed schema conformance (`validate="response"` or `"strict"`) |
 | `fault_applied` | Fault rules activated on a service |
 | `fault_removed` | Fault rules deactivated |
 | `proxy_conn_open` | Transparent proxy accepted client + dialed upstream (RFC-034) |

--- a/docs/tutorial/05-advanced/28-contract-clients.md
+++ b/docs/tutorial/05-advanced/28-contract-clients.md
@@ -1,0 +1,343 @@
+# Chapter 28: Contract-Driven Clients — Call Your API Without Writing Requests
+
+**Duration:** 20 minutes
+**Prerequisites:** [Chapter 19 (OpenAPI Mocks)](19-openapi-mocks.md) or
+[Chapter 18 (Typed gRPC Mocks)](18-typed-grpc-mocks.md), an OpenAPI 3.x
+document or a protobuf `FileDescriptorSet`
+
+## Goals & purpose
+
+Chapters 18 and 19 pointed Faultbox at your contract to build a **mock** —
+the thing your service *calls*. This chapter points it at a contract from
+the other side, to build a **client** — the thing that calls *your* service.
+
+Today a request in a spec looks like this:
+
+```python
+resp = api.public.post(path = "/v1/orders", body = '{"item_id": "sku-1", "qty": 2}')
+resp = courier.main.call(method = "/courier.v1.CourierService/GetOrder",
+                         body = '{"order_id": 42}')
+```
+
+You had to know the path template, the verb, the field names (`order_id`,
+not `orderId`), and the full gRPC method path including package. Nothing
+checks any of it. A typo in a path returns a 404 that looks exactly like
+the failure you were testing for, and a misspelled proto field silently
+marshals to a zero value.
+
+`client()` (shipped in RFC-055) generates all of that from the contract.
+But the reason to reach for it isn't only the typing — it's that a client
+is a **named actor in the trace**, which changes what a failing run can
+tell you.
+
+This chapter teaches you to:
+
+- **Generate a caller** from an OpenAPI document or a proto descriptor set.
+- **Read a trace with several named callers** instead of one anonymous
+  `test` lane.
+- **Assert contract conformance under fault** — that a degraded service
+  still returns what it published.
+- **Use client calls as temporal anchors**.
+
+## 1 · Your first client
+
+Take the orders API from Chapter 19. Point a client at it:
+
+```python
+orders = service("orders", interface("public", "http", 8080), image = "orders:2.1")
+
+api = client("mobile-app",
+    target  = orders.public,
+    openapi = "./specs/orders.yaml",
+)
+
+def test_fetch_order():
+    resp = api.get_order(order_id = 42)
+    assert_eq(resp.status, 200)
+```
+
+`get_order` was never declared anywhere in your spec. It came from the
+document's `operationId: getOrder`, normalized to snake_case. `order_id =
+42` bound to the `{orderId}` path parameter because the contract says
+that's a path parameter.
+
+Ask what else you can call:
+
+```bash
+$ faultbox inspect --clients faultbox.star
+mobile-app
+  target:    orders.public (http)
+  contract:  openapi:./specs/orders.yaml@1.4.0
+  validate:  off
+  operations (2):
+    create_order(body)     POST /orders
+    get_order(order_id)    GET /orders/{orderId}
+```
+
+Misspell one and the error tells you what you meant:
+
+```
+client "mobile-app" has no operation "get_orders" (did you mean "get_order"?)
+  2 operations available — run `faultbox inspect --clients` for the full table
+```
+
+### Naming rules
+
+Contract names become snake_case, deterministically:
+
+| Contract | Generated |
+|---|---|
+| `getOrder` | `get_order` |
+| `GetOrderByID` | `get_order_by_id` |
+| `ListOrdersV2` | `list_orders_v2` |
+| *(no `operationId`)* `GET /orders/{orderId}/items` | `get_orders_order_id_items` |
+
+If two operations collide, Faultbox refuses to load and names both — pass
+`rename = {"getOrderV2": "fetch_order_v2"}` to say which is which.
+
+### Declaring the contract once
+
+If you already tell the interface where its contract lives, the client
+inherits it:
+
+```python
+courier = service("courier",
+    interface("main", "grpc", 9090, spec = "./proto/courier.pb"),
+    image = "courier:1.4")
+
+gcourier = client("gRPC-Courier", target = courier.main)   # no contract kwarg
+```
+
+The loader is picked by extension: `.yaml` / `.yml` / `.json` → OpenAPI,
+`.pb` / `.desc` / `.protoset` → descriptor set.
+
+## 2 · gRPC clients
+
+Same builtin, different contract. Request-message fields become kwargs:
+
+```python
+gcourier = client("gRPC-Courier",
+    target      = courier.main,
+    descriptors = "./proto/courier.pb",
+)
+
+def test_courier_lookup():
+    r = gcourier.get_order(order_id = 42)
+    print(r.data["courier_eta"])
+```
+
+Fields encode against the *real* message type via the descriptor set — the
+same machinery Chapter 18's typed mocks use, pointed the other way. A
+misspelled field is caught before anything reaches the wire:
+
+```
+get_order(include_items=…, order_id=…): encode as courier.v1.GetOrderRequest:
+  unknown field "order_ids" (did you mean "order_id"?)
+```
+
+If the descriptor set declares more than one service, say which:
+
+```python
+gcourier = client("gRPC-Courier",
+    target       = courier.main,
+    descriptors  = "./proto/all_upstreams.pb",
+    grpc_service = "courier.v1.CourierService",
+)
+```
+
+Omitting `grpc_service=` on a multi-service set is an error that lists the
+candidates. Streaming methods are skipped — v1 is unary-only, and the rest
+of the descriptor set still loads.
+
+## 3 · Why a *named* client: reading the trace
+
+Here's the part that isn't about typing.
+
+Every request the test driver makes is recorded as `step_send` from a
+service called `test`. Three logical callers — a mobile app, a partner
+integration, an admin tool — all land in one lane. You cannot ask "did the
+*partner* client see the error, or only the admin one?"
+
+Give them names:
+
+```python
+mobile  = client("mobile-app",  target = orders.public, openapi = CONTRACT,
+                 headers = {"X-Client": "ios/4.2"})
+partner = client("partner-api", target = orders.public, openapi = CONTRACT,
+                 headers = {"X-Client": "partner/1.0"})
+admin   = client("admin-tool",  target = orders.public, openapi = CONTRACT,
+                 headers = {"X-Client": "admin"})
+```
+
+Now each has its own swim lane in the report and its own vector-clock
+participant in ShiViz:
+
+```
+seq  actor          event                     detail
+ 8   mobile-app     client_call.orders        create_order body={item_id:sku-1,qty:2}
+11   mobile-app     client_return.orders      create_order → 201 (23ms)
+15   gRPC-Courier   client_call.courier       get_order(order_id=1001)
+17   gRPC-Courier   client_return.courier     get_order → UNAVAILABLE (11ms)
+19   partner-api    client_call.orders        get_order(order_id=1001)
+21   partner-api    client_return.orders      get_order → 200 (140ms)
+```
+
+You can query by caller:
+
+```python
+partner_failures = events(where = lambda e:
+    e.type == "client_return" and e.client == "partner-api" and e.success == "false")
+```
+
+## 4 · Contract conformance under fault
+
+This is the capability that doesn't exist without a client.
+
+Your service is supposed to degrade gracefully when the courier upstream
+dies. It returns 200 — but with `courier_eta` set to `null`, which its own
+OpenAPI document declares non-nullable. Every consumer's deserializer
+throws. No assertion you'd think to write catches this, because you'd have
+to guess the field.
+
+Turn on response validation:
+
+```python
+mobile = client("mobile-app",
+    target   = orders.public,
+    openapi  = "./specs/orders.yaml",
+    validate = "response",
+)
+
+def test_degraded_response_still_honours_the_contract():
+    with fault(courier.main, grpc_faults.unavailable()):
+        resp = mobile.get_order(order_id = 1001)
+
+        assert_eq(resp.status, 200)          # it "worked"
+        assert_true(resp.contract_ok,        # ...did it?
+                    "degraded response broke the contract: " + resp.contract_error)
+```
+
+Run it and the trace carries the finding as its own event:
+
+```
+#22  mobile-app  contract_violation.orders  get_order: Error at "/courier_eta": Value is not nullable
+```
+
+### The four modes
+
+| `validate=` | Behaviour |
+|---|---|
+| `"off"` (default) | No checks. Identical to a hand-written step method. |
+| `"request"` | Checks the outgoing request **before** sending. Raises — your test asked for something the contract doesn't describe. |
+| `"response"` | Checks the response; sets `.contract_ok` / `.contract_error`, emits `contract_violation`. **Does not raise.** |
+| `"strict"` | Both, and a response violation raises. |
+
+`"response"` deliberately doesn't raise. A contract violation under fault
+is usually *the finding*, not a harness error — it belongs in the trace as
+evidence, with your assertions deciding what it means.
+
+**An undeclared status counts as a violation.** If your document declares
+only 200 and 404 for an operation and the service returns 503, that's the
+undocumented degraded path — exactly what you want surfaced.
+
+For gRPC, a non-OK status is an *outcome*, not a violation (your test
+decides whether `UNAVAILABLE` was expected). Drift shows up instead as
+unknown response fields — the server's proto is newer than your contract.
+
+## 5 · Client calls as anchors
+
+Client events are ordinary events, so the temporal primitives from
+[Chapter 15](../04-safety/15-monitors.md) work with no new syntax:
+
+```python
+courier_failed = match.event(type = "client_return",
+                             client = "gRPC-Courier",
+                             operation = "get_order",
+                             success = "false")
+
+test("orders_never_drops_under_courier_failure",
+    body   = drive_traffic,
+    expect = always(no_dropped_orders, between = ("body_start", courier_failed)),
+)
+```
+
+Before clients, the closest you could write was
+`match.event(type="step_send", target="courier")` — which matches *any*
+call to courier, from anywhere. Now the anchor says which caller, which
+operation, and whether it failed.
+
+## 6 · Faults, TLS, and remote targets
+
+A client dials through the same proxy your step methods do, so everything
+composes unchanged:
+
+```python
+# The fault goes on the SERVICE. The client is just a caller.
+fault(orders.public, error(status = 503), run = lambda: mobile.get_order(order_id = 1))
+```
+
+TLS ([RFC-038](../../rfcs/0038-tls-aware-proxy.md)) and remote targets
+([RFC-036](../../rfcs/0036-remote-services.md)) are inherited from the
+interface. A client against a remote service is arguably the best use of
+both features together: a real cluster pod, a contract-driven caller, no
+image to distribute.
+
+**A client is a trace actor, not a process.** It runs no code of its own,
+installs no seccomp filter, and is never a fault target. Faulting one is an
+error that points you at the service:
+
+```
+fault(mobile-app): a client is a caller, not a process — it has no syscalls to intercept
+  faults go on the service it calls:
+    fault(orders.public, response(status = 503), run = ...)   # protocol-level
+    fault(orders, write = deny("EIO"), run = ...)             # syscall-level
+```
+
+## 7 · Auth and per-call overrides
+
+Static headers apply to every call; `before=` runs per request, which is
+where token minting goes:
+
+```python
+load("@faultbox/mocks/jwt.star", "jwt")
+
+keys = jwt_keypair()
+
+mobile = client("mobile-app",
+    target  = orders.public,
+    openapi = CONTRACT,
+    headers = {"X-Client": "ios/4.2"},
+    before  = lambda req: {
+        "headers": {"Authorization": "Bearer " + jwt_sign(keys, {"sub": "user-1"})},
+    },
+)
+
+# Per-call headers override both.
+resp = mobile.get_order(order_id = 1, headers = {"X-Request-Id": "abc"})
+```
+
+When an operation's parameter collides with a reserved kwarg (`body`,
+`headers`, `timeout`), or you'd rather paste the `operationId` straight
+from the document, use the escape hatch:
+
+```python
+resp = mobile.call("getOrder", params = {"order_id": 42})
+```
+
+## Takeaways
+
+- `client(name, target=, openapi=/descriptors=)` generates a typed caller
+  from a contract. No paths, verbs, or field names in your spec.
+- The **name is the point**: each client gets its own swim lane and
+  vector-clock participant, so a trace says *who* called.
+- `validate="response"` catches degraded-but-schema-invalid responses —
+  including undeclared status codes — without you guessing the field.
+  It records rather than raises, because that's usually the finding.
+- Client events are ordinary events: they work as `events()` queries and as
+  `always(between=)` / `eventually(anchor=)` anchors with no new syntax.
+- Faults, TLS, and remote targets compose unchanged, because a client dials
+  through the same proxy a step method does.
+- A client is a caller, not a process. Fault the service it calls.
+- `faultbox inspect --clients <spec.star>` answers "what can I call?".
+
+Next: [Chapter 23 — Reading a Report →](23-reports.md)

--- a/docs/tutorial/05-advanced/index.md
+++ b/docs/tutorial/05-advanced/index.md
@@ -13,6 +13,7 @@ define high-level operations, and integrate with LLM agents.
 | [Mock Services](17-mock-services.md) | 25 min | mock_service(), @faultbox/mocks/ stdlib, TLS, faulting mocks, when to use vs real services |
 | [Typed gRPC Mocks](18-typed-grpc-mocks.md) | 20 min | grpc.server(descriptors=...), FileDescriptorSet ingestion, typed responses for compiled-stub clients, reflection + grpcurl |
 | [OpenAPI Mocks](19-openapi-mocks.md) | 15 min | http.server(openapi=...), example strategies, overrides, strict validation |
+| [Contract-Driven Clients](28-contract-clients.md) | 20 min | client(), generated operations from OpenAPI/proto, named callers as trace actors, contract conformance under fault |
 | [`.fb` Bundles](20-bundles.md) | 10 min | Reproducibility-by-default, `faultbox inspect`, sharing runs, zero-traffic hints |
 | [JWT/JWKS Mocks](21-jwt-mocks.md) | 12 min | jwt.server() stdlib, EdDSA tokens, claim minting, JWKS outage faults |
 | [End-to-End: Go Microservice](22-go-microservice-end-to-end.md) | 30 min | Full stack: real containers + typed gRPC mocks + JWT + fault_matrix in one tutorial |

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -49,14 +49,16 @@ make lima-create && make lima-build                 # macOS (one-time)
 
 ## Part 3: Simulate the Boundary
 
-Mock the dependencies you can't run - the fastest path to testing a
-real service whose dependencies belong to other teams.
+Mock the dependencies you can't run, and generate the callers that drive
+your service - both from the contracts you already maintain. The fastest
+path to testing a real service whose neighbours belong to other teams.
 
 | # | Chapter | Duration |
 |---|---------|----------|
 | 17 | [Mock Services](05-advanced/17-mock-services.md) | 25 min |
 | 18 | [Typed gRPC Mocks](05-advanced/18-typed-grpc-mocks.md) | 20 min |
 | 19 | [OpenAPI Mocks](05-advanced/19-openapi-mocks.md) | 20 min |
+| 28 | [Contract-Driven Clients](05-advanced/28-contract-clients.md) | 20 min |
 | 21 | [JWT/JWKS Mocks](05-advanced/21-jwt-mocks.md) | 15 min |
 
 ## Part 4: Real Infrastructure

--- a/internal/protocol/client_contract.go
+++ b/internal/protocol/client_contract.go
@@ -1,0 +1,425 @@
+package protocol
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// This file holds the contract-agnostic half of RFC-055 clients: the
+// operation table a client exposes, the canonical-naming rules that turn
+// contract-native identifiers into Starlark attribute names, and the
+// lookup/suggestion machinery behind "did you mean …?" errors.
+//
+// The OpenAPI and gRPC builders (openapi_client.go, grpc_client.go) both
+// produce an *OperationTable; everything above this layer — the Starlark
+// ClientVal, the trace emitter, `faultbox inspect --clients` — works
+// against the table and never against a contract format directly.
+
+// ContractKind identifies which contract format an operation table came
+// from. Recorded on trace events so a run says which kind of document it
+// was checked against, not just which file.
+type ContractKind string
+
+const (
+	ContractOpenAPI ContractKind = "openapi"
+	ContractGRPC    ContractKind = "grpc"
+)
+
+// ContractInfo identifies the exact contract a client was built from. It
+// lands verbatim in the `contract` field of client_call events so a trace
+// records the contract *version* the run exercised — the difference
+// between "this passed" and "this passed against the API we shipped".
+type ContractInfo struct {
+	Kind ContractKind
+	// Path is the document the contract was loaded from.
+	Path string
+	// Version is the contract's own version marker: `info.version` for
+	// OpenAPI, the fully-qualified service name for gRPC. May be empty
+	// when the document declares none.
+	Version string
+}
+
+// String renders the contract identity for trace fields, e.g.
+// "openapi:orders.yaml@1.4.0" or "grpc:courier.pb#courier.v1.CourierService".
+func (c ContractInfo) String() string {
+	switch c.Kind {
+	case ContractGRPC:
+		if c.Version == "" {
+			return "grpc:" + c.Path
+		}
+		return "grpc:" + c.Path + "#" + c.Version
+	default:
+		if c.Version == "" {
+			return string(c.Kind) + ":" + c.Path
+		}
+		return string(c.Kind) + ":" + c.Path + "@" + c.Version
+	}
+}
+
+// ParamLocation is where a bound parameter travels on the wire.
+type ParamLocation string
+
+const (
+	ParamPath   ParamLocation = "path"
+	ParamQuery  ParamLocation = "query"
+	ParamHeader ParamLocation = "header"
+	ParamCookie ParamLocation = "cookie"
+	// ParamField is a protobuf request-message field. gRPC operations
+	// carry only these.
+	ParamField ParamLocation = "field"
+)
+
+// Param is one caller-supplied input to an operation.
+type Param struct {
+	// Name is the canonical snake_case name the spec author passes as a
+	// Starlark kwarg.
+	Name string
+	// WireName is the contract-native name: the `{orderId}` path
+	// placeholder, the `?include=` query key, the `X-Tenant` header, or
+	// the proto field name.
+	WireName string
+	In       ParamLocation
+	Required bool
+	// Description is carried through for `faultbox inspect --clients`.
+	Description string
+}
+
+// Operation is a single callable entry on a client.
+type Operation struct {
+	// Name is the canonical snake_case Starlark attribute.
+	Name string
+	// ContractName is the contract-native identifier — the OpenAPI
+	// `operationId` (or its synthesized stand-in) or the full gRPC method
+	// path. This is the key accepted by client.call().
+	ContractName string
+	// Method is the HTTP verb (uppercase). Empty for gRPC operations.
+	Method string
+	// PathTemplate is the OpenAPI path with `{param}` placeholders intact.
+	// Empty for gRPC operations.
+	PathTemplate string
+	// FullMethod is the gRPC wire path ("/pkg.Service/Method"). Empty for
+	// HTTP operations.
+	FullMethod string
+	// Summary is a one-line human description from the contract.
+	Summary string
+	// Params are ordered: path, then query, then header, then cookie (or
+	// proto field order for gRPC). Stable across runs.
+	Params []Param
+	// AcceptsBody reports whether the operation declares a request body.
+	// gRPC operations bind fields as params instead and leave this false.
+	AcceptsBody bool
+	// BodyRequired reports whether a declared request body is mandatory.
+	BodyRequired bool
+
+	// openapiOp / grpc descriptors are attached by the respective builders
+	// and consumed by request building and response validation. They stay
+	// unexported so consumers above this package can't reach into a
+	// format-specific representation.
+	openapi *openapiOpRef
+	grpc    *grpcOpRef
+}
+
+// SignatureHint renders the operation as a call the user could paste,
+// e.g. `get_order(order_id, include=…)`. Used in inspect output and in
+// "did you mean" errors.
+func (o *Operation) SignatureHint() string {
+	var required, optional []string
+	for _, p := range o.Params {
+		if p.Required {
+			required = append(required, p.Name)
+		} else {
+			optional = append(optional, p.Name+"=…")
+		}
+	}
+	if o.AcceptsBody {
+		if o.BodyRequired {
+			required = append(required, "body")
+		} else {
+			optional = append(optional, "body=…")
+		}
+	}
+	return o.Name + "(" + strings.Join(append(required, optional...), ", ") + ")"
+}
+
+// Wire renders the operation's wire target for diagnostics and trace
+// summaries: "GET /orders/{orderId}" or "/courier.v1.CourierService/GetOrder".
+func (o *Operation) Wire() string {
+	if o.FullMethod != "" {
+		return o.FullMethod
+	}
+	return o.Method + " " + o.PathTemplate
+}
+
+// OperationTable is the full set of operations a client exposes.
+type OperationTable struct {
+	Contract ContractInfo
+	// ops is keyed by canonical name.
+	ops map[string]*Operation
+	// byContractName lets client.call() accept contract-native names.
+	byContractName map[string]*Operation
+	// order is the sorted canonical-name list — deterministic iteration
+	// for inspect output and error messages.
+	order []string
+}
+
+func newOperationTable(info ContractInfo) *OperationTable {
+	return &OperationTable{
+		Contract:       info,
+		ops:            make(map[string]*Operation),
+		byContractName: make(map[string]*Operation),
+	}
+}
+
+// add registers an operation, rejecting canonical-name collisions. Two
+// operations that normalize to the same attribute are a spec error, not
+// something to disambiguate silently: the caller can't tell which one they
+// would have got, and a rename= entry makes the intent explicit
+// (RFC-055 §5.2).
+func (t *OperationTable) add(op *Operation) error {
+	if prev, exists := t.ops[op.Name]; exists {
+		return fmt.Errorf(
+			"operation name collision: %q and %q both normalize to %q\n"+
+				"  fix: pass rename={%q: \"<other_name>\"} to client()",
+			prev.ContractName, op.ContractName, op.Name, op.ContractName)
+	}
+	t.ops[op.Name] = op
+	t.byContractName[op.ContractName] = op
+	t.order = append(t.order, op.Name)
+	return nil
+}
+
+// finalize sorts the canonical-name order. Called once by each builder
+// after every operation is added.
+func (t *OperationTable) finalize() {
+	sort.Strings(t.order)
+}
+
+// Names returns the canonical operation names in sorted order.
+func (t *OperationTable) Names() []string {
+	out := make([]string, len(t.order))
+	copy(out, t.order)
+	return out
+}
+
+// Len reports how many operations the contract declared.
+func (t *OperationTable) Len() int { return len(t.ops) }
+
+// Operations returns every operation in canonical-name order.
+func (t *OperationTable) Operations() []*Operation {
+	out := make([]*Operation, 0, len(t.order))
+	for _, n := range t.order {
+		out = append(out, t.ops[n])
+	}
+	return out
+}
+
+// Lookup resolves a canonical operation name. Exact match only — the
+// suggestion path lives in Resolve.
+func (t *OperationTable) Lookup(name string) (*Operation, bool) {
+	op, ok := t.ops[name]
+	return op, ok
+}
+
+// LookupContractName resolves a contract-native identifier (operationId or
+// "/pkg.Service/Method"). Backs client.call().
+func (t *OperationTable) LookupContractName(name string) (*Operation, bool) {
+	op, ok := t.byContractName[name]
+	return op, ok
+}
+
+// Resolve looks up an operation by canonical name and, on a miss, returns
+// an error carrying the nearest match. Attribute typos are the single most
+// common client error, and "no operation get_orders" without a suggestion
+// makes the user re-read the contract.
+func (t *OperationTable) Resolve(clientName, name string) (*Operation, error) {
+	if op, ok := t.ops[name]; ok {
+		return op, nil
+	}
+	msg := fmt.Sprintf("client %q has no operation %q", clientName, name)
+	if best, ok := t.nearest(name); ok {
+		msg += fmt.Sprintf(" (did you mean %q?)", best)
+	}
+	msg += fmt.Sprintf("\n  %d operations available — run `faultbox inspect --clients` for the full table",
+		len(t.order))
+	return nil, fmt.Errorf("%s", msg)
+}
+
+// nearest finds the closest canonical name within an edit distance that
+// scales with the length of the query, so short names don't match
+// everything and long names tolerate a typo or two.
+func (t *OperationTable) nearest(name string) (string, bool) {
+	budget := len(name)/3 + 1
+	if budget > 4 {
+		budget = 4
+	}
+	best, bestDist := "", budget+1
+	for _, cand := range t.order {
+		d := editDistance(name, cand)
+		if d < bestDist {
+			best, bestDist = cand, d
+		}
+	}
+	if best == "" || bestDist > budget {
+		return "", false
+	}
+	return best, true
+}
+
+// editDistance is Levenshtein distance over runes, two-row variant. Input
+// sizes here are operation names, so allocation behaviour doesn't matter.
+func editDistance(a, b string) int {
+	ar, br := []rune(a), []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(br)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}
+
+// reservedKwargs are the call-site keyword arguments the client layer owns.
+// A contract parameter normalizing to one of these can't be bound by name,
+// so it's rejected at table-build time with an actionable message rather
+// than silently shadowed at call time.
+var reservedKwargs = map[string]string{
+	"body":    "the request body",
+	"headers": "per-call header overrides",
+	"timeout": "the per-call deadline",
+}
+
+// checkReservedParamName rejects a parameter whose canonical name would
+// collide with a reserved call-site kwarg.
+func checkReservedParamName(opContractName, paramWireName, canonical string) error {
+	purpose, clash := reservedKwargs[canonical]
+	if !clash {
+		return nil
+	}
+	return fmt.Errorf(
+		"operation %q declares parameter %q, which normalizes to the reserved kwarg %q (%s)\n"+
+			"  fix: call this operation via client.call(%q, params={%q: …}) instead of the generated attribute",
+		opContractName, paramWireName, canonical, purpose, opContractName, canonical)
+}
+
+// CanonicalName converts a contract-native identifier into a Starlark
+// attribute name: snake_case, lowercase, digits preserved.
+//
+//	getOrder      → get_order
+//	GetOrderByID  → get_order_by_id
+//	ListOrdersV2  → list_orders_v2
+//	HTTPServer    → http_server
+//	get-order     → get_order
+//
+// A name starting with a digit gets an `op_` prefix so the result is
+// always a valid identifier. Returns an error only when the input has no
+// alphanumeric content at all.
+func CanonicalName(raw string) (string, error) {
+	words := splitIdentifierWords(raw)
+	if len(words) == 0 {
+		return "", fmt.Errorf("cannot derive an operation name from %q (no alphanumeric characters)", raw)
+	}
+	out := strings.Join(words, "_")
+	if unicode.IsDigit(rune(out[0])) {
+		out = "op_" + out
+	}
+	return out, nil
+}
+
+// splitIdentifierWords breaks an identifier into lowercase words on
+// separator characters and camel/Pascal-case boundaries.
+//
+// The boundary rule fires when an uppercase rune follows a lowercase rune
+// or a digit ("orderId" → order|Id), or when it starts a new word inside a
+// run of uppercase ("HTTPServer" → HTTP|Server, because S is followed by a
+// lowercase). Digits continue the current word so "V2" stays one token.
+func splitIdentifierWords(raw string) []string {
+	runes := []rune(raw)
+	var words []string
+	var cur strings.Builder
+
+	flush := func() {
+		if cur.Len() > 0 {
+			words = append(words, cur.String())
+			cur.Reset()
+		}
+	}
+
+	for i, r := range runes {
+		switch {
+		case unicode.IsUpper(r):
+			if cur.Len() > 0 {
+				prev := runes[i-1]
+				nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+				if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && nextLower) {
+					flush()
+				}
+			}
+			cur.WriteRune(unicode.ToLower(r))
+		case unicode.IsLower(r) || unicode.IsDigit(r):
+			cur.WriteRune(r)
+		default:
+			// Any other rune (-, _, ., /, space, …) is a separator.
+			flush()
+		}
+	}
+	flush()
+	return words
+}
+
+// paramToString renders a caller-supplied parameter value for a path
+// segment, query value, or header. Starlark's numeric types arrive as
+// int64/float64; everything else is rejected explicitly so a spec author
+// sees "list not supported here" rather than a mangled "[1 2 3]".
+func paramToString(v any) (string, error) {
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	case bool:
+		if t {
+			return "true", nil
+		}
+		return "false", nil
+	case int:
+		return fmt.Sprintf("%d", t), nil
+	case int64:
+		return fmt.Sprintf("%d", t), nil
+	case float64:
+		// Render integral floats without a trailing ".0" — Starlark ints
+		// that overflowed into float, and JSON-decoded numbers, both land
+		// here and users expect "42" not "42.0".
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t)), nil
+		}
+		return fmt.Sprintf("%g", t), nil
+	default:
+		return "", fmt.Errorf("unsupported parameter value of type %T (expected string, int, float, or bool)", v)
+	}
+}

--- a/internal/protocol/client_contract_test.go
+++ b/internal/protocol/client_contract_test.go
@@ -1,0 +1,166 @@
+package protocol
+
+import "testing"
+
+func TestCanonicalName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// camelCase / PascalCase boundaries.
+		{"getOrder", "get_order"},
+		{"GetOrder", "get_order"},
+		{"GetOrderByID", "get_order_by_id"},
+		{"listOrdersV2", "list_orders_v2"},
+		{"HTTPServer", "http_server"},
+		{"parseXMLDocument", "parse_xml_document"},
+		// Already-snake input is idempotent.
+		{"get_order", "get_order"},
+		{"get_order_by_id", "get_order_by_id"},
+		// Separator forms all collapse to the same name.
+		{"get-order", "get_order"},
+		{"get.order", "get_order"},
+		{"get order", "get_order"},
+		{"get//order", "get_order"},
+		// Digits stay attached to the word they trail.
+		{"order2Item", "order2_item"},
+		{"v2", "v2"},
+		// A leading digit would not be a valid attribute; prefix it.
+		{"2faVerify", "op_2fa_verify"},
+		// Single word.
+		{"health", "health"},
+		{"HEALTH", "health"},
+	}
+	for _, c := range cases {
+		got, err := CanonicalName(c.in)
+		if err != nil {
+			t.Errorf("CanonicalName(%q) returned error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("CanonicalName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCanonicalName_NoAlphanumeric(t *testing.T) {
+	for _, in := range []string{"", "///", "---", "  "} {
+		if _, err := CanonicalName(in); err == nil {
+			t.Errorf("CanonicalName(%q): expected error, got nil", in)
+		}
+	}
+}
+
+func TestContractInfo_String(t *testing.T) {
+	cases := []struct {
+		info ContractInfo
+		want string
+	}{
+		{ContractInfo{Kind: ContractOpenAPI, Path: "orders.yaml", Version: "1.4.0"}, "openapi:orders.yaml@1.4.0"},
+		{ContractInfo{Kind: ContractOpenAPI, Path: "orders.yaml"}, "openapi:orders.yaml"},
+		{ContractInfo{Kind: ContractGRPC, Path: "courier.pb", Version: "courier.v1.CourierService"},
+			"grpc:courier.pb#courier.v1.CourierService"},
+		{ContractInfo{Kind: ContractGRPC, Path: "courier.pb"}, "grpc:courier.pb"},
+	}
+	for _, c := range cases {
+		if got := c.info.String(); got != c.want {
+			t.Errorf("ContractInfo%+v.String() = %q, want %q", c.info, got, c.want)
+		}
+	}
+}
+
+func TestOperationTable_ResolveSuggestsNearestName(t *testing.T) {
+	table := newOperationTable(ContractInfo{Kind: ContractOpenAPI, Path: "x.yaml"})
+	for _, name := range []string{"get_order", "list_orders", "create_order"} {
+		if err := table.add(&Operation{Name: name, ContractName: name}); err != nil {
+			t.Fatalf("add(%q): %v", name, err)
+		}
+	}
+	table.finalize()
+
+	if _, err := table.Resolve("api", "get_order"); err != nil {
+		t.Fatalf("Resolve exact match failed: %v", err)
+	}
+
+	_, err := table.Resolve("api", "get_orders")
+	if err == nil {
+		t.Fatal("Resolve(\"get_orders\"): expected error, got nil")
+	}
+	if !contains(err.Error(), `did you mean "get_order"`) {
+		t.Errorf("expected a get_order suggestion, got: %v", err)
+	}
+	if !contains(err.Error(), "3 operations available") {
+		t.Errorf("expected the operation count in the error, got: %v", err)
+	}
+
+	// A name with nothing close to it should not invent a suggestion.
+	_, err = table.Resolve("api", "zzzzzzzzzzzz")
+	if err == nil {
+		t.Fatal("expected error for unknown operation")
+	}
+	if contains(err.Error(), "did you mean") {
+		t.Errorf("expected no suggestion for a distant name, got: %v", err)
+	}
+}
+
+func TestOperationTable_AddRejectsCollision(t *testing.T) {
+	table := newOperationTable(ContractInfo{Kind: ContractOpenAPI, Path: "x.yaml"})
+	if err := table.add(&Operation{Name: "get_order", ContractName: "getOrder"}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	err := table.add(&Operation{Name: "get_order", ContractName: "get-order"})
+	if err == nil {
+		t.Fatal("expected a collision error")
+	}
+	for _, want := range []string{"getOrder", "get-order", "get_order", "rename="} {
+		if !contains(err.Error(), want) {
+			t.Errorf("collision error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestParamToString(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{"abc", "abc"},
+		{int64(42), "42"},
+		{int(7), "7"},
+		{true, "true"},
+		{false, "false"},
+		{float64(42), "42"},   // integral floats lose the ".0"
+		{float64(1.5), "1.5"}, // genuine fractions keep it
+	}
+	for _, c := range cases {
+		got, err := paramToString(c.in)
+		if err != nil {
+			t.Errorf("paramToString(%v): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("paramToString(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	if _, err := paramToString([]any{1, 2}); err == nil {
+		t.Error("paramToString([]any): expected error for an unsupported type")
+	}
+}
+
+func TestEditDistance(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"get_order", "get_orders", 1},
+		{"kitten", "sitting", 3},
+	}
+	for _, c := range cases {
+		if got := editDistance(c.a, c.b); got != c.want {
+			t.Errorf("editDistance(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/protocol/grpc_client.go
+++ b/internal/protocol/grpc_client.go
@@ -1,0 +1,436 @@
+package protocol
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// gRPC half of RFC-055 clients: turn a protoc FileDescriptorSet into an
+// OperationTable, encode caller kwargs as the operation's real request
+// message, and invoke it.
+//
+// This is the caller-side mirror of RFC-023's typed mock. Both build
+// dynamicpb messages from descriptors loaded by LoadDescriptorSet; the mock
+// encodes responses, the client encodes requests and decodes responses.
+//
+// Note this path does NOT go through grpcProtocol.ExecuteStep. That step
+// method invokes with raw []byte against grpc-go's proto codec, which only
+// accepts proto.Message — it cannot carry a typed request. Clients dial and
+// invoke with dynamicpb messages, which is what makes typed calls work.
+
+// grpcOpRef is the format-specific payload hanging off an Operation built
+// from a proto descriptor set.
+type grpcOpRef struct {
+	input  protoreflect.MessageDescriptor
+	output protoreflect.MessageDescriptor
+	files  *protoregistry.Files
+}
+
+// GRPCRequest is a fully-bound unary gRPC call.
+type GRPCRequest struct {
+	FullMethod string
+	// Message is a dynamicpb message of the operation's real request type,
+	// ready to hand to grpc-go's default proto codec.
+	Message proto.Message
+	// JSON is the canonical JSON rendering of Message, recorded on the
+	// client_call trace event so the trace shows what was actually sent.
+	JSON []byte
+}
+
+// GRPCResponse is the outcome of a unary call.
+type GRPCResponse struct {
+	// Code is the gRPC status code. codes.OK on success.
+	Code     codes.Code
+	CodeName string
+	// Message is the status message when Code != OK.
+	Message string
+	// JSON is the protojson rendering of the response message. Empty when
+	// the call failed.
+	JSON []byte
+	// UnknownFieldBytes counts wire bytes the response descriptor could not
+	// account for — a contract-drift signal surfaced by validate="response".
+	UnknownFieldBytes int
+	DurationMs        int64
+}
+
+// BuildGRPCOperations walks a descriptor registry and produces the
+// operation table a client exposes.
+//
+// serviceFQN selects which service to bind when the descriptor set declares
+// more than one. Passing "" is valid only for single-service sets; anything
+// else is an error listing the candidates, because guessing which of eight
+// upstream services the author meant is exactly the kind of implicit
+// behaviour that produces a confusing failure three steps later.
+//
+// Streaming methods are skipped with the rest of the table still built —
+// v1 is unary-only (RFC-055 "out of scope"), and refusing to load a whole
+// descriptor set because one method streams would block adoption for a
+// feature nobody asked for yet.
+func BuildGRPCOperations(files *protoregistry.Files, sourcePath, serviceFQN string,
+	rename map[string]string) (*OperationTable, error) {
+
+	if files == nil {
+		return nil, fmt.Errorf("nil descriptor registry")
+	}
+
+	svc, err := selectGRPCService(files, sourcePath, serviceFQN)
+	if err != nil {
+		return nil, err
+	}
+
+	table := newOperationTable(ContractInfo{
+		Kind:    ContractGRPC,
+		Path:    sourcePath,
+		Version: string(svc.FullName()),
+	})
+
+	usedRenames := make(map[string]bool, len(rename))
+	methods := svc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		if m.IsStreamingClient() || m.IsStreamingServer() {
+			continue
+		}
+		fullMethod := "/" + string(svc.FullName()) + "/" + string(m.Name())
+
+		canonical := ""
+		if target, ok := rename[string(m.Name())]; ok {
+			usedRenames[string(m.Name())] = true
+			c, err := CanonicalName(target)
+			if err != nil {
+				return nil, fmt.Errorf("rename target %q for method %q: %w", target, m.Name(), err)
+			}
+			canonical = c
+		} else if target, ok := rename[fullMethod]; ok {
+			usedRenames[fullMethod] = true
+			c, err := CanonicalName(target)
+			if err != nil {
+				return nil, fmt.Errorf("rename target %q for method %q: %w", target, fullMethod, err)
+			}
+			canonical = c
+		} else {
+			c, err := CanonicalName(string(m.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("method %s: %w", fullMethod, err)
+			}
+			canonical = c
+		}
+
+		params, err := grpcRequestParams(fullMethod, m.Input())
+		if err != nil {
+			return nil, err
+		}
+
+		op := &Operation{
+			Name:         canonical,
+			ContractName: fullMethod,
+			FullMethod:   fullMethod,
+			Params:       params,
+			grpc: &grpcOpRef{
+				input:  m.Input(),
+				output: m.Output(),
+				files:  files,
+			},
+		}
+		if err := table.add(op); err != nil {
+			return nil, err
+		}
+	}
+
+	for key := range rename {
+		if !usedRenames[key] {
+			return nil, fmt.Errorf(
+				"rename key %q matches no unary method on service %s\n"+
+					"  rename keys are proto method names (\"GetOrder\") or full paths (\"/pkg.Svc/GetOrder\")",
+				key, svc.FullName())
+		}
+	}
+
+	if table.Len() == 0 {
+		return nil, fmt.Errorf("service %s declares no unary methods (streaming RPCs are not supported in v1)",
+			svc.FullName())
+	}
+	table.finalize()
+	return table, nil
+}
+
+// selectGRPCService resolves the service a client binds to.
+func selectGRPCService(files *protoregistry.Files, sourcePath, serviceFQN string) (protoreflect.ServiceDescriptor, error) {
+	if serviceFQN != "" {
+		desc, err := files.FindDescriptorByName(protoreflect.FullName(serviceFQN))
+		if err != nil {
+			available := listGRPCServices(files)
+			return nil, fmt.Errorf("service %q not found in %s (available: %s)",
+				serviceFQN, sourcePath, strings.Join(available, ", "))
+		}
+		svc, ok := desc.(protoreflect.ServiceDescriptor)
+		if !ok {
+			return nil, fmt.Errorf("descriptor %q in %s is %T, not a service", serviceFQN, sourcePath, desc)
+		}
+		return svc, nil
+	}
+
+	var found []protoreflect.ServiceDescriptor
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		if strings.HasPrefix(string(fd.Path()), "google/protobuf/") {
+			return true
+		}
+		svcs := fd.Services()
+		for i := 0; i < svcs.Len(); i++ {
+			found = append(found, svcs.Get(i))
+		}
+		return true
+	})
+	sort.Slice(found, func(i, j int) bool { return found[i].FullName() < found[j].FullName() })
+
+	switch len(found) {
+	case 0:
+		return nil, fmt.Errorf("descriptor set %s declares no gRPC services", sourcePath)
+	case 1:
+		return found[0], nil
+	default:
+		names := make([]string, len(found))
+		for i, s := range found {
+			names[i] = string(s.FullName())
+		}
+		return nil, fmt.Errorf(
+			"descriptor set %s declares %d services; pass grpc_service= to pick one\n  candidates: %s",
+			sourcePath, len(found), strings.Join(names, ", "))
+	}
+}
+
+func listGRPCServices(files *protoregistry.Files) []string {
+	var out []string
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		if strings.HasPrefix(string(fd.Path()), "google/protobuf/") {
+			return true
+		}
+		svcs := fd.Services()
+		for i := 0; i < svcs.Len(); i++ {
+			out = append(out, string(svcs.Get(i).FullName()))
+		}
+		return true
+	})
+	sort.Strings(out)
+	return out
+}
+
+// grpcRequestParams maps the top-level fields of a request message onto
+// call-site kwargs. Nested messages are addressed as a whole (pass a dict);
+// we deliberately don't flatten them, because a flattened name space would
+// collide the moment two sub-messages share a field name.
+func grpcRequestParams(fullMethod string, input protoreflect.MessageDescriptor) ([]Param, error) {
+	fields := input.Fields()
+	out := make([]Param, 0, fields.Len())
+	seen := make(map[string]Param, fields.Len())
+
+	for i := 0; i < fields.Len(); i++ {
+		f := fields.Get(i)
+		canonical, err := CanonicalName(string(f.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("method %s field %q: %w", fullMethod, f.Name(), err)
+		}
+		if err := checkReservedParamName(fullMethod, string(f.Name()), canonical); err != nil {
+			return nil, err
+		}
+		if prev, dup := seen[canonical]; dup {
+			return nil, fmt.Errorf("method %s: fields %q and %q both normalize to kwarg %q",
+				fullMethod, prev.WireName, f.Name(), canonical)
+		}
+		p := Param{
+			Name:     canonical,
+			WireName: string(f.Name()),
+			In:       ParamField,
+			// proto3 has no required fields; every field is optional at
+			// the wire level and defaults to its zero value.
+			Required: false,
+		}
+		seen[canonical] = p
+		out = append(out, p)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// BuildGRPCRequest encodes caller-supplied kwargs as the operation's real
+// request message.
+func (t *OperationTable) BuildGRPCRequest(op *Operation, args map[string]any) (*GRPCRequest, error) {
+	if op.grpc == nil {
+		return nil, fmt.Errorf("operation %q is not a gRPC operation", op.Name)
+	}
+
+	byName := make(map[string]Param, len(op.Params))
+	for _, p := range op.Params {
+		byName[p.Name] = p
+	}
+
+	// Translate canonical kwargs back to proto field names. protojson
+	// accepts the proto name verbatim, so this round-trips exactly.
+	payload := make(map[string]any, len(args))
+	for k, v := range args {
+		if _, reserved := reservedKwargs[k]; reserved {
+			if k == "body" {
+				return nil, fmt.Errorf("%s: gRPC operations take request fields as kwargs, not body=", op.SignatureHint())
+			}
+			continue
+		}
+		p, ok := byName[k]
+		if !ok {
+			return nil, unknownArgError(op, k, byName)
+		}
+		payload[p.WireName] = v
+	}
+
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("%s: encode request: %w", op.SignatureHint(), err)
+	}
+
+	msg := dynamicpb.NewMessage(op.grpc.input)
+	opts := protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+		Resolver:       typesResolver{files: op.grpc.files},
+	}
+	if err := opts.Unmarshal(jsonBytes, msg); err != nil {
+		return nil, fmt.Errorf("%s: encode as %s: %w",
+			op.SignatureHint(), op.grpc.input.FullName(), enrichProtoFieldError(err, op.grpc.input))
+	}
+
+	return &GRPCRequest{FullMethod: op.FullMethod, Message: msg, JSON: jsonBytes}, nil
+}
+
+// unknownProtoField extracts the offending field name from a protojson
+// unknown-field error so we can suggest the right one.
+var unknownProtoField = regexp.MustCompile(`unknown field "([^"]+)"`)
+
+// enrichProtoFieldError appends a nearest-field suggestion to protojson's
+// unknown-field error. Field-name typos (cityid vs city_id, camelCase vs
+// snake_case) are the dominant failure when hand-writing a typed request;
+// the raw error names the bad field but not the right one.
+func enrichProtoFieldError(err error, desc protoreflect.MessageDescriptor) error {
+	m := unknownProtoField.FindStringSubmatch(err.Error())
+	if m == nil {
+		return err
+	}
+	bad := m[1]
+	fields := desc.Fields()
+	best, bestDist := "", 4
+	for i := 0; i < fields.Len(); i++ {
+		name := string(fields.Get(i).Name())
+		if d := editDistance(bad, name); d < bestDist {
+			best, bestDist = name, d
+		}
+	}
+	if best == "" {
+		return err
+	}
+	return fmt.Errorf("%w (did you mean %q?)", err, best)
+}
+
+// InvokeGRPCUnary dials addr and performs one unary call.
+//
+// Stateless per call (RFC-055 OQ-5): the connection is created and torn
+// down around the invoke, matching how the existing step methods behave and
+// keeping the proxy's connection accounting honest — one client call is one
+// proxy connection in the trace.
+func InvokeGRPCUnary(ctx context.Context, addr string, op *Operation, req *GRPCRequest,
+	headers map[string]string, tlsCfg *tls.Config, timeout time.Duration) (*GRPCResponse, error) {
+
+	if op.grpc == nil {
+		return nil, fmt.Errorf("operation %q is not a gRPC operation", op.Name)
+	}
+	start := time.Now()
+
+	creds := insecure.NewCredentials()
+	if tlsCfg != nil {
+		creds = credentials.NewTLS(tlsCfg)
+	}
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	if len(headers) > 0 {
+		md := metadata.New(nil)
+		for k, v := range headers {
+			md.Set(strings.ToLower(k), v)
+		}
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+
+	resp := dynamicpb.NewMessage(op.grpc.output)
+	invokeErr := conn.Invoke(ctx, op.FullMethod, req.Message, resp)
+	out := &GRPCResponse{DurationMs: time.Since(start).Milliseconds()}
+
+	if invokeErr != nil {
+		st, _ := status.FromError(invokeErr)
+		out.Code = st.Code()
+		out.CodeName = st.Code().String()
+		out.Message = st.Message()
+		return out, nil
+	}
+
+	out.Code = codes.OK
+	out.CodeName = codes.OK.String()
+	out.UnknownFieldBytes = len(resp.ProtoReflect().GetUnknown())
+
+	jsonBytes, err := protojson.MarshalOptions{
+		// Emit zero values so a decoded response has the full field set —
+		// spec authors index into resp.data and shouldn't have to know
+		// which fields protojson elides.
+		EmitUnpopulated: true,
+		Resolver:        typesResolver{files: op.grpc.files},
+	}.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s response as %s: %w", op.FullMethod, op.grpc.output.FullName(), err)
+	}
+	out.JSON = jsonBytes
+	return out, nil
+}
+
+// ValidateGRPCResponse reports contract conformance for a completed call.
+//
+// A typed decode already enforces most of the contract — wire bytes that
+// don't match the response descriptor fail at Invoke. What survives that
+// and still indicates drift is unknown fields: bytes the server sent that
+// this descriptor set has no field for, i.e. the server is running a newer
+// proto than the contract the test was checked against.
+func (t *OperationTable) ValidateGRPCResponse(op *Operation, resp *GRPCResponse) error {
+	if op.grpc == nil || resp == nil {
+		return nil
+	}
+	if resp.Code != codes.OK {
+		// A non-OK status is an outcome, not a conformance failure. The
+		// test's own assertions decide whether UNAVAILABLE was expected.
+		return nil
+	}
+	if resp.UnknownFieldBytes > 0 {
+		return fmt.Errorf("response carried %d bytes of fields absent from %s — the server's proto is newer than %s",
+			resp.UnknownFieldBytes, op.grpc.output.FullName(), t.Contract.Path)
+	}
+	return nil
+}

--- a/internal/protocol/grpc_client_test.go
+++ b/internal/protocol/grpc_client_test.go
@@ -1,0 +1,461 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// buildOrderDescriptorSet synthesizes a FileDescriptorSet for:
+//
+//	syntax = "proto3";
+//	package courier.v1;
+//	message GetOrderRequest { int64 order_id = 1; string include_items = 2; }
+//	message Order { int64 id = 1; string courier_eta = 2; }
+//	message ListOrdersRequest { string status = 1; }
+//	message OrderList { }
+//	service CourierService {
+//	  rpc GetOrder (GetOrderRequest) returns (Order);
+//	  rpc ListOrdersV2 (ListOrdersRequest) returns (OrderList);
+//	  rpc StreamOrders (ListOrdersRequest) returns (stream Order);   // skipped: streaming
+//	}
+func buildOrderDescriptorSet() *descriptorpb.FileDescriptorSet {
+	syntax := "proto3"
+	pkg := "courier.v1"
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("courier/v1/courier.proto"),
+		Package: &pkg,
+		Syntax:  &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("GetOrderRequest"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					msgField("order_id", 1, descriptorpb.FieldDescriptorProto_TYPE_INT64),
+					msgField("include_items", 2, descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				},
+			},
+			{
+				Name: proto.String("Order"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					msgField("id", 1, descriptorpb.FieldDescriptorProto_TYPE_INT64),
+					msgField("courier_eta", 2, descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				},
+			},
+			{
+				Name: proto.String("ListOrdersRequest"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					msgField("status", 1, descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				},
+			},
+			{Name: proto.String("OrderList")},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: proto.String("CourierService"),
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       proto.String("GetOrder"),
+						InputType:  proto.String(".courier.v1.GetOrderRequest"),
+						OutputType: proto.String(".courier.v1.Order"),
+					},
+					{
+						Name:       proto.String("ListOrdersV2"),
+						InputType:  proto.String(".courier.v1.ListOrdersRequest"),
+						OutputType: proto.String(".courier.v1.OrderList"),
+					},
+					{
+						Name:            proto.String("StreamOrders"),
+						InputType:       proto.String(".courier.v1.ListOrdersRequest"),
+						OutputType:      proto.String(".courier.v1.Order"),
+						ServerStreaming: proto.Bool(true),
+					},
+				},
+			},
+		},
+	}
+	return &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{fdp}}
+}
+
+func loadCourierTable(t *testing.T) *OperationTable {
+	t.Helper()
+	path := writeFds(t, buildOrderDescriptorSet())
+	files, err := LoadDescriptorSet(path)
+	if err != nil {
+		t.Fatalf("LoadDescriptorSet: %v", err)
+	}
+	table, err := BuildGRPCOperations(files, path, "", nil)
+	if err != nil {
+		t.Fatalf("BuildGRPCOperations: %v", err)
+	}
+	return table
+}
+
+func TestBuildGRPCOperations_NamesAndContract(t *testing.T) {
+	table := loadCourierTable(t)
+
+	// StreamOrders is dropped: v1 is unary-only, and one streaming method
+	// must not make the whole descriptor set unusable.
+	want := []string{"get_order", "list_orders_v2"}
+	got := table.Names()
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("operation names = %v, want %v", got, want)
+	}
+
+	if table.Contract.Kind != ContractGRPC {
+		t.Errorf("contract kind = %q, want %q", table.Contract.Kind, ContractGRPC)
+	}
+	if table.Contract.Version != "courier.v1.CourierService" {
+		t.Errorf("contract version = %q, want the service FQN", table.Contract.Version)
+	}
+
+	op, ok := table.Lookup("get_order")
+	if !ok {
+		t.Fatal("get_order not found")
+	}
+	if op.FullMethod != "/courier.v1.CourierService/GetOrder" {
+		t.Errorf("full method = %q", op.FullMethod)
+	}
+	if op.Wire() != "/courier.v1.CourierService/GetOrder" {
+		t.Errorf("Wire() = %q", op.Wire())
+	}
+
+	// Request fields become kwargs, sorted by canonical name. proto3 has
+	// no required fields, so none is marked required.
+	if len(op.Params) != 2 {
+		t.Fatalf("params = %+v, want 2", op.Params)
+	}
+	if op.Params[0].Name != "include_items" || op.Params[1].Name != "order_id" {
+		t.Errorf("param names = %q, %q; want include_items, order_id", op.Params[0].Name, op.Params[1].Name)
+	}
+	for _, p := range op.Params {
+		if p.In != ParamField {
+			t.Errorf("param %q location = %q, want %q", p.Name, p.In, ParamField)
+		}
+		if p.Required {
+			t.Errorf("param %q marked required; proto3 fields never are", p.Name)
+		}
+	}
+}
+
+func TestBuildGRPCOperations_LookupByContractName(t *testing.T) {
+	table := loadCourierTable(t)
+	op, ok := table.LookupContractName("/courier.v1.CourierService/GetOrder")
+	if !ok {
+		t.Fatal("LookupContractName by full method path failed")
+	}
+	if op.Name != "get_order" {
+		t.Errorf("resolved to %q, want get_order", op.Name)
+	}
+}
+
+func TestBuildGRPCOperations_MultiServiceRequiresSelection(t *testing.T) {
+	set := buildOrderDescriptorSet()
+	// A second service in the same file forces an explicit choice.
+	set.File[0].Service = append(set.File[0].Service, &descriptorpb.ServiceDescriptorProto{
+		Name: proto.String("BillingService"),
+		Method: []*descriptorpb.MethodDescriptorProto{{
+			Name:       proto.String("Charge"),
+			InputType:  proto.String(".courier.v1.GetOrderRequest"),
+			OutputType: proto.String(".courier.v1.Order"),
+		}},
+	})
+	path := writeFds(t, set)
+	files, err := LoadDescriptorSet(path)
+	if err != nil {
+		t.Fatalf("LoadDescriptorSet: %v", err)
+	}
+
+	_, err = BuildGRPCOperations(files, path, "", nil)
+	if err == nil {
+		t.Fatal("expected an error when the set declares multiple services")
+	}
+	for _, want := range []string{"grpc_service=", "courier.v1.BillingService", "courier.v1.CourierService"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+
+	// Naming one resolves it.
+	table, err := BuildGRPCOperations(files, path, "courier.v1.BillingService", nil)
+	if err != nil {
+		t.Fatalf("BuildGRPCOperations with grpc_service=: %v", err)
+	}
+	if names := table.Names(); len(names) != 1 || names[0] != "charge" {
+		t.Errorf("names = %v, want [charge]", names)
+	}
+
+	// An unknown service name lists the candidates.
+	_, err = BuildGRPCOperations(files, path, "courier.v1.NoSuchService", nil)
+	if err == nil || !strings.Contains(err.Error(), "available:") {
+		t.Errorf("expected an error listing available services, got: %v", err)
+	}
+}
+
+func TestBuildGRPCOperations_Rename(t *testing.T) {
+	path := writeFds(t, buildOrderDescriptorSet())
+	files, err := LoadDescriptorSet(path)
+	if err != nil {
+		t.Fatalf("LoadDescriptorSet: %v", err)
+	}
+
+	// Rename accepts the bare method name...
+	table, err := BuildGRPCOperations(files, path, "", map[string]string{"GetOrder": "fetch_order"})
+	if err != nil {
+		t.Fatalf("BuildGRPCOperations: %v", err)
+	}
+	if _, ok := table.Lookup("fetch_order"); !ok {
+		t.Errorf("rename by method name failed; names = %v", table.Names())
+	}
+
+	// ...and the full wire path.
+	table, err = BuildGRPCOperations(files, path, "",
+		map[string]string{"/courier.v1.CourierService/GetOrder": "fetch_order"})
+	if err != nil {
+		t.Fatalf("BuildGRPCOperations: %v", err)
+	}
+	if _, ok := table.Lookup("fetch_order"); !ok {
+		t.Errorf("rename by full path failed; names = %v", table.Names())
+	}
+
+	// An unused rename key is an error rather than a silent no-op.
+	_, err = BuildGRPCOperations(files, path, "", map[string]string{"NoSuchMethod": "x"})
+	if err == nil || !strings.Contains(err.Error(), "NoSuchMethod") {
+		t.Errorf("expected an unused-rename error, got: %v", err)
+	}
+}
+
+func TestBuildGRPCRequest(t *testing.T) {
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+
+	req, err := table.BuildGRPCRequest(op, map[string]any{
+		"order_id":      int64(42),
+		"include_items": "true",
+	})
+	if err != nil {
+		t.Fatalf("BuildGRPCRequest: %v", err)
+	}
+	if req.FullMethod != "/courier.v1.CourierService/GetOrder" {
+		t.Errorf("full method = %q", req.FullMethod)
+	}
+
+	// The message must round-trip through the wire format as the real type.
+	wire, err := proto.Marshal(req.Message)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if len(wire) == 0 {
+		t.Fatal("encoded request is empty")
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(req.JSON, &decoded); err != nil {
+		t.Fatalf("request JSON is not valid: %v", err)
+	}
+	if decoded["order_id"] != float64(42) {
+		t.Errorf("request JSON order_id = %v, want 42", decoded["order_id"])
+	}
+}
+
+func TestBuildGRPCRequest_Errors(t *testing.T) {
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+
+	t.Run("unknown kwarg suggests the nearest field", func(t *testing.T) {
+		_, err := table.BuildGRPCRequest(op, map[string]any{"order_ids": int64(1)})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), `did you mean "order_id"`) {
+			t.Errorf("expected a field suggestion, got: %v", err)
+		}
+	})
+
+	t.Run("body= is rejected for gRPC", func(t *testing.T) {
+		_, err := table.BuildGRPCRequest(op, map[string]any{"body": "{}"})
+		if err == nil || !strings.Contains(err.Error(), "not body=") {
+			t.Errorf("expected a body= rejection, got: %v", err)
+		}
+	})
+
+	t.Run("wrong field type surfaces the message type", func(t *testing.T) {
+		_, err := table.BuildGRPCRequest(op, map[string]any{"order_id": "not-a-number"})
+		if err == nil {
+			t.Fatal("expected a type error")
+		}
+		if !strings.Contains(err.Error(), "courier.v1.GetOrderRequest") {
+			t.Errorf("error should name the request message type, got: %v", err)
+		}
+	})
+}
+
+// startTypedMock spins up the RFC-023 typed gRPC mock on a loopback port
+// and returns its address. Using the real mock (rather than a bespoke test
+// server) exercises the full contract loop: the same descriptor set encodes
+// the response on the mock side and decodes it on the client side.
+func startTypedMock(t *testing.T, routes []MockRoute) string {
+	t.Helper()
+	path := writeFds(t, buildOrderDescriptorSet())
+	files, err := LoadDescriptorSet(path)
+	if err != nil {
+		t.Fatalf("LoadDescriptorSet: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	p := &grpcProtocol{}
+	done := make(chan error, 1)
+	go func() {
+		done <- p.ServeMock(ctx, addr, MockSpec{Routes: routes, Descriptors: files}, nil)
+	}()
+
+	// Wait for the listener to accept before returning.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return addr
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("mock did not start on %s", addr)
+	return ""
+}
+
+func TestInvokeGRPCUnary_TypedRoundTrip(t *testing.T) {
+	addr := startTypedMock(t, []MockRoute{{
+		Pattern:  "/courier.v1.CourierService/GetOrder",
+		Response: &MockResponse{Body: []byte(`{"id": 1001, "courier_eta": "12m"}`)},
+	}})
+
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+	req, err := table.BuildGRPCRequest(op, map[string]any{"order_id": int64(1001)})
+	if err != nil {
+		t.Fatalf("BuildGRPCRequest: %v", err)
+	}
+
+	resp, err := InvokeGRPCUnary(context.Background(), addr, op, req, nil, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("InvokeGRPCUnary: %v", err)
+	}
+	if resp.Code != codes.OK {
+		t.Fatalf("code = %s (%s), want OK", resp.CodeName, resp.Message)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(resp.JSON, &decoded); err != nil {
+		t.Fatalf("response JSON invalid: %v (raw %s)", err, resp.JSON)
+	}
+	// protojson renders int64 as a string and applies lowerCamelCase to
+	// field names — both are protojson's documented behaviour, and the
+	// Starlark layer sees exactly this shape on resp.data.
+	if decoded["id"] != "1001" && decoded["id"] != float64(1001) {
+		t.Errorf("response id = %v, want 1001", decoded["id"])
+	}
+	if decoded["courierEta"] != "12m" && decoded["courier_eta"] != "12m" {
+		t.Errorf("response courier_eta missing from %v", decoded)
+	}
+
+	if err := table.ValidateGRPCResponse(op, resp); err != nil {
+		t.Errorf("expected a conforming response, got: %v", err)
+	}
+}
+
+func TestInvokeGRPCUnary_StatusError(t *testing.T) {
+	// The mock turns a non-zero Status into a gRPC status code.
+	addr := startTypedMock(t, []MockRoute{{
+		Pattern:  "/courier.v1.CourierService/GetOrder",
+		Response: &MockResponse{Status: int(codes.Unavailable), Body: []byte("courier down")},
+	}})
+
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+	req, err := table.BuildGRPCRequest(op, map[string]any{"order_id": int64(1)})
+	if err != nil {
+		t.Fatalf("BuildGRPCRequest: %v", err)
+	}
+
+	resp, err := InvokeGRPCUnary(context.Background(), addr, op, req, nil, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("InvokeGRPCUnary returned a transport error: %v", err)
+	}
+	if resp.Code != codes.Unavailable {
+		t.Errorf("code = %s, want Unavailable", resp.CodeName)
+	}
+	if resp.CodeName != "Unavailable" {
+		t.Errorf("code name = %q, want Unavailable", resp.CodeName)
+	}
+	if !strings.Contains(resp.Message, "courier down") {
+		t.Errorf("status message = %q, want the mock's message", resp.Message)
+	}
+
+	// A non-OK status is an outcome, not a conformance failure — the test's
+	// own assertions decide whether UNAVAILABLE was expected.
+	if err := table.ValidateGRPCResponse(op, resp); err != nil {
+		t.Errorf("a status error must not register as a contract violation: %v", err)
+	}
+}
+
+func TestInvokeGRPCUnary_UnroutedMethodIsUnimplemented(t *testing.T) {
+	addr := startTypedMock(t, nil)
+
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+	req, err := table.BuildGRPCRequest(op, map[string]any{"order_id": int64(1)})
+	if err != nil {
+		t.Fatalf("BuildGRPCRequest: %v", err)
+	}
+
+	resp, err := InvokeGRPCUnary(context.Background(), addr, op, req, nil, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("InvokeGRPCUnary: %v", err)
+	}
+	if resp.Code != codes.Unimplemented {
+		t.Errorf("code = %s, want Unimplemented", resp.CodeName)
+	}
+}
+
+func TestInvokeGRPCUnary_ConnectionRefused(t *testing.T) {
+	// Reserve and immediately release a port so nothing is listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	table := loadCourierTable(t)
+	op, _ := table.Lookup("get_order")
+	req, err := table.BuildGRPCRequest(op, map[string]any{"order_id": int64(1)})
+	if err != nil {
+		t.Fatalf("BuildGRPCRequest: %v", err)
+	}
+
+	resp, err := InvokeGRPCUnary(context.Background(), addr, op, req, nil, nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("InvokeGRPCUnary should report transport failure as a status, not an error: %v", err)
+	}
+	if resp.Code == codes.OK {
+		t.Error("expected a non-OK status when nothing is listening")
+	}
+	if resp.DurationMs < 0 {
+		t.Errorf("duration = %d, want a non-negative measurement", resp.DurationMs)
+	}
+}

--- a/internal/protocol/http.go
+++ b/internal/protocol/http.go
@@ -51,7 +51,10 @@ func (p *httpProtocol) Healthcheck(ctx context.Context, addr string, timeout tim
 func (p *httpProtocol) ExecuteStep(ctx context.Context, addr, method string, kwargs map[string]any) (*StepResult, error) {
 	httpMethod := strings.ToUpper(method)
 	switch httpMethod {
-	case "GET", "POST", "PUT", "DELETE", "PATCH":
+	// HEAD and OPTIONS are here for RFC-055 clients: an OpenAPI document
+	// may declare them, and a generated operation must be callable. They
+	// are not exposed as step methods on InterfaceRef.
+	case "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS":
 	default:
 		return nil, fmt.Errorf("unsupported HTTP method %q", method)
 	}
@@ -93,11 +96,21 @@ func (p *httpProtocol) ExecuteStep(ctx context.Context, addr, method string, kwa
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	bodyStr := strings.TrimSpace(string(respBody))
 
+	// content_type rides along in Fields so RFC-055 clients can check the
+	// response against the media type the contract declares. It also lands
+	// on step_recv events, where "what did this endpoint actually return?"
+	// is worth one field.
+	fields := map[string]string{}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		fields["content_type"] = ct
+	}
+
 	return &StepResult{
 		StatusCode: resp.StatusCode,
 		Body:       bodyStr,
 		Success:    true,
 		DurationMs: elapsed,
+		Fields:     fields,
 	}, nil
 }
 

--- a/internal/protocol/openapi_client.go
+++ b/internal/protocol/openapi_client.go
@@ -1,0 +1,643 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// OpenAPI half of RFC-055 clients: turn a loaded OpenAPI document into an
+// OperationTable, bind caller kwargs onto the wire, and check responses
+// against the contract.
+//
+// This is the caller-side mirror of openapi.go's GenerateRoutes, which does
+// the same walk to produce mock responses. Both read the same
+// *OpenAPISpec; neither knows about the other.
+
+// openapiOpRef is the format-specific payload hanging off an Operation
+// built from an OpenAPI document.
+type openapiOpRef struct {
+	op *openapi3.Operation
+	// contentType is the request body media type, chosen once at build
+	// time (application/json preferred). Empty when no body is declared.
+	contentType string
+}
+
+// HTTPRequest is a fully-bound HTTP call, ready for the transport.
+type HTTPRequest struct {
+	Method string
+	// Path is the resolved path plus encoded query string.
+	Path        string
+	Headers     map[string]string
+	Body        []byte
+	ContentType string
+}
+
+// BuildOpenAPIOperations walks an OpenAPI document and produces the
+// operation table a client exposes.
+//
+// rename maps a contract-native operation name (operationId, or the
+// synthesized stand-in for operations that declare none) to the canonical
+// attribute the spec author wants. Renames are applied before collision
+// detection, so they are the documented fix for a collision. A rename key
+// that matches no operation is an error — a silently-ignored rename would
+// leave the author believing they'd fixed something.
+func BuildOpenAPIOperations(spec *OpenAPISpec, rename map[string]string) (*OperationTable, error) {
+	if spec == nil || spec.Doc == nil {
+		return nil, fmt.Errorf("nil OpenAPI spec")
+	}
+	if spec.Doc.Paths == nil || spec.Doc.Paths.Len() == 0 {
+		return nil, fmt.Errorf("OpenAPI document %s declares no paths", spec.Path)
+	}
+
+	info := ContractInfo{Kind: ContractOpenAPI, Path: spec.Path}
+	if spec.Doc.Info != nil {
+		info.Version = spec.Doc.Info.Version
+	}
+	table := newOperationTable(info)
+
+	// Deterministic walk: sorted paths, canonical method order.
+	pathKeys := make([]string, 0, spec.Doc.Paths.Len())
+	for k := range spec.Doc.Paths.Map() {
+		pathKeys = append(pathKeys, k)
+	}
+	sort.Strings(pathKeys)
+
+	usedRenames := make(map[string]bool, len(rename))
+
+	for _, p := range pathKeys {
+		item := spec.Doc.Paths.Value(p)
+		if item == nil {
+			continue
+		}
+		for _, method := range httpMethodsOf(item) {
+			op := operationFor(item, method)
+			if op == nil {
+				continue
+			}
+			built, err := buildOpenAPIOperation(method, p, item, op, rename, usedRenames)
+			if err != nil {
+				return nil, err
+			}
+			if err := table.add(built); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for key := range rename {
+		if !usedRenames[key] {
+			return nil, fmt.Errorf(
+				"rename key %q matches no operation in %s\n"+
+					"  rename keys are operationIds (or the synthesized name shown by `faultbox inspect --clients`)",
+				key, spec.Path)
+		}
+	}
+
+	if table.Len() == 0 {
+		return nil, fmt.Errorf("OpenAPI document %s declares no operations", spec.Path)
+	}
+	table.finalize()
+	return table, nil
+}
+
+func buildOpenAPIOperation(method, pathTemplate string, item *openapi3.PathItem, op *openapi3.Operation,
+	rename map[string]string, usedRenames map[string]bool) (*Operation, error) {
+
+	contractName := op.OperationID
+	if contractName == "" {
+		contractName = synthesizeOperationID(method, pathTemplate)
+	}
+
+	canonical := ""
+	if target, ok := rename[contractName]; ok {
+		usedRenames[contractName] = true
+		c, err := CanonicalName(target)
+		if err != nil {
+			return nil, fmt.Errorf("rename target %q for operation %q: %w", target, contractName, err)
+		}
+		canonical = c
+	} else {
+		c, err := CanonicalName(contractName)
+		if err != nil {
+			return nil, fmt.Errorf("operation %s %s: %w", method, pathTemplate, err)
+		}
+		canonical = c
+	}
+
+	built := &Operation{
+		Name:         canonical,
+		ContractName: contractName,
+		Method:       method,
+		PathTemplate: pathTemplate,
+		Summary:      op.Summary,
+		openapi:      &openapiOpRef{op: op},
+	}
+
+	params, err := collectOpenAPIParams(contractName, item, op)
+	if err != nil {
+		return nil, err
+	}
+	built.Params = params
+
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		built.AcceptsBody = true
+		built.BodyRequired = op.RequestBody.Value.Required
+		if _, ct, ok := pickMediaType(op.RequestBody.Value.Content); ok {
+			built.openapi.contentType = ct
+		} else {
+			built.openapi.contentType = "application/json"
+		}
+	}
+
+	return built, nil
+}
+
+// collectOpenAPIParams merges path-item-level parameters (shared by every
+// operation on that path) with operation-level ones. Operation-level wins
+// on a (name, in) clash, per the OpenAPI spec.
+func collectOpenAPIParams(contractName string, item *openapi3.PathItem, op *openapi3.Operation) ([]Param, error) {
+	type key struct{ name, in string }
+	merged := make(map[key]*openapi3.Parameter)
+
+	for _, ref := range item.Parameters {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+		merged[key{ref.Value.Name, ref.Value.In}] = ref.Value
+	}
+	for _, ref := range op.Parameters {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+		merged[key{ref.Value.Name, ref.Value.In}] = ref.Value
+	}
+
+	out := make([]Param, 0, len(merged))
+	for k, p := range merged {
+		canonical, err := CanonicalName(p.Name)
+		if err != nil {
+			return nil, fmt.Errorf("operation %q parameter %q: %w", contractName, p.Name, err)
+		}
+		if err := checkReservedParamName(contractName, p.Name, canonical); err != nil {
+			return nil, err
+		}
+		loc := ParamLocation(k.in)
+		out = append(out, Param{
+			Name:        canonical,
+			WireName:    p.Name,
+			In:          loc,
+			Required:    p.Required || loc == ParamPath, // path params are always required
+			Description: p.Description,
+		})
+	}
+
+	// Two distinct wire names can normalize to the same kwarg (`order-id`
+	// in the query and `orderId` in the path). Binding would be ambiguous,
+	// so refuse at build time.
+	seen := make(map[string]Param, len(out))
+	for _, p := range out {
+		if prev, dup := seen[p.Name]; dup {
+			return nil, fmt.Errorf(
+				"operation %q: parameters %q (%s) and %q (%s) both normalize to kwarg %q",
+				contractName, prev.WireName, prev.In, p.WireName, p.In, p.Name)
+		}
+		seen[p.Name] = p
+	}
+
+	sortParams(out)
+	return out, nil
+}
+
+// sortParams orders parameters path → query → header → cookie, then by
+// canonical name. Stable ordering keeps inspect output and signature hints
+// reproducible.
+func sortParams(ps []Param) {
+	rank := map[ParamLocation]int{ParamPath: 0, ParamQuery: 1, ParamHeader: 2, ParamCookie: 3, ParamField: 4}
+	sort.SliceStable(ps, func(i, j int) bool {
+		ri, rj := rank[ps[i].In], rank[ps[j].In]
+		if ri != rj {
+			return ri < rj
+		}
+		return ps[i].Name < ps[j].Name
+	})
+}
+
+// synthesizeOperationID builds a stable contract-native name for an
+// operation that declares no operationId — common in real-world documents.
+//
+// The rule (RFC-055 §5.2): method, then each path segment, with `{param}`
+// placeholders contributing the parameter's *name* rather than a
+// positional marker. `GET /orders/{orderId}/items` → "get orders orderId
+// items" → canonicalized downstream to `get_orders_order_id_items`.
+// Renaming a literal segment changes the name; that's intended — the
+// generated name tracks the path it describes.
+func synthesizeOperationID(method, pathTemplate string) string {
+	parts := []string{strings.ToLower(method)}
+	for _, seg := range splitPathSegments(pathTemplate) {
+		seg = strings.TrimSuffix(strings.TrimPrefix(seg, "{"), "}")
+		if seg == "" {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	return strings.Join(parts, "_")
+}
+
+// BuildHTTPRequest binds caller-supplied arguments onto the operation's
+// wire form.
+//
+// args carries the call-site kwargs: one entry per declared parameter
+// (keyed by canonical name), plus the reserved `body` and `headers` keys.
+// Unknown keys are an error — the same strict-kwarg stance the proxy fault
+// builtins adopted in v0.13.2, and the whole point of a typed client.
+//
+// basePath is prepended to the operation's path; defaultHeaders are the
+// client-level headers, which per-call `headers=` overrides.
+func (t *OperationTable) BuildHTTPRequest(op *Operation, args map[string]any,
+	basePath string, defaultHeaders map[string]string) (*HTTPRequest, error) {
+
+	if op.openapi == nil {
+		return nil, fmt.Errorf("operation %q is not an HTTP operation", op.Name)
+	}
+
+	byName := make(map[string]Param, len(op.Params))
+	for _, p := range op.Params {
+		byName[p.Name] = p
+	}
+
+	// Reject unknown kwargs before doing any work, so the error names the
+	// offending key rather than surfacing as a missing-required-param
+	// complaint later.
+	for k := range args {
+		if _, ok := byName[k]; ok {
+			continue
+		}
+		if _, reserved := reservedKwargs[k]; reserved {
+			continue
+		}
+		return nil, unknownArgError(op, k, byName)
+	}
+
+	if _, ok := args["body"]; !ok && op.AcceptsBody && op.BodyRequired {
+		return nil, fmt.Errorf("%s: body= is required", op.SignatureHint())
+	}
+	if _, ok := args["body"]; ok && !op.AcceptsBody {
+		return nil, fmt.Errorf("%s: operation %s declares no request body", op.SignatureHint(), op.Wire())
+	}
+
+	resolvedPath := op.PathTemplate
+	query := url.Values{}
+	headers := make(map[string]string, len(defaultHeaders)+len(op.Params))
+	for k, v := range defaultHeaders {
+		headers[k] = v
+	}
+	var cookies []string
+
+	for _, p := range op.Params {
+		raw, provided := args[p.Name]
+		if !provided {
+			if p.Required {
+				return nil, fmt.Errorf("%s: missing required %s parameter %q", op.SignatureHint(), p.In, p.Name)
+			}
+			continue
+		}
+		// Query parameters accept lists (repeated key); everything else
+		// takes a single scalar.
+		if list, isList := raw.([]any); isList {
+			if p.In != ParamQuery {
+				return nil, fmt.Errorf("%s: parameter %q is a %s parameter and cannot take a list",
+					op.SignatureHint(), p.Name, p.In)
+			}
+			for _, item := range list {
+				s, err := paramToString(item)
+				if err != nil {
+					return nil, fmt.Errorf("%s: parameter %q: %w", op.SignatureHint(), p.Name, err)
+				}
+				query.Add(p.WireName, s)
+			}
+			continue
+		}
+		s, err := paramToString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: parameter %q: %w", op.SignatureHint(), p.Name, err)
+		}
+		switch p.In {
+		case ParamPath:
+			placeholder := "{" + p.WireName + "}"
+			if !strings.Contains(resolvedPath, placeholder) {
+				return nil, fmt.Errorf("operation %s declares path parameter %q but its path %q has no %s placeholder",
+					op.ContractName, p.WireName, op.PathTemplate, placeholder)
+			}
+			resolvedPath = strings.ReplaceAll(resolvedPath, placeholder, url.PathEscape(s))
+		case ParamQuery:
+			query.Set(p.WireName, s)
+		case ParamHeader:
+			headers[p.WireName] = s
+		case ParamCookie:
+			cookies = append(cookies, p.WireName+"="+s)
+		}
+	}
+
+	if rest := remainingPlaceholders(resolvedPath); rest != "" {
+		return nil, fmt.Errorf("%s: path %q still has unbound placeholder %s", op.SignatureHint(), op.PathTemplate, rest)
+	}
+
+	// Per-call headers override client-level defaults and header params.
+	if hv, ok := args["headers"]; ok {
+		extra, err := stringMapArg(hv)
+		if err != nil {
+			return nil, fmt.Errorf("%s: headers=: %w", op.SignatureHint(), err)
+		}
+		for k, v := range extra {
+			headers[k] = v
+		}
+	}
+	if len(cookies) > 0 {
+		sort.Strings(cookies)
+		if existing := headers["Cookie"]; existing != "" {
+			headers["Cookie"] = existing + "; " + strings.Join(cookies, "; ")
+		} else {
+			headers["Cookie"] = strings.Join(cookies, "; ")
+		}
+	}
+
+	req := &HTTPRequest{
+		Method:  op.Method,
+		Path:    joinBasePath(basePath, resolvedPath),
+		Headers: headers,
+	}
+	if q := query.Encode(); q != "" {
+		req.Path += "?" + q
+	}
+
+	if bv, ok := args["body"]; ok {
+		body, ct, err := encodeRequestBody(bv, op.openapi.contentType)
+		if err != nil {
+			return nil, fmt.Errorf("%s: body=: %w", op.SignatureHint(), err)
+		}
+		req.Body = body
+		req.ContentType = ct
+		if _, set := headers["Content-Type"]; !set {
+			headers["Content-Type"] = ct
+		}
+	}
+
+	return req, nil
+}
+
+// unknownArgError reports an unrecognized kwarg, suggesting the nearest
+// declared parameter when there is one.
+func unknownArgError(op *Operation, key string, byName map[string]Param) error {
+	names := make([]string, 0, len(byName))
+	for n := range byName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	best, bestDist := "", 4
+	for _, n := range names {
+		if d := editDistance(key, n); d < bestDist {
+			best, bestDist = n, d
+		}
+	}
+	msg := fmt.Sprintf("%s: unknown argument %q", op.SignatureHint(), key)
+	if best != "" {
+		msg += fmt.Sprintf(" (did you mean %q?)", best)
+	}
+	if len(names) > 0 {
+		msg += "\n  declared parameters: " + strings.Join(names, ", ")
+	} else {
+		msg += "\n  operation declares no parameters"
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// remainingPlaceholders returns the first unbound `{param}` in a path, or
+// "" when the path is fully resolved. Guards against a document whose path
+// template references a parameter it never declares.
+func remainingPlaceholders(p string) string {
+	open := strings.IndexByte(p, '{')
+	if open < 0 {
+		return ""
+	}
+	close := strings.IndexByte(p[open:], '}')
+	if close < 0 {
+		return p[open:]
+	}
+	return p[open : open+close+1]
+}
+
+// joinBasePath prefixes a client-level base path onto an operation path,
+// collapsing duplicate slashes. An empty base returns the path unchanged.
+func joinBasePath(base, p string) string {
+	base = strings.TrimSpace(base)
+	if base == "" || base == "/" {
+		return p
+	}
+	joined := path.Join("/"+strings.Trim(base, "/"), p)
+	// path.Join drops a meaningful trailing slash; restore it.
+	if strings.HasSuffix(p, "/") && !strings.HasSuffix(joined, "/") {
+		joined += "/"
+	}
+	return joined
+}
+
+// encodeRequestBody renders a body argument into wire bytes. Strings pass
+// through verbatim (the escape hatch for hand-crafted payloads); dicts and
+// lists are JSON-encoded.
+func encodeRequestBody(v any, contentType string) ([]byte, string, error) {
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	switch t := v.(type) {
+	case string:
+		return []byte(t), contentType, nil
+	case []byte:
+		return t, contentType, nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, "", fmt.Errorf("encode as JSON: %w", err)
+		}
+		return b, contentType, nil
+	}
+}
+
+// stringMapArg coerces a headers= argument into a string map.
+func stringMapArg(v any) (map[string]string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		if sm, ok := v.(map[string]string); ok {
+			return sm, nil
+		}
+		return nil, fmt.Errorf("expected a dict of string→string, got %T", v)
+	}
+	out := make(map[string]string, len(m))
+	for k, raw := range m {
+		s, err := paramToString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("header %q: %w", k, err)
+		}
+		out[k] = s
+	}
+	return out, nil
+}
+
+// ExecuteHTTPRequest sends a bound request to addr.
+//
+// It deliberately routes through the registered http protocol plugin's
+// ExecuteStep rather than opening its own transport: the client must be
+// byte-for-byte the same caller as a hand-written step method, so proxy
+// interception, timeouts, and body limits behave identically whether the
+// request came from a contract or from `api.public.get(path=…)`.
+//
+// The per-call deadline rides on ctx.
+func ExecuteHTTPRequest(ctx context.Context, addr string, req *HTTPRequest) (*StepResult, error) {
+	p, ok := Get("http")
+	if !ok {
+		return nil, fmt.Errorf("http protocol plugin is not registered")
+	}
+	kwargs := map[string]any{"path": req.Path}
+	if len(req.Body) > 0 {
+		kwargs["body"] = string(req.Body)
+	}
+	if len(req.Headers) > 0 {
+		headers := make(map[string]any, len(req.Headers))
+		for k, v := range req.Headers {
+			headers[k] = v
+		}
+		kwargs["headers"] = headers
+	}
+	return p.ExecuteStep(ctx, addr, req.Method, kwargs)
+}
+
+// ResponseContentType extracts the response media type a StepResult
+// carried, defaulting to application/json when the server declared none —
+// the same assumption ValidateHTTPResponse makes about an empty type.
+func ResponseContentType(res *StepResult) string {
+	if res == nil || res.Fields == nil {
+		return ""
+	}
+	return res.Fields["content_type"]
+}
+
+// ValidateHTTPRequest checks a bound request against the operation's
+// declared requestBody schema. Used by validate="request" and "strict".
+func (t *OperationTable) ValidateHTTPRequest(op *Operation, req *HTTPRequest) error {
+	if op.openapi == nil || op.openapi.op == nil {
+		return nil
+	}
+	oo := op.openapi.op
+	if oo.RequestBody == nil || oo.RequestBody.Value == nil {
+		return nil
+	}
+	body := trimTrailingWS(req.Body)
+	if len(body) == 0 {
+		if oo.RequestBody.Value.Required {
+			return fmt.Errorf("request body is required")
+		}
+		return nil
+	}
+	ct := req.ContentType
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	if ct == "" {
+		ct = "application/json"
+	}
+	media, ok := oo.RequestBody.Value.Content[ct]
+	if !ok || media == nil || media.Schema == nil {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return fmt.Errorf("malformed JSON body: %w", err)
+	}
+	if err := media.Schema.Value.VisitJSON(decoded); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateHTTPResponse checks a response against the schema the contract
+// declares for its status code.
+//
+// Two failure classes, both meaningful findings rather than harness errors
+// (RFC-055 §5.4):
+//
+//   - **Undeclared status.** The service returned a code the document never
+//     mentions — the classic undocumented degraded path.
+//   - **Schema mismatch.** The code is declared but the payload doesn't
+//     match, e.g. a null in a non-nullable field under load.
+//
+// Non-JSON content types are accepted without inspection, matching the
+// mock-side ValidateRequest behaviour.
+func (t *OperationTable) ValidateHTTPResponse(op *Operation, status int, contentType string, body []byte) error {
+	if op.openapi == nil || op.openapi.op == nil {
+		return nil
+	}
+	responses := op.openapi.op.Responses
+	if responses == nil || responses.Len() == 0 {
+		return nil
+	}
+
+	respRef := responses.Status(status)
+	if respRef == nil {
+		respRef = responses.Default()
+		if respRef == nil {
+			return fmt.Errorf("status %d is not declared for %s (declared: %s)",
+				status, op.Wire(), strings.Join(sortedResponseKeys(responses.Map()), ", "))
+		}
+	}
+	if respRef.Value == nil {
+		return nil
+	}
+
+	ct := contentType
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	if len(respRef.Value.Content) == 0 {
+		// Status-only response (204 and friends). A body where none is
+		// declared isn't worth failing over — servers add them routinely.
+		return nil
+	}
+	if ct == "" {
+		ct = "application/json"
+	}
+	media, ok := respRef.Value.Content[ct]
+	if !ok {
+		declared := make([]string, 0, len(respRef.Value.Content))
+		for k := range respRef.Value.Content {
+			declared = append(declared, k)
+		}
+		sort.Strings(declared)
+		return fmt.Errorf("content type %q is not declared for %s %d (declared: %s)",
+			ct, op.Wire(), status, strings.Join(declared, ", "))
+	}
+	if media == nil || media.Schema == nil || media.Schema.Value == nil {
+		return nil
+	}
+	if !strings.Contains(ct, "json") {
+		return nil
+	}
+	body = trimTrailingWS(body)
+	if len(body) == 0 {
+		return fmt.Errorf("empty body, but %s %d declares a %s schema", op.Wire(), status, ct)
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return fmt.Errorf("malformed JSON body: %w", err)
+	}
+	if err := media.Schema.Value.VisitJSON(decoded); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/protocol/openapi_client_test.go
+++ b/internal/protocol/openapi_client_test.go
@@ -1,0 +1,689 @@
+package protocol
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ordersSpec exercises the shapes a real document throws at the client
+// builder: declared and missing operationIds, every parameter location,
+// path-item-level shared parameters, a required request body, and multiple
+// declared response codes with schemas.
+const ordersSpec = `
+openapi: 3.0.3
+info:
+  title: Orders
+  version: 1.4.0
+paths:
+  /orders:
+    get:
+      operationId: listOrders
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+        - name: tag
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: order list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [item_id, qty]
+              properties:
+                item_id:
+                  type: string
+                qty:
+                  type: integer
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+  /orders/{orderId}:
+    parameters:
+      - name: X-Tenant
+        in: header
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: include
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: one order
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, courier_eta]
+                properties:
+                  id:
+                    type: integer
+                  courier_eta:
+                    type: string
+        "404":
+          description: missing
+    delete:
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: gone
+  /healthz:
+    get:
+      operationId: health
+      responses:
+        "200":
+          description: ok
+`
+
+func loadOrdersTable(t *testing.T) *OperationTable {
+	t.Helper()
+	spec, err := LoadOpenAPI(writeSpec(t, ordersSpec))
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+	table, err := BuildOpenAPIOperations(spec, nil)
+	if err != nil {
+		t.Fatalf("BuildOpenAPIOperations: %v", err)
+	}
+	return table
+}
+
+func TestBuildOpenAPIOperations_NamesAndContract(t *testing.T) {
+	table := loadOrdersTable(t)
+
+	want := []string{"create_order", "delete_orders_order_id", "get_order", "health", "list_orders"}
+	got := table.Names()
+	if len(got) != len(want) {
+		t.Fatalf("operation names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("operation names = %v, want %v", got, want)
+			break
+		}
+	}
+
+	if table.Contract.Kind != ContractOpenAPI {
+		t.Errorf("contract kind = %q, want %q", table.Contract.Kind, ContractOpenAPI)
+	}
+	if table.Contract.Version != "1.4.0" {
+		t.Errorf("contract version = %q, want 1.4.0", table.Contract.Version)
+	}
+
+	// DELETE /orders/{orderId} declares no operationId, so its name is
+	// synthesized from the method and path — including the parameter's
+	// name, not a positional placeholder.
+	del, ok := table.Lookup("delete_orders_order_id")
+	if !ok {
+		t.Fatal("synthesized operation delete_orders_order_id not found")
+	}
+	if del.ContractName != "delete_orders_orderId" {
+		t.Errorf("synthesized contract name = %q, want delete_orders_orderId", del.ContractName)
+	}
+	if del.Method != "DELETE" || del.PathTemplate != "/orders/{orderId}" {
+		t.Errorf("synthesized op wire = %q, want DELETE /orders/{orderId}", del.Wire())
+	}
+}
+
+func TestBuildOpenAPIOperations_ParamPartitioning(t *testing.T) {
+	table := loadOrdersTable(t)
+	op, ok := table.Lookup("get_order")
+	if !ok {
+		t.Fatal("get_order not found")
+	}
+
+	// Ordered path → query → header, then by name. The X-Tenant header is
+	// declared on the path item, not the operation, and must still appear.
+	want := []struct {
+		name     string
+		in       ParamLocation
+		required bool
+	}{
+		{"order_id", ParamPath, true},
+		{"include", ParamQuery, false},
+		{"x_tenant", ParamHeader, true},
+	}
+	if len(op.Params) != len(want) {
+		t.Fatalf("params = %+v, want %d entries", op.Params, len(want))
+	}
+	for i, w := range want {
+		got := op.Params[i]
+		if got.Name != w.name || got.In != w.in || got.Required != w.required {
+			t.Errorf("param[%d] = {%s %s required=%v}, want {%s %s required=%v}",
+				i, got.Name, got.In, got.Required, w.name, w.in, w.required)
+		}
+	}
+
+	if op.AcceptsBody {
+		t.Error("get_order should not accept a body")
+	}
+
+	create, _ := table.Lookup("create_order")
+	if !create.AcceptsBody || !create.BodyRequired {
+		t.Errorf("create_order: AcceptsBody=%v BodyRequired=%v, want both true",
+			create.AcceptsBody, create.BodyRequired)
+	}
+	if hint := create.SignatureHint(); hint != "create_order(body)" {
+		t.Errorf("SignatureHint() = %q, want create_order(body)", hint)
+	}
+}
+
+func TestBuildHTTPRequest_BindsEveryLocation(t *testing.T) {
+	table := loadOrdersTable(t)
+	op, _ := table.Lookup("get_order")
+
+	req, err := table.BuildHTTPRequest(op, map[string]any{
+		"order_id": int64(42),
+		"include":  "items",
+		"x_tenant": "acme",
+		"headers":  map[string]any{"X-Request-Id": "abc"},
+	}, "", map[string]string{"X-Client": "ios/4.2"})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+
+	if req.Method != "GET" {
+		t.Errorf("method = %q, want GET", req.Method)
+	}
+	if req.Path != "/orders/42?include=items" {
+		t.Errorf("path = %q, want /orders/42?include=items", req.Path)
+	}
+	for k, want := range map[string]string{
+		"X-Tenant":     "acme",    // header parameter
+		"X-Client":     "ios/4.2", // client-level default
+		"X-Request-Id": "abc",     // per-call override
+	} {
+		if req.Headers[k] != want {
+			t.Errorf("header %s = %q, want %q", k, req.Headers[k], want)
+		}
+	}
+}
+
+func TestBuildHTTPRequest_QueryListAndBasePath(t *testing.T) {
+	table := loadOrdersTable(t)
+	op, _ := table.Lookup("list_orders")
+
+	req, err := table.BuildHTTPRequest(op, map[string]any{
+		"status": "open",
+		"tag":    []any{"urgent", "vip"},
+	}, "/v1", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if !strings.HasPrefix(req.Path, "/v1/orders?") {
+		t.Errorf("path = %q, want the /v1 base path prefix", req.Path)
+	}
+	// url.Values.Encode sorts keys, so this ordering is stable.
+	if req.Path != "/v1/orders?status=open&tag=urgent&tag=vip" {
+		t.Errorf("path = %q, want repeated tag params", req.Path)
+	}
+}
+
+func TestBuildHTTPRequest_BodyEncoding(t *testing.T) {
+	table := loadOrdersTable(t)
+	op, _ := table.Lookup("create_order")
+
+	// Dict bodies are JSON-encoded.
+	req, err := table.BuildHTTPRequest(op, map[string]any{
+		"body": map[string]any{"item_id": "sku-1", "qty": int64(2)},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if req.ContentType != "application/json" {
+		t.Errorf("content type = %q, want application/json", req.ContentType)
+	}
+	if req.Headers["Content-Type"] != "application/json" {
+		t.Errorf("Content-Type header = %q, want application/json", req.Headers["Content-Type"])
+	}
+	if got := string(req.Body); got != `{"item_id":"sku-1","qty":2}` {
+		t.Errorf("body = %s, want the JSON-encoded dict", got)
+	}
+
+	// String bodies pass through verbatim — the hand-crafted-payload
+	// escape hatch.
+	req, err = table.BuildHTTPRequest(op, map[string]any{"body": `{"raw":true}`}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest (string body): %v", err)
+	}
+	if got := string(req.Body); got != `{"raw":true}` {
+		t.Errorf("body = %s, want verbatim passthrough", got)
+	}
+}
+
+func TestBuildHTTPRequest_Errors(t *testing.T) {
+	table := loadOrdersTable(t)
+	getOrder, _ := table.Lookup("get_order")
+	createOrder, _ := table.Lookup("create_order")
+	health, _ := table.Lookup("health")
+
+	cases := []struct {
+		name string
+		op   *Operation
+		args map[string]any
+		want []string
+	}{
+		{
+			name: "missing required path param",
+			op:   getOrder,
+			args: map[string]any{"x_tenant": "acme"},
+			want: []string{"missing required path parameter", "order_id"},
+		},
+		{
+			name: "missing required header param",
+			op:   getOrder,
+			args: map[string]any{"order_id": int64(1)},
+			want: []string{"missing required header parameter", "x_tenant"},
+		},
+		{
+			name: "unknown kwarg suggests the nearest parameter",
+			op:   getOrder,
+			args: map[string]any{"order_ids": int64(1), "x_tenant": "acme"},
+			want: []string{`unknown argument "order_ids"`, `did you mean "order_id"`, "declared parameters:"},
+		},
+		{
+			name: "missing required body",
+			op:   createOrder,
+			args: map[string]any{},
+			want: []string{"body= is required"},
+		},
+		{
+			name: "body on an operation that declares none",
+			op:   health,
+			args: map[string]any{"body": "{}"},
+			want: []string{"declares no request body"},
+		},
+		{
+			name: "list value for a non-query parameter",
+			op:   getOrder,
+			args: map[string]any{"order_id": []any{1, 2}, "x_tenant": "acme"},
+			want: []string{"cannot take a list"},
+		},
+		{
+			name: "unsupported scalar type",
+			op:   getOrder,
+			args: map[string]any{"order_id": map[string]any{}, "x_tenant": "acme"},
+			want: []string{"unsupported parameter value"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := table.BuildHTTPRequest(c.op, c.args, "", nil)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			for _, w := range c.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("error %q missing %q", err.Error(), w)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildOpenAPIOperations_CollisionAndRename(t *testing.T) {
+	const colliding = `
+openapi: 3.0.3
+info: {title: X, version: "1"}
+paths:
+  /a:
+    get:
+      operationId: getOrder
+      responses: {"200": {description: ok}}
+  /b:
+    get:
+      operationId: get-order
+      responses: {"200": {description: ok}}
+`
+	spec, err := LoadOpenAPI(writeSpec(t, colliding))
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+
+	_, err = BuildOpenAPIOperations(spec, nil)
+	if err == nil {
+		t.Fatal("expected a collision error")
+	}
+	if !strings.Contains(err.Error(), "collision") || !strings.Contains(err.Error(), "rename=") {
+		t.Errorf("collision error should name the fix, got: %v", err)
+	}
+
+	// The documented fix resolves it.
+	table, err := BuildOpenAPIOperations(spec, map[string]string{"get-order": "get_order_b"})
+	if err != nil {
+		t.Fatalf("BuildOpenAPIOperations with rename: %v", err)
+	}
+	if _, ok := table.Lookup("get_order_b"); !ok {
+		t.Errorf("renamed operation not found; names = %v", table.Names())
+	}
+	if _, ok := table.Lookup("get_order"); !ok {
+		t.Errorf("original operation missing; names = %v", table.Names())
+	}
+}
+
+func TestBuildOpenAPIOperations_UnusedRenameIsAnError(t *testing.T) {
+	spec, err := LoadOpenAPI(writeSpec(t, ordersSpec))
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+	_, err = BuildOpenAPIOperations(spec, map[string]string{"noSuchOp": "whatever"})
+	if err == nil {
+		t.Fatal("expected an error for a rename key matching no operation")
+	}
+	if !strings.Contains(err.Error(), "noSuchOp") {
+		t.Errorf("error should name the unused key, got: %v", err)
+	}
+}
+
+func TestBuildOpenAPIOperations_ReservedParamName(t *testing.T) {
+	const reserved = `
+openapi: 3.0.3
+info: {title: X, version: "1"}
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: headers
+          in: query
+          schema: {type: string}
+      responses: {"200": {description: ok}}
+`
+	spec, err := LoadOpenAPI(writeSpec(t, reserved))
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+	_, err = BuildOpenAPIOperations(spec, nil)
+	if err == nil {
+		t.Fatal("expected an error for a parameter colliding with a reserved kwarg")
+	}
+	for _, want := range []string{"reserved kwarg", `"headers"`, "client.call("} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestBuildOpenAPIOperations_NoPaths(t *testing.T) {
+	const empty = `
+openapi: 3.0.3
+info: {title: X, version: "1"}
+paths: {}
+`
+	spec, err := LoadOpenAPI(writeSpec(t, empty))
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+	if _, err := BuildOpenAPIOperations(spec, nil); err == nil {
+		t.Fatal("expected an error for a document with no paths")
+	}
+}
+
+func TestValidateHTTPResponse(t *testing.T) {
+	table := loadOrdersTable(t)
+	getOrder, _ := table.Lookup("get_order")
+	del, _ := table.Lookup("delete_orders_order_id")
+
+	t.Run("conforming response passes", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 200, "application/json",
+			[]byte(`{"id": 1, "courier_eta": "12m"}`))
+		if err != nil {
+			t.Errorf("expected conformance, got: %v", err)
+		}
+	})
+
+	t.Run("null in a required field is a violation", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 200, "application/json",
+			[]byte(`{"id": 1, "courier_eta": null}`))
+		if err == nil {
+			t.Fatal("expected a schema violation for a null courier_eta")
+		}
+	})
+
+	t.Run("missing required field is a violation", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 200, "application/json", []byte(`{"id": 1}`))
+		if err == nil {
+			t.Fatal("expected a schema violation for the missing courier_eta")
+		}
+	})
+
+	t.Run("undeclared status is a violation", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 503, "application/json", []byte(`{"error":"down"}`))
+		if err == nil {
+			t.Fatal("expected a violation for an undeclared 503")
+		}
+		if !strings.Contains(err.Error(), "503") || !strings.Contains(err.Error(), "declared:") {
+			t.Errorf("error should name the status and what was declared, got: %v", err)
+		}
+	})
+
+	t.Run("declared status with no content accepts anything", func(t *testing.T) {
+		if err := table.ValidateHTTPResponse(getOrder, 404, "application/json", []byte(`{"x":1}`)); err != nil {
+			t.Errorf("404 declares no content, so any body conforms; got: %v", err)
+		}
+		if err := table.ValidateHTTPResponse(del, 204, "", nil); err != nil {
+			t.Errorf("204 status-only should conform; got: %v", err)
+		}
+	})
+
+	t.Run("malformed JSON is a violation", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 200, "application/json", []byte(`{"id":`))
+		if err == nil || !strings.Contains(err.Error(), "malformed JSON") {
+			t.Errorf("expected a malformed-JSON violation, got: %v", err)
+		}
+	})
+
+	t.Run("undeclared content type is a violation", func(t *testing.T) {
+		err := table.ValidateHTTPResponse(getOrder, 200, "text/html", []byte(`<html>`))
+		if err == nil || !strings.Contains(err.Error(), "content type") {
+			t.Errorf("expected a content-type violation, got: %v", err)
+		}
+	})
+}
+
+func TestValidateHTTPRequest(t *testing.T) {
+	table := loadOrdersTable(t)
+	op, _ := table.Lookup("create_order")
+
+	good, err := table.BuildHTTPRequest(op, map[string]any{
+		"body": map[string]any{"item_id": "sku-1", "qty": int64(2)},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if err := table.ValidateHTTPRequest(op, good); err != nil {
+		t.Errorf("expected a conforming request, got: %v", err)
+	}
+
+	// qty is declared as an integer; a string violates the schema.
+	bad, err := table.BuildHTTPRequest(op, map[string]any{
+		"body": map[string]any{"item_id": "sku-1", "qty": "two"},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if err := table.ValidateHTTPRequest(op, bad); err == nil {
+		t.Error("expected a schema violation for a string qty")
+	}
+
+	// Missing a required property is likewise caught before the wire.
+	missing, err := table.BuildHTTPRequest(op, map[string]any{
+		"body": map[string]any{"item_id": "sku-1"},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if err := table.ValidateHTTPRequest(op, missing); err == nil {
+		t.Error("expected a schema violation for the missing qty")
+	}
+}
+
+// TestExecuteHTTPRequest_ContractLoop drives an RFC-021 mock generated from
+// the *same* OpenAPI document the client was built from. This is the loop
+// the feature exists to make checkable: contract → mock (callee), contract →
+// client (caller), and a conformance verdict on what came back.
+func TestExecuteHTTPRequest_ContractLoop(t *testing.T) {
+	specPath := writeSpec(t, ordersSpec)
+	spec, err := LoadOpenAPI(specPath)
+	if err != nil {
+		t.Fatalf("LoadOpenAPI: %v", err)
+	}
+	table, err := BuildOpenAPIOperations(spec, nil)
+	if err != nil {
+		t.Fatalf("BuildOpenAPIOperations: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	// A conforming route for get_order, plus a deliberately non-conforming
+	// one that returns a null in a required field — the degraded-response
+	// shape validate="response" exists to catch.
+	routes := []MockRoute{
+		{
+			Pattern: "GET /orders/*",
+			Response: &MockResponse{
+				Status:      200,
+				Body:        []byte(`{"id": 1001, "courier_eta": "12m"}`),
+				ContentType: "application/json",
+			},
+		},
+		{
+			Pattern: "GET /healthz",
+			Response: &MockResponse{
+				Status:      200,
+				Body:        []byte(`{"courier_eta": null}`),
+				ContentType: "application/json",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p, ok := Get("http")
+	if !ok {
+		t.Fatal("http protocol not registered")
+	}
+	server, ok := p.(MockHandler)
+	if !ok {
+		t.Fatal("http protocol does not implement MockHandler")
+	}
+	go func() { _ = server.ServeMock(ctx, addr, MockSpec{Routes: routes}, nil) }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Run("conforming response", func(t *testing.T) {
+		op, _ := table.Lookup("get_order")
+		req, err := table.BuildHTTPRequest(op, map[string]any{
+			"order_id": int64(1001),
+			"x_tenant": "acme",
+		}, "", nil)
+		if err != nil {
+			t.Fatalf("BuildHTTPRequest: %v", err)
+		}
+		res, err := ExecuteHTTPRequest(context.Background(), addr, req)
+		if err != nil {
+			t.Fatalf("ExecuteHTTPRequest: %v", err)
+		}
+		if res.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200 (body %s)", res.StatusCode, res.Body)
+		}
+		if ct := ResponseContentType(res); !strings.Contains(ct, "json") {
+			t.Errorf("content type = %q, want a JSON media type", ct)
+		}
+		if err := table.ValidateHTTPResponse(op, res.StatusCode, ResponseContentType(res), []byte(res.Body)); err != nil {
+			t.Errorf("expected a conforming response, got: %v", err)
+		}
+	})
+
+	t.Run("null in a required field is caught", func(t *testing.T) {
+		op, _ := table.Lookup("get_order")
+		// Serve the bad payload through the /healthz route, then validate
+		// it against get_order's schema — the same check the client runs
+		// when a service degrades.
+		health, _ := table.Lookup("health")
+		req, err := table.BuildHTTPRequest(health, nil, "", nil)
+		if err != nil {
+			t.Fatalf("BuildHTTPRequest: %v", err)
+		}
+		res, err := ExecuteHTTPRequest(context.Background(), addr, req)
+		if err != nil {
+			t.Fatalf("ExecuteHTTPRequest: %v", err)
+		}
+		err = table.ValidateHTTPResponse(op, res.StatusCode, ResponseContentType(res), []byte(res.Body))
+		if err == nil {
+			t.Fatal("expected a contract violation for the null courier_eta")
+		}
+	})
+}
+
+func TestJoinBasePath(t *testing.T) {
+	cases := []struct{ base, p, want string }{
+		{"", "/orders", "/orders"},
+		{"/", "/orders", "/orders"},
+		{"/v1", "/orders", "/v1/orders"},
+		{"v1", "/orders", "/v1/orders"},
+		{"/v1/", "/orders", "/v1/orders"},
+		{"/v1", "/orders/", "/v1/orders/"},
+	}
+	for _, c := range cases {
+		if got := joinBasePath(c.base, c.p); got != c.want {
+			t.Errorf("joinBasePath(%q, %q) = %q, want %q", c.base, c.p, got, c.want)
+		}
+	}
+}

--- a/internal/report/app.js
+++ b/internal/report/app.js
@@ -1283,7 +1283,7 @@
   }
 
   function recentStepRow(c) {
-    var label = c.type === "step_send" ? "→ call" : "← reply";
+    var label = isSendEvent(c.type) ? "→ call" : "← reply";
     var line = label + " · " + (c.target || "?")
       + (c.method ? "." + c.method : "")
       + (c.summary ? "  " + stripArrowFromSummary(c.summary) : "");
@@ -1829,6 +1829,11 @@
   // the test lane buried among other interactions. Falls back to
   // ev.service when fields.target is missing — keeps older bundles
   // and non-step events on their original lanes.
+  //
+  // RFC-055 client events are deliberately NOT re-routed. A step event's
+  // emitter is the anonymous "test" driver, so showing it on the callee's
+  // lane is strictly more informative. A client event's emitter is the
+  // named actor we want on screen, so ev.service is already right.
   function laneFor(ev) {
     if ((ev.type === "step_send" || ev.type === "step_recv") &&
         ev.fields && ev.fields.target) {
@@ -1987,6 +1992,17 @@
   // v0.12.10: spec-anchored steps (events the user wrote directly in
   // the test body) get a +50 bump — a slot containing both a monitor
   // poll and a user-written step always shows the user's call.
+  // RFC-055: client_call / client_return are the client-side twins of
+  // step_send / step_recv and carry the same field schema, so everywhere
+  // the viewer reasons about "a call and its reply" it treats both pairs
+  // alike. laneFor is the deliberate exception — see its comment.
+  function isCallEvent(t) {
+    return t === "step_send" || t === "step_recv" ||
+           t === "client_call" || t === "client_return";
+  }
+  function isSendEvent(t) { return t === "step_send" || t === "client_call"; }
+  function isRecvEvent(t) { return t === "step_recv" || t === "client_return"; }
+
   function severityScore(ev) {
     var t = ev.type || "";
     var bonus = (ev.fields && ev.fields.spec) ? 50 : 0;
@@ -1994,7 +2010,10 @@
     if (t === "fault_applied" || t === "fault_removed" ||
         t === "proxy_fault_applied" || t === "proxy_fault_removed") return 90 + bonus;
     if (t === "fault_zero_traffic" || t === "fault_skipped_no_seccomp") return 85 + bonus;
-    if (t === "step_send" || t === "step_recv") {
+    // A contract violation is a finding in its own right, not a step
+    // outcome — rank it with the faults so it can't fold away.
+    if (t === "contract_violation") return 95 + bonus;
+    if (isCallEvent(t)) {
       var f = ev.fields || {};
       if (f.success === "false" || f.error) return 80 + bonus;
       var sc = parseInt(f.status_code || "0", 10);
@@ -2017,12 +2036,13 @@
     if (t === "fault_applied" || t === "fault_removed" ||
         t === "proxy_fault_applied" || t === "proxy_fault_removed" ||
         t === "fault_skipped_no_seccomp" || t === "fault_zero_traffic" ||
-        t === "violation" ||
+        t === "violation" || t === "contract_violation" ||
         t === "service_started" || t === "service_ready" || t === "service_stopped" ||
         t === "session_completed") {
       return true;
     }
-    if ((t === "step_send" || t === "step_recv") && ev.fields) {
+    if (isCallEvent(t) && ev.fields) {
+      if (ev.fields.contract_ok === "false") return true;
       if (ev.fields.success === "false") return true;
       if (ev.fields.error) return true;
     }
@@ -2036,8 +2056,14 @@
   // never reach this path.
   function laneFoldKey(ev) {
     var t = ev.type || "";
-    if (t !== "step_send" && t !== "step_recv") return "_typed_" + t;
+    if (!isCallEvent(t)) return "_typed_" + t;
     var f = ev.fields || {};
+    // Client calls fold by operation: the path carries a per-call id
+    // ("/orders/42") that would defeat folding, while the operation name
+    // is the stable identity of what was called.
+    if (f.operation) {
+      return "client:" + (f.client || "?") + "." + f.operation;
+    }
     var summary = f.summary || (f.sql || f.query || f.path || f.command || f.topic || "");
     return "step:" + (f.target || "?") + "." + (f.method || "?") + "::" + summary;
   }
@@ -2098,9 +2124,9 @@
     var t = ev.type || "";
     if (t === "fault_applied" || t === "fault_removed" ||
         t === "proxy_fault_applied" || t === "proxy_fault_removed") return "fault";
-    if (t === "violation") return "violation";
+    if (t === "violation" || t === "contract_violation") return "violation";
     if (t === "syscall") return "syscall";
-    if (t === "step_send" || t === "step_recv") {
+    if (isCallEvent(t)) {
       // v0.12.6: failed steps render in the fault palette so the eye
       // finds the DB invalid-connection and the truck-api 500 among
       // a sea of yellow SELECT 1 markers. Without this every step
@@ -2220,8 +2246,8 @@
     // arrow on its own.
     var f = ev.fields || {};
     var headline;
-    if (ev.type === "step_send" || ev.type === "step_recv") {
-      var label = ev.type === "step_send" ? "→ call" : "← reply";
+    if (isCallEvent(ev.type)) {
+      var label = isSendEvent(ev.type) ? "→ call" : "← reply";
       headline = f.summary ? (label + " · " + stripArrowFromSummary(f.summary)) : label;
     } else {
       headline = f.summary || ev.type || "event";
@@ -2512,13 +2538,13 @@
       return head;
     }
 
-    if (t === "step_send" || t === "step_recv") {
+    if (isCallEvent(t)) {
       // v0.12.9: the runtime's `summary` field starts with a bare
       // arrow (→ / ←) which several customers found ambiguous.
       // Pair the arrow with an explicit "call" / "reply" word so
       // the direction is unambiguous on a first read. The arrow
       // still scans faster once learned.
-      var label = t === "step_send" ? "→ call" : "← reply";
+      var label = isSendEvent(t) ? "→ call" : "← reply";
       // v0.12.10: ★ prefix marks spec-anchored steps (calls the user
       // wrote directly in the test body). Helps the eye skim past
       // monitor / proxy noise to land on familiar landmarks.
@@ -2529,9 +2555,11 @@
       var parts = [star + label, "·", (f.target || "?") + (f.method ? "." + f.method : "")];
       var preview = f.sql || f.query || f.path || f.command || f.topic || f.body;
       if (preview) parts.push(clip(preview, 80));
-      if (t === "step_recv" && f.status_code) parts.push("[" + f.status_code + "]");
-      else if (t === "step_recv" && f.status) parts.push("[" + f.status + "]");
-      if (t === "step_recv" && f.error) parts.push("ERR: " + clip(f.error, 60));
+      if (isRecvEvent(t) && f.status_code) parts.push("[" + f.status_code + "]");
+      else if (isRecvEvent(t) && f.status) parts.push("[" + f.status + "]");
+      else if (isRecvEvent(t) && f.grpc_code) parts.push("[" + f.grpc_code + "]");
+      if (isRecvEvent(t) && f.error) parts.push("ERR: " + clip(f.error, 60));
+      if (isRecvEvent(t) && f.contract_ok === "false") parts.push("⚠ contract");
       return parts.join(" ");
     }
 
@@ -2599,7 +2627,8 @@
     }
     var knownTypes = ["syscall", "fault_applied", "fault_removed",
       "service_started", "service_ready", "service_stopped",
-      "step_send", "step_recv", "violation"];
+      "step_send", "step_recv",
+      "client_call", "client_return", "contract_violation", "violation"];
     var typeOpts = [];
     for (var j = 0; j < knownTypes.length; j++) {
       if (typesPresent[knownTypes[j]]) typeOpts.push(knownTypes[j]);

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -137,6 +137,13 @@ var anchorTypes = map[string]bool{
 	"service_stopped":          true,
 	"step_send":                true,
 	"step_recv":                true,
+	// RFC-055 client events. These are anchors by construction — the
+	// spec author names them in eventually()/always() windows — so
+	// shedding them at the default downsample level would defeat the
+	// feature outright.
+	"client_call":        true,
+	"client_return":      true,
+	"contract_violation": true,
 }
 
 // Build reads a bundle and writes a single self-contained report.html

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -1147,10 +1147,11 @@ func callerPosition(thread *starlark.Thread) (string, int32) {
 // inline with the assertion failure — the value Starlark already
 // folded away by the time we got here.
 //
-// Filter rule: keep step_send / step_recv only, walk backwards until
-// we have `max` entries or run out. Reverse so the slice reads
-// chronologically. Fault / violation events stay out of Context — the
-// drill-down already surfaces those in dedicated sections.
+// Filter rule: keep call/reply events only — step_send / step_recv and
+// their RFC-055 client equivalents — walking backwards until we have
+// `max` entries or run out. Reverse so the slice reads chronologically.
+// Fault / violation events stay out of Context — the drill-down already
+// surfaces those in dedicated sections.
 func (rt *Runtime) recentAssertionContext(max int) []AssertionContext {
 	if rt.events == nil || max <= 0 {
 		return nil
@@ -1159,7 +1160,7 @@ func (rt *Runtime) recentAssertionContext(max int) []AssertionContext {
 	picks := make([]AssertionContext, 0, max)
 	for i := len(all) - 1; i >= 0 && len(picks) < max; i-- {
 		ev := all[i]
-		if ev.Type != "step_send" && ev.Type != "step_recv" {
+		if !isCallEventType(ev.Type) {
 			continue
 		}
 		f := ev.Fields

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -2367,7 +2367,7 @@ func (rt *Runtime) builtinEvents(thread *starlark.Thread, fn *starlark.Builtin, 
 		// never have matched. Same for unmediated_io (RFC-040) and packet
 		// (RFC-054): a predicate naming them returned an empty list and the
 		// author had no way to tell "no such events" from "not allowed here".
-		if whereFn == nil && ev.Type != "syscall" && ev.Type != "stdout" && ev.Type != "topic" && ev.Type != "wal" {
+		if whereFn == nil && !dictFilterQueryable(ev.Type) {
 			continue
 		}
 
@@ -2389,6 +2389,28 @@ func (rt *Runtime) builtinEvents(thread *starlark.Thread, fn *starlark.Builtin, 
 	}
 
 	return starlark.NewList(result), nil
+}
+
+// dictFilterQueryable gates which event types the *dict-filter* form of
+// events() returns — events(service=…, syscall=…, decision=…). The where=
+// form has no type gate at all; see the call site.
+//
+// The original four are observation streams: syscalls and event-source
+// output. RFC-055 adds the client types, because a spec's whole reason to
+// name a client is to ask what that client did, and `events(service=
+// "mobile-app")` should answer it.
+//
+// step_send / step_recv stay out deliberately. Admitting them would change
+// what events() returns for every spec written before now — a silent
+// behaviour change to existing assertions. Client events are additive: no
+// spec predating RFC-055 can have any.
+func dictFilterQueryable(typ string) bool {
+	switch typ {
+	case "syscall", "stdout", "topic", "wal",
+		"client_call", "client_return", "contract_violation":
+		return true
+	}
+	return false
 }
 
 func formatFilters(filters []eventFilter) string {

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -26,7 +26,11 @@ type parallelResult struct {
 // builtins returns all Starlark built-in functions for a runtime.
 func (rt *Runtime) builtins() starlark.StringDict {
 	out := starlark.StringDict{
-		"service":           starlark.NewBuiltin("service", rt.builtinService),
+		"service": starlark.NewBuiltin("service", rt.builtinService),
+		// Contract-driven callers (RFC-055). A topology entity in the same
+		// tier as service() and mock_service(): declared at spec load,
+		// bound to an interface, and its own actor in the trace.
+		"client":            starlark.NewBuiltin("client", rt.builtinClient),
 		"interface":         starlark.NewBuiltin("interface", builtinInterface),
 		"tcp":               starlark.NewBuiltin("tcp", builtinTCP),
 		"http":              starlark.NewBuiltin("http", builtinHTTP),
@@ -543,7 +547,9 @@ func (rt *Runtime) builtinService(thread *starlark.Thread, fn *starlark.Builtin,
 		}
 	}
 
-	rt.registerService(svc)
+	if err := rt.registerService(svc); err != nil {
+		return nil, err
+	}
 	return svc, nil
 }
 

--- a/internal/star/builtins.go
+++ b/internal/star/builtins.go
@@ -847,6 +847,19 @@ func (rt *Runtime) builtinFault(thread *starlark.Thread, fn *starlark.Builtin, a
 		return rt.builtinFaultProtocol(thread, ifRef, args[1:], kwargs)
 	}
 
+	// A client is a trace actor, not a process: it runs no code of its own,
+	// installs no seccomp filter, and has nothing to fault. What the author
+	// almost certainly means is "make the thing this client calls fail", so
+	// name the interface they already have in hand (RFC-055 §5.7).
+	if c, ok := args[0].(*ClientVal); ok {
+		return nil, fmt.Errorf(
+			"fault(%s): a client is a caller, not a process — it has no syscalls to intercept\n"+
+				"  faults go on the service it calls:\n"+
+				"    fault(%s.%s, response(status = 503), run = ...)   # protocol-level\n"+
+				"    fault(%s, write = deny(\"EIO\"), run = ...)        # syscall-level",
+			c.Name, c.Target.Service.Name, c.Target.Interface.Name, c.Target.Service.Name)
+	}
+
 	svc, ok := args[0].(*ServiceDef)
 	if !ok {
 		return nil, fmt.Errorf("fault() first arg must be a service, interface_ref, or fault_assumption, got %s", args[0].Type())
@@ -1091,6 +1104,12 @@ func (rt *Runtime) builtinFaultAll(thread *starlark.Thread, fn *starlark.Builtin
 func (rt *Runtime) builtinFaultStart(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("fault_start() requires a service argument")
+	}
+	if c, ok := args[0].(*ClientVal); ok {
+		return nil, fmt.Errorf(
+			"fault_start(%s): a client is a caller, not a process — it has no syscalls to intercept\n"+
+				"  fault the service it calls instead: fault_start(%s, write = deny(\"EIO\"))",
+			c.Name, c.Target.Service.Name)
 	}
 	svc, ok := args[0].(*ServiceDef)
 	if !ok {

--- a/internal/star/client.go
+++ b/internal/star/client.go
@@ -26,6 +26,20 @@ import (
 //     so N logical callers show up as N participants rather than one
 //     anonymous `test` driver.
 
+// isCallEventType reports whether an event type is one half of a
+// request/response pair. step_send/step_recv (test-driver steps) and
+// client_call/client_return (RFC-055 clients) carry the same field
+// schema, so consumers that reason about "a call and its reply" —
+// assertion context, the report's lane rendering, severity scoring —
+// treat both pairs alike rather than growing a parallel branch.
+func isCallEventType(t string) bool {
+	switch t {
+	case "step_send", "step_recv", "client_call", "client_return":
+		return true
+	}
+	return false
+}
+
 // clientReservedAttrs are the ClientVal attributes that are not
 // operations. An operation normalizing to one of these would be
 // unreachable, so client() rejects it at load time.

--- a/internal/star/client.go
+++ b/internal/star/client.go
@@ -1,0 +1,672 @@
+package star
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/protocol"
+)
+
+// RFC-055 clients. A ClientVal is a named caller bound to a service
+// interface, with its callable surface generated from an API contract.
+//
+// Two things make it more than sugar over step methods:
+//
+//  1. Calls are contract-checked. Parameters bind by name against the
+//     declared operation; responses can be validated against the schema
+//     the service publishes.
+//  2. The client is its own trace actor. Events carry `service = <client
+//     name>`, which is what the event log keys lanes and vector clocks on,
+//     so N logical callers show up as N participants rather than one
+//     anonymous `test` driver.
+
+// clientReservedAttrs are the ClientVal attributes that are not
+// operations. An operation normalizing to one of these would be
+// unreachable, so client() rejects it at load time.
+var clientReservedAttrs = map[string]string{
+	"name":       "the client's trace identity",
+	"target":     "the bound interface",
+	"contract":   "the contract identity string",
+	"operations": "the list of generated operation names",
+	"call":       "the by-contract-name escape hatch",
+}
+
+// ValidateMode governs contract checking on a client's calls.
+type ValidateMode string
+
+const (
+	// ValidateOff performs no schema checks — byte-identical behaviour to
+	// a hand-written step method.
+	ValidateOff ValidateMode = "off"
+	// ValidateRequest checks outgoing requests. A failure is a spec error:
+	// the test asked for something the contract doesn't describe.
+	ValidateRequest ValidateMode = "request"
+	// ValidateResponse checks responses and records the verdict on the
+	// Response without raising — a contract violation under fault is
+	// usually the finding, not a harness error.
+	ValidateResponse ValidateMode = "response"
+	// ValidateStrict checks both and raises on a response violation.
+	ValidateStrict ValidateMode = "strict"
+)
+
+func (m ValidateMode) checksRequest() bool {
+	return m == ValidateRequest || m == ValidateStrict
+}
+
+func (m ValidateMode) checksResponse() bool {
+	return m == ValidateResponse || m == ValidateStrict
+}
+
+// ClientVal is the Starlark value produced by client().
+type ClientVal struct {
+	Name   string
+	Target *InterfaceRef
+	Table  *protocol.OperationTable
+
+	BasePath string
+	Headers  map[string]string
+	Before   starlark.Callable
+	Validate ValidateMode
+	Timeout  time.Duration
+
+	runtime *Runtime
+	frozen  bool
+}
+
+var _ starlark.Value = (*ClientVal)(nil)
+var _ starlark.HasAttrs = (*ClientVal)(nil)
+
+func (c *ClientVal) String() string {
+	return fmt.Sprintf("<client %s → %s.%s (%d operations)>",
+		c.Name, c.Target.Service.Name, c.Target.Interface.Name, c.Table.Len())
+}
+func (c *ClientVal) Type() string          { return "client" }
+func (c *ClientVal) Freeze()               { c.frozen = true }
+func (c *ClientVal) Truth() starlark.Bool  { return true }
+func (c *ClientVal) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: client") }
+
+func (c *ClientVal) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "name":
+		return starlark.String(c.Name), nil
+	case "target":
+		return c.Target, nil
+	case "contract":
+		return starlark.String(c.Table.Contract.String()), nil
+	case "operations":
+		names := c.Table.Names()
+		items := make([]starlark.Value, len(names))
+		for i, n := range names {
+			items[i] = starlark.String(n)
+		}
+		return starlark.NewList(items), nil
+	case "call":
+		return starlark.NewBuiltin("call", c.builtinCall), nil
+	}
+
+	op, err := c.Table.Resolve(c.Name, name)
+	if err != nil {
+		// NoSuchAttrError so `hasattr()` and Starlark's own diagnostics
+		// behave, but keep our suggestion text — the resolver's message is
+		// the whole point of typing the client.
+		return nil, starlark.NoSuchAttrError(err.Error())
+	}
+	return &OperationVal{client: c, op: op}, nil
+}
+
+func (c *ClientVal) AttrNames() []string {
+	names := c.Table.Names()
+	for k := range clientReservedAttrs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// builtinCall backs client.call("<contract-native name>", params={...}, ...).
+//
+// The escape hatch for operations whose canonical name can't be spelled as
+// an attribute — a parameter that collides with a reserved kwarg, or a
+// caller who'd rather paste the operationId straight from the document.
+// Parameters go in an explicit `params=` dict so they can't collide with
+// the reserved call-site kwargs.
+func (c *ClientVal) builtinCall(thread *starlark.Thread, _ *starlark.Builtin,
+	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
+	var name string
+	var params *starlark.Dict
+	var body starlark.Value
+	var headers *starlark.Dict
+	var timeout string
+	if err := starlark.UnpackArgs("call", args, kwargs,
+		"name", &name,
+		"params?", &params,
+		"body?", &body,
+		"headers?", &headers,
+		"timeout?", &timeout,
+	); err != nil {
+		return nil, err
+	}
+
+	op, ok := c.Table.LookupContractName(name)
+	if !ok {
+		// Fall back to the canonical name so call() accepts either
+		// spelling — users reach for it when an attribute won't work, and
+		// making them remember which name form applies is a papercut.
+		resolved, err := c.Table.Resolve(c.Name, name)
+		if err != nil {
+			return nil, fmt.Errorf("client %q call(%q): no such operation\n"+
+				"  call() accepts an operationId / method path, or a generated name", c.Name, name)
+		}
+		op = resolved
+	}
+
+	callArgs := make(map[string]any)
+	if params != nil {
+		for _, pair := range params.Items() {
+			key, ok := pair[0].(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf("client %q call(%q): params keys must be strings (got %s)",
+					c.Name, name, pair[0].Type())
+			}
+			native, err := starlarkToGo(pair[1])
+			if err != nil {
+				return nil, fmt.Errorf("client %q call(%q): params[%q]: %w", c.Name, name, string(key), err)
+			}
+			callArgs[string(key)] = native
+		}
+	}
+	if body != nil {
+		native, err := starlarkToGo(body)
+		if err != nil {
+			return nil, fmt.Errorf("client %q call(%q): body=: %w", c.Name, name, err)
+		}
+		callArgs["body"] = native
+	}
+	if headers != nil {
+		native, err := starlarkToGo(headers)
+		if err != nil {
+			return nil, fmt.Errorf("client %q call(%q): headers=: %w", c.Name, name, err)
+		}
+		callArgs["headers"] = native
+	}
+	if timeout != "" {
+		callArgs["timeout"] = timeout
+	}
+
+	return c.runtime.executeClientCall(thread, c, op, callArgs)
+}
+
+// OperationVal is one generated, callable operation on a client.
+type OperationVal struct {
+	client *ClientVal
+	op     *protocol.Operation
+}
+
+var _ starlark.Value = (*OperationVal)(nil)
+var _ starlark.Callable = (*OperationVal)(nil)
+var _ starlark.HasAttrs = (*OperationVal)(nil)
+
+func (o *OperationVal) String() string {
+	return fmt.Sprintf("<operation %s.%s → %s>", o.client.Name, o.op.Name, o.op.Wire())
+}
+func (o *OperationVal) Type() string          { return "operation" }
+func (o *OperationVal) Freeze()               {}
+func (o *OperationVal) Truth() starlark.Bool  { return true }
+func (o *OperationVal) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: operation") }
+func (o *OperationVal) Name() string          { return o.op.Name }
+
+// Attr exposes the operation's contract metadata. Useful for building
+// assertions and for `print()`-driven exploration of an unfamiliar API.
+func (o *OperationVal) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "name":
+		return starlark.String(o.op.Name), nil
+	case "contract_name":
+		return starlark.String(o.op.ContractName), nil
+	case "wire":
+		return starlark.String(o.op.Wire()), nil
+	case "signature":
+		return starlark.String(o.op.SignatureHint()), nil
+	case "params":
+		items := make([]starlark.Value, 0, len(o.op.Params))
+		for _, p := range o.op.Params {
+			items = append(items, starlark.String(p.Name))
+		}
+		return starlark.NewList(items), nil
+	}
+	return nil, starlark.NoSuchAttrError(fmt.Sprintf("operation has no .%s attribute", name))
+}
+
+func (o *OperationVal) AttrNames() []string {
+	return []string{"contract_name", "name", "params", "signature", "wire"}
+}
+
+// CallInternal binds kwargs and performs the call.
+//
+// Positional arguments are refused: contract parameters are a named set
+// with no meaningful order, and accepting positions would silently break
+// the moment the contract declares a new one.
+func (o *OperationVal) CallInternal(thread *starlark.Thread,
+	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
+	if len(args) > 0 {
+		return nil, fmt.Errorf("%s takes keyword arguments only (got %d positional)\n  %s",
+			o.op.Name, len(args), o.op.SignatureHint())
+	}
+
+	callArgs := make(map[string]any, len(kwargs))
+	for _, kv := range kwargs {
+		key, _ := starlark.AsString(kv[0])
+		native, err := starlarkToGo(kv[1])
+		if err != nil {
+			return nil, fmt.Errorf("%s: argument %q: %w", o.op.SignatureHint(), key, err)
+		}
+		callArgs[key] = native
+	}
+	return o.client.runtime.executeClientCall(thread, o.client, o.op, callArgs)
+}
+
+// executeClientCall runs one contract-bound call and records it in the
+// trace as the client's own activity.
+func (rt *Runtime) executeClientCall(thread *starlark.Thread, c *ClientVal,
+	op *protocol.Operation, args map[string]any) (starlark.Value, error) {
+
+	timeout := c.Timeout
+	if raw, ok := args["timeout"]; ok {
+		s, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s: timeout= must be a duration string like \"5s\"", op.SignatureHint())
+		}
+		d, err := parseStarDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("%s: timeout=%q: %w", op.SignatureHint(), s, err)
+		}
+		timeout = d
+		delete(args, "timeout")
+	}
+
+	addr := rt.clientAddr(c)
+	specCaller := rt.callerInTest(thread)
+
+	// The test body caused this call: record that edge before the client
+	// advances its own clock, or the client's lane reads as an independent
+	// process spontaneously emitting requests (RFC-055 §5.5).
+	rt.events.MergeClock(c.Name, "test")
+
+	switch {
+	case op.FullMethod != "":
+		return rt.executeGRPCClientCall(c, op, args, addr, specCaller, timeout)
+	default:
+		return rt.executeHTTPClientCall(c, op, args, addr, specCaller, timeout)
+	}
+}
+
+// clientAddr resolves where a client's calls go: the proxy listener when
+// one is up for the target interface, otherwise the interface's own host
+// address. Identical resolution to executeStep, so a client is the same
+// caller as a step method as far as fault injection is concerned.
+func (rt *Runtime) clientAddr(c *ClientVal) string {
+	iface := c.Target.Interface
+	port := iface.Port
+	if iface.HostPort > 0 {
+		port = iface.HostPort
+	}
+	addr := fmt.Sprintf("localhost:%d", port)
+	if proxyAddr := rt.proxyMgr.GetProxyAddr(c.Target.Service.Name, iface.Name); proxyAddr != "" {
+		addr = proxyAddr
+	}
+	return addr
+}
+
+func (rt *Runtime) executeHTTPClientCall(c *ClientVal, op *protocol.Operation, args map[string]any,
+	addr, specCaller string, timeout time.Duration) (starlark.Value, error) {
+
+	req, err := c.Table.BuildHTTPRequest(op, args, c.BasePath, c.Headers)
+	if err != nil {
+		return nil, fmt.Errorf("client %q: %w", c.Name, err)
+	}
+
+	if c.Before != nil {
+		if err := rt.applyBeforeHook(c, op, req); err != nil {
+			return nil, err
+		}
+	}
+
+	if c.Validate.checksRequest() {
+		if err := c.Table.ValidateHTTPRequest(op, req); err != nil {
+			return nil, fmt.Errorf("client %q %s: request does not conform to %s: %w",
+				c.Name, op.Name, c.Table.Contract.Path, err)
+		}
+	}
+
+	target := c.Target.Service.Name
+	fields := map[string]string{
+		"client":    c.Name,
+		"target":    target,
+		"interface": c.Target.Interface.Name,
+		"protocol":  c.Target.Interface.Protocol,
+		"operation": op.Name,
+		"contract":  c.Table.Contract.String(),
+		"method":    req.Method,
+		"path":      truncate(req.Path, 200),
+		"params":    truncate(formatCallParams(op, args), 200),
+		"summary":   fmt.Sprintf("→ %s.%s %s %s", c.Name, op.Name, req.Method, truncate(req.Path, 120)),
+	}
+	if len(req.Body) > 0 {
+		fields["body"] = truncate(string(req.Body), 200)
+	}
+	if specCaller != "" {
+		fields["spec"] = specCaller
+	}
+	rt.events.MergeClock(target, c.Name)
+	rt.events.Emit("client_call", c.Name, fields)
+
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	res, err := protocol.ExecuteHTTPRequest(ctx, addr, req)
+	if err != nil {
+		return nil, fmt.Errorf("client %q %s: %w", c.Name, op.Name, err)
+	}
+
+	rt.events.MergeClock(c.Name, target)
+
+	resp := &Response{
+		Status:     res.StatusCode,
+		Body:       res.Body,
+		DurationMs: res.DurationMs,
+		Ok:         res.Success,
+		Error:      res.Error,
+		Client:     c.Name,
+		Operation:  op.Name,
+		ContractOk: true,
+	}
+
+	var violation error
+	if c.Validate.checksResponse() && res.Success {
+		violation = c.Table.ValidateHTTPResponse(op, res.StatusCode,
+			protocol.ResponseContentType(res), []byte(res.Body))
+		if violation != nil {
+			resp.ContractOk = false
+			resp.ContractError = violation.Error()
+		}
+	}
+
+	rt.emitClientReturn(c, op, target, specCaller, resp, map[string]string{
+		"status_code": fmt.Sprintf("%d", res.StatusCode),
+		"summary": fmt.Sprintf("← %s.%s %s (%dms)", c.Name, op.Name,
+			httpOutcome(res.StatusCode, res.Success, res.Error), res.DurationMs),
+	}, errorBodyField(res.StatusCode, res.Body))
+
+	if violation != nil {
+		rt.emitContractViolation(c, op, target, specCaller, violation)
+		if c.Validate == ValidateStrict {
+			return nil, fmt.Errorf("client %q %s: response does not conform to %s: %w",
+				c.Name, op.Name, c.Table.Contract.Path, violation)
+		}
+	}
+
+	// The test driver observes the client's result: merge back so
+	// assertions after the call are causally downstream of it.
+	rt.events.MergeClock("test", c.Name)
+	return resp, nil
+}
+
+func (rt *Runtime) executeGRPCClientCall(c *ClientVal, op *protocol.Operation, args map[string]any,
+	addr, specCaller string, timeout time.Duration) (starlark.Value, error) {
+
+	req, err := c.Table.BuildGRPCRequest(op, args)
+	if err != nil {
+		return nil, fmt.Errorf("client %q: %w", c.Name, err)
+	}
+
+	headers := make(map[string]string, len(c.Headers))
+	for k, v := range c.Headers {
+		headers[k] = v
+	}
+	if raw, ok := args["headers"]; ok {
+		extra, err := stringMapFromNative(raw)
+		if err != nil {
+			return nil, fmt.Errorf("client %q %s: headers=: %w", c.Name, op.Name, err)
+		}
+		for k, v := range extra {
+			headers[k] = v
+		}
+	}
+
+	target := c.Target.Service.Name
+	fields := map[string]string{
+		"client":      c.Name,
+		"target":      target,
+		"interface":   c.Target.Interface.Name,
+		"protocol":    c.Target.Interface.Protocol,
+		"operation":   op.Name,
+		"contract":    c.Table.Contract.String(),
+		"method_path": op.FullMethod,
+		"params":      truncate(formatCallParams(op, args), 200),
+		"summary":     fmt.Sprintf("→ %s.%s %s", c.Name, op.Name, op.FullMethod),
+	}
+	if len(req.JSON) > 0 && string(req.JSON) != "{}" {
+		fields["body"] = truncate(string(req.JSON), 200)
+	}
+	if specCaller != "" {
+		fields["spec"] = specCaller
+	}
+	rt.events.MergeClock(target, c.Name)
+	rt.events.Emit("client_call", c.Name, fields)
+
+	var tlsCfg *tls.Config
+	res, err := protocol.InvokeGRPCUnary(context.Background(), addr, op, req, headers, tlsCfg, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("client %q %s: %w", c.Name, op.Name, err)
+	}
+
+	rt.events.MergeClock(c.Name, target)
+
+	ok := res.Code == 0 // codes.OK
+	resp := &Response{
+		Body:       string(res.JSON),
+		DurationMs: res.DurationMs,
+		Ok:         ok,
+		Client:     c.Name,
+		Operation:  op.Name,
+		ContractOk: true,
+	}
+	if !ok {
+		resp.Error = fmt.Sprintf("%s: %s", res.CodeName, res.Message)
+	}
+
+	var violation error
+	if c.Validate.checksResponse() {
+		violation = c.Table.ValidateGRPCResponse(op, res)
+		if violation != nil {
+			resp.ContractOk = false
+			resp.ContractError = violation.Error()
+		}
+	}
+
+	extra := map[string]string{
+		"grpc_code": res.CodeName,
+		"summary":   fmt.Sprintf("← %s.%s %s (%dms)", c.Name, op.Name, res.CodeName, res.DurationMs),
+	}
+	if res.Message != "" {
+		extra["grpc_message"] = truncate(res.Message, 200)
+	}
+	rt.emitClientReturn(c, op, target, specCaller, resp, extra, "")
+
+	if violation != nil {
+		rt.emitContractViolation(c, op, target, specCaller, violation)
+		if c.Validate == ValidateStrict {
+			return nil, fmt.Errorf("client %q %s: response does not conform to %s: %w",
+				c.Name, op.Name, c.Table.Contract.Path, violation)
+		}
+	}
+
+	rt.events.MergeClock("test", c.Name)
+	return resp, nil
+}
+
+// emitClientReturn emits the client_return event. Field names are shared
+// with step_recv wherever the concept already exists (status_code,
+// duration_ms, success, error, body, summary, spec) so downstream
+// consumers need one allowlist entry rather than a parallel schema.
+func (rt *Runtime) emitClientReturn(c *ClientVal, op *protocol.Operation, target, specCaller string,
+	resp *Response, extra map[string]string, bodyField string) {
+
+	fields := map[string]string{
+		"client":      c.Name,
+		"target":      target,
+		"operation":   op.Name,
+		"duration_ms": fmt.Sprintf("%d", resp.DurationMs),
+		"success":     fmt.Sprintf("%t", resp.Ok),
+		"contract_ok": fmt.Sprintf("%t", resp.ContractOk),
+	}
+	for k, v := range extra {
+		fields[k] = v
+	}
+	if resp.Error != "" {
+		fields["error"] = truncate(resp.Error, 200)
+	}
+	if resp.ContractError != "" {
+		fields["contract_error"] = truncate(resp.ContractError, 200)
+	}
+	if bodyField != "" {
+		fields["body"] = bodyField
+	}
+	if specCaller != "" {
+		fields["spec"] = specCaller
+	}
+	rt.events.Emit("client_return", c.Name, fields)
+}
+
+// emitContractViolation records a conformance failure as its own event so
+// it is greppable, matchable as an anchor, and visible in the report
+// without the reader having to notice a field on a return event.
+func (rt *Runtime) emitContractViolation(c *ClientVal, op *protocol.Operation,
+	target, specCaller string, violation error) {
+
+	fields := map[string]string{
+		"client":    c.Name,
+		"target":    target,
+		"operation": op.Name,
+		"contract":  c.Table.Contract.String(),
+		"detail":    truncate(violation.Error(), 400),
+		"summary":   fmt.Sprintf("%s: %s", op.Wire(), truncate(violation.Error(), 160)),
+	}
+	if specCaller != "" {
+		fields["spec"] = specCaller
+	}
+	rt.events.Emit("contract_violation", c.Name, fields)
+}
+
+// applyBeforeHook runs the client's before= callable and folds the result
+// back into the request. v1 reads `headers` and `body` off the returned
+// dict; everything else is ignored so the hook can pass the request
+// through unchanged.
+func (rt *Runtime) applyBeforeHook(c *ClientVal, op *protocol.Operation, req *protocol.HTTPRequest) error {
+	reqDict := starlark.NewDict(5)
+	_ = reqDict.SetKey(starlark.String("operation"), starlark.String(op.Name))
+	_ = reqDict.SetKey(starlark.String("method"), starlark.String(req.Method))
+	_ = reqDict.SetKey(starlark.String("path"), starlark.String(req.Path))
+	_ = reqDict.SetKey(starlark.String("body"), starlark.String(string(req.Body)))
+	headerDict := starlark.NewDict(len(req.Headers))
+	for k, v := range req.Headers {
+		_ = headerDict.SetKey(starlark.String(k), starlark.String(v))
+	}
+	_ = reqDict.SetKey(starlark.String("headers"), headerDict)
+
+	thread := &starlark.Thread{Name: "client-before-" + c.Name}
+	out, err := starlark.Call(thread, c.Before, starlark.Tuple{reqDict}, nil)
+	if err != nil {
+		return fmt.Errorf("client %q before= hook: %w", c.Name, err)
+	}
+	outDict, ok := out.(*starlark.Dict)
+	if !ok {
+		return fmt.Errorf("client %q before= hook must return a dict (got %s)", c.Name, out.Type())
+	}
+
+	if hv, found, _ := outDict.Get(starlark.String("headers")); found {
+		hd, ok := hv.(*starlark.Dict)
+		if !ok {
+			return fmt.Errorf("client %q before= hook: headers must be a dict (got %s)", c.Name, hv.Type())
+		}
+		for _, pair := range hd.Items() {
+			k, kok := starlark.AsString(pair[0])
+			v, vok := starlark.AsString(pair[1])
+			if !kok || !vok {
+				return fmt.Errorf("client %q before= hook: header keys and values must be strings", c.Name)
+			}
+			req.Headers[k] = v
+		}
+	}
+	if bv, found, _ := outDict.Get(starlark.String("body")); found {
+		s, ok := starlark.AsString(bv)
+		if !ok {
+			return fmt.Errorf("client %q before= hook: body must be a string (got %s)", c.Name, bv.Type())
+		}
+		req.Body = []byte(s)
+	}
+	return nil
+}
+
+// formatCallParams renders the bound arguments for the trace, in the
+// operation's declared parameter order so the same call always produces
+// the same string. Reserved kwargs are excluded — the body has its own
+// field and headers are noise in a one-line summary.
+func formatCallParams(op *protocol.Operation, args map[string]any) string {
+	var parts []string
+	for _, p := range op.Params {
+		if v, ok := args[p.Name]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%v", p.Name, v))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// httpOutcome renders a one-word result for the return event's summary.
+func httpOutcome(status int, success bool, errMsg string) string {
+	if !success {
+		if errMsg != "" {
+			return "failed"
+		}
+		return "failed"
+	}
+	return fmt.Sprintf("%d", status)
+}
+
+// errorBodyField reuses the step_recv rule: record the response body on
+// non-2xx only, capped, so debugging a 500 reads off the trace without
+// bloating bundles with successful payloads.
+func errorBodyField(status int, body string) string {
+	if b, ok := errorBodyForTrace(status, body); ok {
+		return b
+	}
+	return ""
+}
+
+// stringMapFromNative coerces a converted Starlark dict into a string map.
+func stringMapFromNative(v any) (map[string]string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected a dict, got %T", v)
+	}
+	out := make(map[string]string, len(m))
+	for k, raw := range m {
+		s, ok := raw.(string)
+		if !ok {
+			s = fmt.Sprintf("%v", raw)
+		}
+		out[k] = s
+	}
+	return out, nil
+}

--- a/internal/star/client_builtins.go
+++ b/internal/star/client_builtins.go
@@ -1,0 +1,296 @@
+package star
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"go.starlark.net/starlark"
+
+	"github.com/faultbox/Faultbox/internal/protocol"
+)
+
+// builtinClient implements the client() topology entity (RFC-055).
+//
+//	client(
+//	    name,                        # trace identity; must not collide with a service
+//	    target = <InterfaceRef>,     # the interface to call
+//	    openapi = "./api.yaml",      # OpenAPI 3.x document      } exactly one, or
+//	    descriptors = "./svc.pb",    # protoc FileDescriptorSet  } inherited from
+//	                                 #   interface(spec=)
+//	    grpc_service = "pkg.Svc",    # required when the set declares >1 service
+//	    base_path = "/v1",
+//	    headers = {...},
+//	    before = lambda req: req,
+//	    rename = {"getOrder": "fetch_order"},
+//	    validate = "off",            # off | request | response | strict
+//	    timeout = "5s",
+//	)
+//
+// Everything is resolved at spec load: the contract is parsed, the
+// operation table is built, and names are checked. A client that loads is
+// a client whose every operation is callable.
+func (rt *Runtime) builtinClient(thread *starlark.Thread, fn *starlark.Builtin,
+	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
+	var (
+		name        string
+		targetVal   starlark.Value
+		openapiPath string
+		descPath    string
+		grpcService string
+		basePath    string
+		headersVal  *starlark.Dict
+		beforeVal   starlark.Value
+		renameVal   *starlark.Dict
+		validateStr string
+		timeoutStr  string
+	)
+	if err := starlark.UnpackArgs("client", args, kwargs,
+		"name", &name,
+		"target", &targetVal,
+		"openapi?", &openapiPath,
+		"descriptors?", &descPath,
+		"grpc_service?", &grpcService,
+		"base_path?", &basePath,
+		"headers?", &headersVal,
+		"before?", &beforeVal,
+		"rename?", &renameVal,
+		"validate?", &validateStr,
+		"timeout?", &timeoutStr,
+	); err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("client() requires a non-empty name")
+	}
+	target, ok := targetVal.(*InterfaceRef)
+	if !ok {
+		return nil, fmt.Errorf("client(%q) target= must be a service interface like `orders.public` (got %s)",
+			name, targetVal.Type())
+	}
+
+	// A client and a service share the lane and vector-clock namespace, so
+	// a shared name would silently fold two actors into one participant —
+	// exactly the ambiguity clients exist to remove (RFC-055 OQ-8).
+	rt.mu.Lock()
+	_, serviceExists := rt.services[name]
+	rt.mu.Unlock()
+	if serviceExists {
+		return nil, fmt.Errorf("client(%q): a service is already named %q\n"+
+			"  clients and services share the trace's lane and vector-clock namespace; pick a distinct name",
+			name, name)
+	}
+	if name == "test" {
+		return nil, fmt.Errorf("client(%q): \"test\" is the test driver's own trace identity; pick another name", name)
+	}
+	if existing, dup := rt.clients[name]; dup {
+		return nil, fmt.Errorf("client(%q) is already declared (bound to %s.%s)",
+			name, existing.Target.Service.Name, existing.Target.Interface.Name)
+	}
+
+	validate, err := parseValidateMode(name, validateStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var timeout time.Duration
+	if timeoutStr != "" {
+		timeout, err = parseStarDuration(timeoutStr)
+		if err != nil {
+			return nil, fmt.Errorf("client(%q) timeout=%q: %w", name, timeoutStr, err)
+		}
+	}
+
+	headers, err := stringDictArg(name, "headers", headersVal)
+	if err != nil {
+		return nil, err
+	}
+	rename, err := stringDictArg(name, "rename", renameVal)
+	if err != nil {
+		return nil, err
+	}
+
+	var before starlark.Callable
+	if beforeVal != nil && beforeVal != starlark.None {
+		before, ok = beforeVal.(starlark.Callable)
+		if !ok {
+			return nil, fmt.Errorf("client(%q) before= must be callable (got %s)", name, beforeVal.Type())
+		}
+	}
+
+	table, err := rt.buildClientTable(name, target, openapiPath, descPath, grpcService, rename)
+	if err != nil {
+		return nil, err
+	}
+
+	// An operation whose canonical name shadows a ClientVal attribute
+	// would be unreachable through the generated surface.
+	for _, opName := range table.Names() {
+		if purpose, clash := clientReservedAttrs[opName]; clash {
+			return nil, fmt.Errorf(
+				"client(%q): operation %q shadows the built-in client attribute %q (%s)\n"+
+					"  fix: rename={\"<contract name>\": \"<other_name>\"}",
+				name, opName, opName, purpose)
+		}
+	}
+
+	c := &ClientVal{
+		Name:     name,
+		Target:   target,
+		Table:    table,
+		BasePath: basePath,
+		Headers:  headers,
+		Before:   before,
+		Validate: validate,
+		Timeout:  timeout,
+		runtime:  rt,
+	}
+
+	rt.mu.Lock()
+	if rt.clients == nil {
+		rt.clients = make(map[string]*ClientVal)
+	}
+	rt.clients[name] = c
+	rt.mu.Unlock()
+
+	return c, nil
+}
+
+// buildClientTable resolves the contract source and builds the operation
+// table. Exactly one contract may be supplied explicitly; omitting both
+// falls back to the target interface's `spec=`, which until RFC-055 was
+// parsed and read by nothing.
+func (rt *Runtime) buildClientTable(name string, target *InterfaceRef,
+	openapiPath, descPath, grpcService string, rename map[string]string) (*protocol.OperationTable, error) {
+
+	if openapiPath != "" && descPath != "" {
+		return nil, fmt.Errorf("client(%q): pass either openapi= or descriptors=, not both", name)
+	}
+
+	inherited := false
+	if openapiPath == "" && descPath == "" {
+		spec := strings.TrimSpace(target.Interface.Spec)
+		if spec == "" {
+			return nil, fmt.Errorf(
+				"client(%q): no contract\n"+
+					"  pass openapi=\"…\" or descriptors=\"…\", or declare it once on the interface:\n"+
+					"    interface(%q, %q, %d, spec=\"./contract\")",
+				name, target.Interface.Name, target.Interface.Protocol, target.Interface.Port)
+		}
+		inherited = true
+		switch strings.ToLower(filepath.Ext(spec)) {
+		case ".yaml", ".yml", ".json":
+			openapiPath = spec
+		case ".pb", ".desc", ".protoset":
+			descPath = spec
+		default:
+			return nil, fmt.Errorf(
+				"client(%q): cannot tell what kind of contract %q is from its extension\n"+
+					"  pass openapi= or descriptors= explicitly (.yaml/.yml/.json → OpenAPI, .pb/.desc → descriptor set)",
+				name, spec)
+		}
+	}
+
+	if openapiPath != "" {
+		resolved := rt.resolveSpecPath(openapiPath)
+		spec, err := protocol.LoadOpenAPI(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("client(%q) openapi%s: %w", name, inheritedNote(inherited), err)
+		}
+		table, err := protocol.BuildOpenAPIOperations(spec, rename)
+		if err != nil {
+			return nil, fmt.Errorf("client(%q): %w", name, err)
+		}
+		if grpcService != "" {
+			return nil, fmt.Errorf("client(%q): grpc_service= applies to descriptors=, not openapi=", name)
+		}
+		return table, nil
+	}
+
+	resolved := rt.resolveSpecPath(descPath)
+	files, err := protocol.LoadDescriptorSet(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("client(%q) descriptors%s: %w", name, inheritedNote(inherited), err)
+	}
+	table, err := protocol.BuildGRPCOperations(files, resolved, grpcService, rename)
+	if err != nil {
+		return nil, fmt.Errorf("client(%q): %w", name, err)
+	}
+	return table, nil
+}
+
+func inheritedNote(inherited bool) string {
+	if inherited {
+		return " (inherited from interface(spec=))"
+	}
+	return ""
+}
+
+// resolveSpecPath resolves a contract path relative to the spec's own
+// directory, matching load_file() and build= rather than the process CWD.
+func (rt *Runtime) resolveSpecPath(p string) string {
+	if filepath.IsAbs(p) || rt.baseDir == "" {
+		return p
+	}
+	return filepath.Join(rt.baseDir, p)
+}
+
+func parseValidateMode(clientName, s string) (ValidateMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off":
+		return ValidateOff, nil
+	case "request":
+		return ValidateRequest, nil
+	case "response":
+		return ValidateResponse, nil
+	case "strict":
+		return ValidateStrict, nil
+	default:
+		return "", fmt.Errorf("client(%q) validate=%q: expected one of off, request, response, strict",
+			clientName, s)
+	}
+}
+
+// stringDictArg coerces a Starlark dict kwarg into a string map, naming
+// the client and the kwarg on failure.
+func stringDictArg(clientName, kwarg string, d *starlark.Dict) (map[string]string, error) {
+	if d == nil || d.Len() == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, d.Len())
+	for _, pair := range d.Items() {
+		k, kok := starlark.AsString(pair[0])
+		v, vok := starlark.AsString(pair[1])
+		if !kok || !vok {
+			return nil, fmt.Errorf("client(%q) %s= keys and values must be strings (got %s: %s)",
+				clientName, kwarg, pair[0].Type(), pair[1].Type())
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// ClientNames returns the declared client names in sorted order. Used by
+// `faultbox inspect` and by the report to label driver lanes.
+func (rt *Runtime) ClientNames() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	names := make([]string, 0, len(rt.clients))
+	for n := range rt.clients {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Client returns a declared client by name.
+func (rt *Runtime) Client(name string) (*ClientVal, bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	c, ok := rt.clients[name]
+	return c, ok
+}

--- a/internal/star/client_test.go
+++ b/internal/star/client_test.go
@@ -385,3 +385,59 @@ def test_positional(t):
 		t.Errorf("error = %v, want a keyword-only complaint", callErr)
 	}
 }
+
+// TestClient_IsNotAFaultTarget checks the diagnostic for a mistake the
+// entity invites: a client looks like a service in a spec, so reaching for
+// fault(client, ...) is a natural first guess. It's wrong — a client runs
+// no code and has no syscalls — and the error has to say what to do
+// instead, not just name the type it rejected (RFC-055 §5.7).
+func TestClient_IsNotAFaultTarget(t *testing.T) {
+	_, specPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	preamble := `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + specPath + `")
+`
+	cases := []struct {
+		name string
+		call string
+		want []string
+	}{
+		{
+			name: "fault()",
+			call: `fault(api, write = deny("EIO"), run = lambda: None)`,
+			// Must name the client, explain why, and show both the
+			// protocol-level and syscall-level forms against the target.
+			want: []string{
+				"fault(mobile-app)",
+				"a client is a caller, not a process",
+				"fault(orders.public, response(status = 503)",
+				`fault(orders, write = deny("EIO")`,
+			},
+		},
+		{
+			name: "fault_start()",
+			call: `fault_start(api, write = deny("EIO"))`,
+			want: []string{
+				"fault_start(mobile-app)",
+				"a client is a caller, not a process",
+				"fault_start(orders,",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt := New(testLogger())
+			err := rt.LoadString("client_test.star", preamble+"\n"+c.call+"\n")
+			if err == nil {
+				t.Fatal("expected an error; a client is not a fault target")
+			}
+			for _, w := range c.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("error missing %q:\n%s", w, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/internal/star/client_test.go
+++ b/internal/star/client_test.go
@@ -1,0 +1,387 @@
+package star
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+// starString reads a string global out of a loaded spec.
+func starString(t *testing.T, rt *Runtime, name string) string {
+	t.Helper()
+	v, ok := rt.globals[name]
+	if !ok {
+		t.Fatalf("global %q not found", name)
+	}
+	s, ok := starlark.AsString(v)
+	if !ok {
+		t.Fatalf("global %q is %s, not a string", name, v.Type())
+	}
+	return s
+}
+
+// starList reads a list-of-strings global out of a loaded spec.
+func starList(t *testing.T, rt *Runtime, name string) []string {
+	t.Helper()
+	v, ok := rt.globals[name]
+	if !ok {
+		t.Fatalf("global %q not found", name)
+	}
+	list, ok := v.(*starlark.List)
+	if !ok {
+		t.Fatalf("global %q is %s, not a list", name, v.Type())
+	}
+	out := make([]string, 0, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		s, ok := starlark.AsString(list.Index(i))
+		if !ok {
+			t.Fatalf("global %q[%d] is %s, not a string", name, i, list.Index(i).Type())
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// RFC-055 Phase 2 — the Starlark surface of client(). Spec-load behaviour
+// (contract resolution, name validation, generated attributes) is covered
+// here; the trace-emission half is exercised in client_trace_test.go.
+
+const clientOrdersSpec = `
+openapi: 3.0.3
+info:
+  title: Orders
+  version: 2.1.0
+paths:
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        "200":
+          description: one order
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, courier_eta]
+                properties:
+                  id: {type: integer}
+                  courier_eta: {type: string}
+  /orders:
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [item_id]
+              properties:
+                item_id: {type: string}
+                qty: {type: integer}
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: {type: object}
+`
+
+// writeSpecFile drops a contract next to a spec directory and returns the
+// directory, so LoadFile-relative resolution can be exercised.
+func writeSpecFile(t *testing.T, name, body string) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return dir, path
+}
+
+func loadClientSpec(t *testing.T, src string) *Runtime {
+	t.Helper()
+	rt := New(testLogger())
+	if err := rt.LoadString("client_test.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	return rt
+}
+
+func TestClient_GeneratesOperationsFromOpenAPI(t *testing.T) {
+	_, specPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	rt := loadClientSpec(t, `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "`+specPath+`")
+
+OPS      = api.operations
+NAME     = api.name
+CONTRACT = api.contract
+SIG      = api.get_order.signature
+WIRE     = api.get_order.wire
+`)
+
+	if got := starString(t, rt, "NAME"); got != "mobile-app" {
+		t.Errorf("api.name = %q, want mobile-app", got)
+	}
+	if got := starString(t, rt, "CONTRACT"); !strings.HasSuffix(got, "orders.yaml@2.1.0") {
+		t.Errorf("api.contract = %q, want it to carry the document version", got)
+	}
+	if got := starString(t, rt, "SIG"); got != "get_order(order_id)" {
+		t.Errorf("signature = %q, want get_order(order_id)", got)
+	}
+	if got := starString(t, rt, "WIRE"); got != "GET /orders/{orderId}" {
+		t.Errorf("wire = %q, want GET /orders/{orderId}", got)
+	}
+
+	ops := starList(t, rt, "OPS")
+	want := []string{"create_order", "get_order"}
+	if len(ops) != len(want) || ops[0] != want[0] || ops[1] != want[1] {
+		t.Errorf("operations = %v, want %v", ops, want)
+	}
+
+	c, ok := rt.Client("mobile-app")
+	if !ok {
+		t.Fatal("client not registered on the runtime")
+	}
+	if c.Target.Service.Name != "orders" {
+		t.Errorf("target service = %q, want orders", c.Target.Service.Name)
+	}
+	if names := rt.ClientNames(); len(names) != 1 || names[0] != "mobile-app" {
+		t.Errorf("ClientNames() = %v, want [mobile-app]", names)
+	}
+}
+
+func TestClient_InheritsContractFromInterfaceSpec(t *testing.T) {
+	_, specPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	rt := loadClientSpec(t, `
+orders = service("orders",
+    interface("public", "http", 8080, spec = "`+specPath+`"), image = "orders:1")
+api = client("mobile-app", target = orders.public)
+OPS = api.operations
+`)
+	ops := starList(t, rt, "OPS")
+	if len(ops) != 2 {
+		t.Errorf("operations = %v, want the two from the inherited contract", ops)
+	}
+}
+
+func TestClient_UnknownOperationSuggests(t *testing.T) {
+	_, specPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	rt := New(testLogger())
+	err := rt.LoadString("client_test.star", `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "`+specPath+`")
+X = api.get_orders
+`)
+	if err == nil {
+		t.Fatal("expected an error for an unknown operation")
+	}
+	for _, want := range []string{`no operation "get_orders"`, `did you mean "get_order"`, "faultbox inspect --clients"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestClient_LoadErrors(t *testing.T) {
+	_, openapiPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "no contract at all",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public)`,
+			want: []string{"no contract", "openapi=", "interface("},
+		},
+		{
+			name: "both contracts supplied",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `", descriptors = "x.pb")`,
+			want: []string{"either openapi= or descriptors=, not both"},
+		},
+		{
+			name: "target is not an interface",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders, openapi = "` + openapiPath + `")`,
+			want: []string{"target= must be a service interface"},
+		},
+		{
+			name: "client name collides with a service",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("orders", target = orders.public, openapi = "` + openapiPath + `")`,
+			want: []string{"a service is already named", "vector-clock namespace"},
+		},
+		{
+			name: "service name collides with a client",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("billing", target = orders.public, openapi = "` + openapiPath + `")
+dup = service("billing", interface("public", "http", 8081), image = "billing:1")`,
+			want: []string{"a client is already named", "vector-clock namespace"},
+		},
+		{
+			name: "client named test",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("test", target = orders.public, openapi = "` + openapiPath + `")`,
+			want: []string{"test driver's own trace identity"},
+		},
+		{
+			name: "duplicate client name",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+a = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `")
+b = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `")`,
+			want: []string{"already declared"},
+		},
+		{
+			name: "bad validate mode",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `", validate = "loose")`,
+			want: []string{"validate=", "off, request, response, strict"},
+		},
+		{
+			name: "bad timeout",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `", timeout = "soon")`,
+			want: []string{"timeout="},
+		},
+		{
+			name: "grpc_service with openapi",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `", grpc_service = "pkg.Svc")`,
+			want: []string{"grpc_service= applies to descriptors="},
+		},
+		{
+			name: "before is not callable",
+			src: `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + openapiPath + `", before = 42)`,
+			want: []string{"before= must be callable"},
+		},
+		{
+			name: "unknown contract extension on interface spec",
+			src: `
+orders = service("orders",
+    interface("public", "http", 8080, spec = "./contract.thrift"), image = "orders:1")
+api = client("mobile-app", target = orders.public)`,
+			want: []string{"cannot tell what kind of contract"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt := New(testLogger())
+			err := rt.LoadString("client_test.star", c.src)
+			if err == nil {
+				t.Fatal("expected a load error, got nil")
+			}
+			for _, w := range c.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("error %q missing %q", err.Error(), w)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_ResolvesContractRelativeToSpecDir(t *testing.T) {
+	dir, _ := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+	specPath := filepath.Join(dir, "faultbox.star")
+	if err := os.WriteFile(specPath, []byte(`
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "./orders.yaml")
+OPS = api.operations
+`), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	rt := New(testLogger())
+	if err := rt.LoadFile(specPath); err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if ops := starList(t, rt, "OPS"); len(ops) != 2 {
+		t.Errorf("operations = %v, want 2 — the relative contract path should resolve against the spec dir", ops)
+	}
+}
+
+func TestClient_OperationShadowingReservedAttrIsRejected(t *testing.T) {
+	const shadowing = `
+openapi: 3.0.3
+info: {title: X, version: "1"}
+paths:
+  /call:
+    get:
+      operationId: call
+      responses: {"200": {description: ok}}
+`
+	_, specPath := writeSpecFile(t, "shadow.yaml", shadowing)
+
+	rt := New(testLogger())
+	err := rt.LoadString("client_test.star", `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "`+specPath+`")
+`)
+	if err == nil {
+		t.Fatal("expected an error for an operation shadowing a client attribute")
+	}
+	for _, want := range []string{"shadows the built-in client attribute", "rename="} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestClient_PositionalArgsRejected(t *testing.T) {
+	_, specPath := writeSpecFile(t, "orders.yaml", clientOrdersSpec)
+
+	rt := New(testLogger())
+	err := rt.LoadString("client_test.star", `
+orders = service("orders", interface("public", "http", 8080), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "`+specPath+`")
+
+def test_positional(t):
+    api.get_order(42)
+`)
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	// The rejection happens at call time; assert the message shape via a
+	// direct invocation rather than running the test body.
+	c, _ := rt.Client("mobile-app")
+	op, ok := c.Table.Lookup("get_order")
+	if !ok {
+		t.Fatal("get_order missing")
+	}
+	ov := &OperationVal{client: c, op: op}
+	_, callErr := ov.CallInternal(nil, starlark.Tuple{starlark.MakeInt(42)}, nil)
+	if callErr == nil {
+		t.Fatal("expected positional arguments to be rejected")
+	}
+	if !strings.Contains(callErr.Error(), "keyword arguments only") {
+		t.Errorf("error = %v, want a keyword-only complaint", callErr)
+	}
+}

--- a/internal/star/client_trace_test.go
+++ b/internal/star/client_trace_test.go
@@ -1,0 +1,371 @@
+package star
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// RFC-055 §5.5 — the trace half. A client call must land in the event log
+// as the *client's* activity: its own lane (service = client name), its own
+// vector-clock participant, and events an anchor can match.
+
+// startOrdersServer runs a bare HTTP server that serves the ordersSpec
+// contract, plus one deliberately non-conforming route. Using net/http
+// directly (rather than mock_service) keeps this test focused on the
+// client's own behaviour.
+func startOrdersServer(t *testing.T) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/orders/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/500"):
+			w.WriteHeader(503)
+			_, _ = w.Write([]byte(`{"error":"courier down"}`))
+		case strings.HasSuffix(r.URL.Path, "/degraded"):
+			// 200, but courier_eta is null — the schema declares it
+			// required and non-nullable.
+			_, _ = w.Write([]byte(`{"id": 7, "courier_eta": null}`))
+		default:
+			_, _ = w.Write([]byte(`{"id": 42, "courier_eta": "12m"}`))
+		}
+	})
+	mux.HandleFunc("/orders", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := json.Marshal(map[string]any{"echo": r.Header.Get("X-Client")})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		_, _ = w.Write(body)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return ln.Addr().String()
+}
+
+// clientRuntime loads a spec whose target service points at addr. The
+// service is declared with a binary that is never started — client calls
+// dial the address directly, so no process lifecycle is involved.
+func clientRuntime(t *testing.T, addr, clientKwargs string) *Runtime {
+	t.Helper()
+	dir := t.TempDir()
+	contract := filepath.Join(dir, "orders.yaml")
+	if err := os.WriteFile(contract, []byte(clientOrdersSpec), 0o644); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+
+	rt := New(testLogger())
+	src := `
+orders = service("orders", interface("public", "http", ` + portStr + `), image = "orders:1")
+api = client("mobile-app", target = orders.public, openapi = "` + contract + `"` + clientKwargs + `)
+`
+	if err := rt.LoadString("client_trace.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	return rt
+}
+
+// callOp invokes a generated operation directly, bypassing test-body
+// execution so the assertions can focus on the event log.
+func callOp(t *testing.T, rt *Runtime, clientName, opName string, args map[string]any) *Response {
+	t.Helper()
+	c, ok := rt.Client(clientName)
+	if !ok {
+		t.Fatalf("client %q not found", clientName)
+	}
+	op, ok := c.Table.Lookup(opName)
+	if !ok {
+		t.Fatalf("operation %q not found", opName)
+	}
+	v, err := rt.executeClientCall(nil, c, op, args)
+	if err != nil {
+		t.Fatalf("executeClientCall(%s): %v", opName, err)
+	}
+	resp, ok := v.(*Response)
+	if !ok {
+		t.Fatalf("call returned %T, want *Response", v)
+	}
+	return resp
+}
+
+// eventsOfType returns every event of a given type from the log.
+func eventsOfType(rt *Runtime, typ string) []Event {
+	var out []Event
+	for _, ev := range rt.events.Events() {
+		if ev.Type == typ {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func TestClientCall_EmitsClientLaneEvents(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, headers = {"X-Client": "ios/4.2"}`)
+
+	resp := callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": int64(42)})
+	if !resp.Ok || resp.Status != 200 {
+		t.Fatalf("response = status %d ok=%v error=%q", resp.Status, resp.Ok, resp.Error)
+	}
+	if resp.Client != "mobile-app" || resp.Operation != "get_order" {
+		t.Errorf("response provenance = client %q operation %q", resp.Client, resp.Operation)
+	}
+	if !resp.ContractOk {
+		t.Errorf("contract_ok = false with validation off; want true (\"not checked\" reads as no violation)")
+	}
+
+	calls := eventsOfType(rt, "client_call")
+	returns := eventsOfType(rt, "client_return")
+	if len(calls) != 1 || len(returns) != 1 {
+		t.Fatalf("got %d client_call / %d client_return events, want 1 each", len(calls), len(returns))
+	}
+
+	call, ret := calls[0], returns[0]
+
+	// The event's Service is what the report keys lanes on and what the
+	// event log advances a vector clock for. It must be the client.
+	if call.Service != "mobile-app" {
+		t.Errorf("client_call service = %q, want mobile-app — the client needs its own lane", call.Service)
+	}
+	if ret.Service != "mobile-app" {
+		t.Errorf("client_return service = %q, want mobile-app", ret.Service)
+	}
+	if call.EventType != "client_call" {
+		t.Errorf("client_call event_type = %q", call.EventType)
+	}
+
+	wantCallFields := map[string]string{
+		"client":    "mobile-app",
+		"target":    "orders",
+		"operation": "get_order",
+		"method":    "GET",
+		"path":      "/orders/42",
+		"params":    "order_id=42",
+		"interface": "public",
+		"protocol":  "http",
+	}
+	for k, want := range wantCallFields {
+		if got := call.Fields[k]; got != want {
+			t.Errorf("client_call field %s = %q, want %q", k, got, want)
+		}
+	}
+	if !strings.HasSuffix(call.Fields["contract"], "orders.yaml@2.1.0") {
+		t.Errorf("client_call contract = %q, want the versioned contract identity", call.Fields["contract"])
+	}
+
+	for k, want := range map[string]string{
+		"client":      "mobile-app",
+		"target":      "orders",
+		"operation":   "get_order",
+		"status_code": "200",
+		"success":     "true",
+		"contract_ok": "true",
+	} {
+		if got := ret.Fields[k]; got != want {
+			t.Errorf("client_return field %s = %q, want %q", k, got, want)
+		}
+	}
+
+	// Vector clocks: the client is a participant, and by the time it
+	// returns it has observed both the test driver and the target.
+	if call.VectorClock["mobile-app"] == 0 {
+		t.Errorf("client_call vector clock has no mobile-app entry: %v", call.VectorClock)
+	}
+	if ret.VectorClock["mobile-app"] <= call.VectorClock["mobile-app"] {
+		t.Errorf("client clock did not advance between call and return: %v → %v",
+			call.VectorClock, ret.VectorClock)
+	}
+}
+
+func TestClientCall_TwoClientsAreDistinctActors(t *testing.T) {
+	addr := startOrdersServer(t)
+	dir := t.TempDir()
+	contract := filepath.Join(dir, "orders.yaml")
+	if err := os.WriteFile(contract, []byte(clientOrdersSpec), 0o644); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	_, portStr, _ := net.SplitHostPort(addr)
+
+	rt := New(testLogger())
+	if err := rt.LoadString("two_clients.star", `
+orders = service("orders", interface("public", "http", `+portStr+`), image = "orders:1")
+mobile  = client("mobile-app",  target = orders.public, openapi = "`+contract+`",
+                 headers = {"X-Client": "ios"})
+partner = client("partner-api", target = orders.public, openapi = "`+contract+`",
+                 headers = {"X-Client": "partner"})
+`); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": int64(1)})
+	callOp(t, rt, "partner-api", "get_order", map[string]any{"order_id": int64(2)})
+
+	lanes := map[string]int{}
+	for _, ev := range eventsOfType(rt, "client_call") {
+		lanes[ev.Service]++
+	}
+	if len(lanes) != 2 || lanes["mobile-app"] != 1 || lanes["partner-api"] != 1 {
+		t.Errorf("client_call lanes = %v, want one call each on mobile-app and partner-api", lanes)
+	}
+}
+
+func TestClientCall_ContractViolationIsRecordedNotRaised(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "response"`)
+
+	// The /degraded path returns 200 with a null in a required field.
+	resp := callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": "degraded"})
+	if !resp.Ok || resp.Status != 200 {
+		t.Fatalf("expected a 200 with a bad payload, got status %d ok=%v", resp.Status, resp.Ok)
+	}
+	if resp.ContractOk {
+		t.Error("contract_ok = true; the null courier_eta violates the declared schema")
+	}
+	if resp.ContractError == "" {
+		t.Error("contract_error is empty on a violation")
+	}
+
+	violations := eventsOfType(rt, "contract_violation")
+	if len(violations) != 1 {
+		t.Fatalf("got %d contract_violation events, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.Service != "mobile-app" {
+		t.Errorf("contract_violation service = %q, want the client's lane", v.Service)
+	}
+	for _, k := range []string{"client", "target", "operation", "contract", "detail"} {
+		if v.Fields[k] == "" {
+			t.Errorf("contract_violation field %q is empty", k)
+		}
+	}
+
+	// The return event records the verdict too, so a reader scanning only
+	// returns still sees it.
+	returns := eventsOfType(rt, "client_return")
+	if got := returns[len(returns)-1].Fields["contract_ok"]; got != "false" {
+		t.Errorf("client_return contract_ok = %q, want false", got)
+	}
+}
+
+func TestClientCall_UndeclaredStatusIsAViolation(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "response"`)
+
+	// The contract declares only 200 for getOrder; the server returns 503.
+	resp := callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": "500"})
+	if resp.Status != 503 {
+		t.Fatalf("status = %d, want 503", resp.Status)
+	}
+	if resp.ContractOk {
+		t.Error("an undeclared 503 should register as a contract violation")
+	}
+	if !strings.Contains(resp.ContractError, "503") {
+		t.Errorf("contract_error = %q, want it to name the undeclared status", resp.ContractError)
+	}
+
+	// Non-2xx bodies are recorded on the return event, same rule as
+	// step_recv, so a failure reads off the trace.
+	returns := eventsOfType(rt, "client_return")
+	if body := returns[len(returns)-1].Fields["body"]; !strings.Contains(body, "courier down") {
+		t.Errorf("client_return body = %q, want the error payload", body)
+	}
+}
+
+func TestClientCall_StrictRaisesOnViolation(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "strict"`)
+
+	c, _ := rt.Client("mobile-app")
+	op, _ := c.Table.Lookup("get_order")
+	_, err := rt.executeClientCall(nil, c, op, map[string]any{"order_id": "degraded"})
+	if err == nil {
+		t.Fatal("validate=strict must raise on a response violation")
+	}
+	if !strings.Contains(err.Error(), "does not conform") {
+		t.Errorf("error = %v, want a conformance complaint", err)
+	}
+	// The violation is still in the trace — raising must not cost evidence.
+	if len(eventsOfType(rt, "contract_violation")) != 1 {
+		t.Error("strict mode should still emit the contract_violation event")
+	}
+}
+
+func TestClientCall_RequestValidationRejectsBadCall(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "request"`)
+
+	c, _ := rt.Client("mobile-app")
+	op, _ := c.Table.Lookup("create_order")
+	// item_id is required by the requestBody schema.
+	_, err := rt.executeClientCall(nil, c, op, map[string]any{
+		"body": map[string]any{"qty": int64(2)},
+	})
+	if err == nil {
+		t.Fatal("validate=request must reject a body that violates the schema")
+	}
+	if !strings.Contains(err.Error(), "request does not conform") {
+		t.Errorf("error = %v, want a request-conformance complaint", err)
+	}
+	// Nothing went on the wire, so nothing should be in the trace.
+	if n := len(eventsOfType(rt, "client_call")); n != 0 {
+		t.Errorf("got %d client_call events for a rejected request, want 0", n)
+	}
+}
+
+func TestClientCall_HeadersAndBeforeHook(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `,
+    headers = {"X-Client": "ios/4.2"},
+    before = lambda req: {"headers": {"Authorization": "Bearer tok"}}`)
+
+	// POST /orders echoes back the X-Client header the server saw.
+	resp := callOp(t, rt, "mobile-app", "create_order", map[string]any{
+		"body": map[string]any{"item_id": "sku-1"},
+	})
+	if resp.Status != 201 {
+		t.Fatalf("status = %d, want 201", resp.Status)
+	}
+	if !strings.Contains(resp.Body, "ios/4.2") {
+		t.Errorf("server did not see the client-level header; body = %s", resp.Body)
+	}
+
+	// The before= hook's header reached the request. It isn't echoed, so
+	// assert on what the client recorded instead.
+	calls := eventsOfType(rt, "client_call")
+	if len(calls) != 1 {
+		t.Fatalf("got %d client_call events, want 1", len(calls))
+	}
+	if body := calls[0].Fields["body"]; !strings.Contains(body, "sku-1") {
+		t.Errorf("client_call body = %q, want the encoded request", body)
+	}
+}
+
+func TestClientCall_UnknownKwargIsRejectedAtCallTime(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, "")
+
+	c, _ := rt.Client("mobile-app")
+	op, _ := c.Table.Lookup("get_order")
+	_, err := rt.executeClientCall(nil, c, op, map[string]any{"order_ids": int64(1)})
+	if err == nil {
+		t.Fatal("expected an unknown-argument error")
+	}
+	for _, want := range []string{`unknown argument "order_ids"`, `did you mean "order_id"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}

--- a/internal/star/client_trace_test.go
+++ b/internal/star/client_trace_test.go
@@ -449,3 +449,110 @@ func TestClientEvents_ReachDownstreamConsumers(t *testing.T) {
 		}
 	})
 }
+
+// eventMatcher builds the same matcher shape match.event(type=…, **fields)
+// produces, so these tests exercise the real matching path rather than a
+// hand-rolled predicate.
+func eventMatcher(typ string, fields map[string]string) *MatcherVal {
+	criteria := map[string]string{"type": typ}
+	for k, v := range fields {
+		criteria[k] = v
+	}
+	return &MatcherVal{
+		name:    "event(" + typ + ")",
+		matchFn: func(ev Event) bool { return matchEventCriteria(ev, criteria) },
+	}
+}
+
+// TestClientCall_ProxyFaultApplies is the regression guard for RFC-055's
+// central composition claim: a client is the *same caller* as a step
+// method as far as fault injection is concerned.
+//
+// It holds because clientAddr resolves through proxyMgr.GetProxyAddr
+// exactly as executeStep does. Nothing else enforces that — refactor the
+// address resolution and the whole "faults compose for free" story dies
+// silently, with every client test still green. Hence this test.
+func TestClientCall_ProxyFaultApplies(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, "")
+
+	c, _ := rt.Client("mobile-app")
+	// With no proxy up the client dials the interface directly, spelled
+	// "localhost:<port>" — the same form executeStep builds.
+	_, port, _ := net.SplitHostPort(addr)
+	if got := rt.clientAddr(c); got != "localhost:"+port {
+		t.Fatalf("clientAddr = %q, want localhost:%s with no proxy up", got, port)
+	}
+
+	// Stand in for a running proxy on the target interface. When one is
+	// up, the client must dial *it* rather than the service directly —
+	// that redirection is the entire fault-injection integration.
+	iface := c.Target.Interface
+	rt.proxyMgr.RegisterListenAddr(c.Target.Service.Name, iface.Name, "127.0.0.1:59999")
+
+	if got := rt.clientAddr(c); got != "127.0.0.1:59999" {
+		t.Errorf("clientAddr = %q with a proxy up, want the proxy listener — "+
+			"client calls must traverse the fault path, not bypass it", got)
+	}
+}
+
+// TestClientEvents_WorkAsTemporalAnchors is the regression guard for
+// RFC-055 §5.6. Client events are ordinary events, so match.event() should
+// select them with no new matcher syntax — that "no new syntax" property is
+// what OQ-3 leaned on when it deferred the match.call() sugar, so it needs
+// a test rather than an assurance.
+func TestClientEvents_WorkAsTemporalAnchors(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "response"`)
+
+	callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": int64(42)})
+	callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": "degraded"})
+
+	cases := []struct {
+		name    string
+		matcher *MatcherVal
+		want    int
+	}{
+		{
+			name:    "by client and operation",
+			matcher: eventMatcher("client_call", map[string]string{"client": "mobile-app", "operation": "get_order"}),
+			want:    2,
+		},
+		{
+			name:    "by a different client selects nothing",
+			matcher: eventMatcher("client_call", map[string]string{"client": "partner-api"}),
+			want:    0,
+		},
+		{
+			name:    "by contract verdict",
+			matcher: eventMatcher("client_return", map[string]string{"contract_ok": "false"}),
+			want:    1,
+		},
+		{
+			name:    "violations are matchable in their own right",
+			matcher: eventMatcher("contract_violation", map[string]string{"client": "mobile-app"}),
+			want:    1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := len(rt.events.MatchingEvents(tc.matcher))
+			if got != tc.want {
+				t.Errorf("matched %d events, want %d", got, tc.want)
+			}
+		})
+	}
+
+	// An anchor is only useful if it can open a window, which means
+	// FirstMatching has to find it — that is the lookup eventually(anchor=)
+	// and always(between=) both run.
+	anchor := eventMatcher("client_return", map[string]string{"contract_ok": "false"})
+	ev, found := rt.events.FirstMatching(anchor)
+	if !found {
+		t.Fatal("FirstMatching did not resolve the anchor; eventually(anchor=) would never open")
+	}
+	if ev.Fields["operation"] != "get_order" {
+		t.Errorf("anchor resolved to operation %q, want get_order", ev.Fields["operation"])
+	}
+}

--- a/internal/star/client_trace_test.go
+++ b/internal/star/client_trace_test.go
@@ -143,8 +143,13 @@ func TestClientCall_EmitsClientLaneEvents(t *testing.T) {
 	if ret.Service != "mobile-app" {
 		t.Errorf("client_return service = %q, want mobile-app", ret.Service)
 	}
-	if call.EventType != "client_call" {
-		t.Errorf("client_call event_type = %q", call.EventType)
+	// The dotted form names the callee; the event's Service names the
+	// caller. Between them a reader gets both ends of the edge.
+	if call.EventType != "client_call.orders" {
+		t.Errorf("client_call event_type = %q, want client_call.orders", call.EventType)
+	}
+	if ret.EventType != "client_return.orders" {
+		t.Errorf("client_return event_type = %q, want client_return.orders", ret.EventType)
 	}
 
 	wantCallFields := map[string]string{
@@ -368,4 +373,79 @@ func TestClientCall_UnknownKwargIsRejectedAtCallTime(t *testing.T) {
 			t.Errorf("error %q missing %q", err.Error(), want)
 		}
 	}
+}
+
+// TestClientEvents_ReachDownstreamConsumers covers the RFC-055 Phase 3
+// migration: every consumer that had step_send/step_recv hard-coded must
+// also recognise the client pair, or client calls go missing exactly where
+// a reader looks for them.
+func TestClientEvents_ReachDownstreamConsumers(t *testing.T) {
+	addr := startOrdersServer(t)
+	rt := clientRuntime(t, addr, `, validate = "response"`)
+
+	callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": int64(42)})
+	callOp(t, rt, "mobile-app", "get_order", map[string]any{"order_id": "500"})
+
+	t.Run("assertion context includes client calls", func(t *testing.T) {
+		ctx := rt.recentAssertionContext(4)
+		if len(ctx) == 0 {
+			t.Fatal("recentAssertionContext returned nothing; client calls are invisible at failure time")
+		}
+		var sawCall, sawReturn bool
+		for _, c := range ctx {
+			switch c.Type {
+			case "client_call":
+				sawCall = true
+			case "client_return":
+				sawReturn = true
+				if c.Target != "orders" {
+					t.Errorf("context target = %q, want orders", c.Target)
+				}
+			}
+		}
+		if !sawCall || !sawReturn {
+			t.Errorf("context = %+v, want both client_call and client_return", ctx)
+		}
+		// Chronological order, like the step path.
+		for i := 1; i < len(ctx); i++ {
+			if ctx[i].Seq < ctx[i-1].Seq {
+				t.Errorf("context is not in chronological order: %+v", ctx)
+				break
+			}
+		}
+	})
+
+	t.Run("normalized trace records operation not path", func(t *testing.T) {
+		var lines []string
+		for _, ev := range rt.events.Events() {
+			switch ev.Type {
+			case "client_call", "client_return":
+				lines = append(lines, ev.Fields["operation"])
+			}
+		}
+		if len(lines) != 4 {
+			t.Fatalf("got %d client events, want 4", len(lines))
+		}
+		// Both calls normalize to the same operation even though their
+		// paths differ (/orders/42 vs /orders/500) — that's the point of
+		// keying the normalized line on the operation.
+		for _, l := range lines {
+			if l != "get_order" {
+				t.Errorf("operation = %q, want get_order", l)
+			}
+		}
+	})
+
+	t.Run("isCallEventType covers both pairs", func(t *testing.T) {
+		for _, typ := range []string{"step_send", "step_recv", "client_call", "client_return"} {
+			if !isCallEventType(typ) {
+				t.Errorf("isCallEventType(%q) = false, want true", typ)
+			}
+		}
+		for _, typ := range []string{"syscall", "fault_applied", "contract_violation", ""} {
+			if isCallEventType(typ) {
+				t.Errorf("isCallEventType(%q) = true, want false", typ)
+			}
+		}
+	})
 }

--- a/internal/star/client_trace_test.go
+++ b/internal/star/client_trace_test.go
@@ -1,11 +1,13 @@
 package star
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -555,4 +557,161 @@ func TestClientEvents_WorkAsTemporalAnchors(t *testing.T) {
 	if ev.Fields["operation"] != "get_order" {
 		t.Errorf("anchor resolved to operation %q, want get_order", ev.Fields["operation"])
 	}
+}
+
+// TestClientGRPC_EndToEnd is the RFC-055 gRPC path exercised the way a
+// user meets it: declared in a spec, called as a generated attribute, with
+// the result read off the trace.
+//
+// Every other client test in this package is HTTP. The protocol-layer gRPC
+// tests cover encode/invoke/decode, but nothing joined that to the Starlark
+// surface — client(descriptors=) → attribute call → client event was
+// untested as a whole, which is the shape of the RFC's own example.
+//
+// The mock and the client are built from the *same* descriptor set, so a
+// pass means the typed encoder and the typed decoder agree on the wire.
+func TestClientGRPC_EndToEnd(t *testing.T) {
+	pbPath := writeTestDescriptorSet(t)
+	port := freePortForTest(t)
+
+	rt := New(testLogger())
+	src := `
+geo = mock_service("geo",
+    interface("main", "grpc", ` + strconv.Itoa(port) + `),
+    descriptors = "` + pbPath + `",
+    routes = {
+        "/test.geo.GeoService/GetCity": grpc_typed_response(
+            body = {"id": 42, "name": "Almaty", "country": "KZ", "currency": "KZT"},
+        ),
+    },
+)
+
+geo_client = client("geo-client", target = geo.main, descriptors = "` + pbPath + `")
+`
+	if err := rt.LoadString("grpc_client.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	c, ok := rt.Client("geo-client")
+	if !ok {
+		t.Fatal("geo-client not registered")
+	}
+
+	// The single service in the set is selected without grpc_service=, and
+	// GetCity normalizes to get_city.
+	if names := c.Table.Names(); len(names) != 1 || names[0] != "get_city" {
+		t.Fatalf("operations = %v, want [get_city]", names)
+	}
+	if got := c.Table.Contract.Version; got != "test.geo.GeoService" {
+		t.Errorf("contract version = %q, want the service FQN", got)
+	}
+
+	// Start the mock the same way a test run would.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	resp := callOp(t, rt, "geo-client", "get_city", map[string]any{"id": int64(42)})
+	if !resp.Ok {
+		t.Fatalf("call failed: %s", resp.Error)
+	}
+
+	// The response decoded as the real message type, not google.protobuf.Struct.
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &decoded); err != nil {
+		t.Fatalf("response body is not JSON: %v (%s)", err, resp.Body)
+	}
+	if decoded["name"] != "Almaty" {
+		t.Errorf("response name = %v, want Almaty (body %s)", decoded["name"], resp.Body)
+	}
+	if decoded["currency"] != "KZT" {
+		t.Errorf("response currency = %v, want KZT", decoded["currency"])
+	}
+	if resp.Client != "geo-client" || resp.Operation != "get_city" {
+		t.Errorf("provenance = client %q operation %q", resp.Client, resp.Operation)
+	}
+
+	// The trace records it on the client's own lane, with the gRPC status.
+	calls := eventsOfType(rt, "client_call")
+	returns := eventsOfType(rt, "client_return")
+	if len(calls) != 1 || len(returns) != 1 {
+		t.Fatalf("got %d client_call / %d client_return, want 1 each", len(calls), len(returns))
+	}
+	if calls[0].Service != "geo-client" {
+		t.Errorf("client_call service = %q, want geo-client", calls[0].Service)
+	}
+	if got := calls[0].Fields["method_path"]; got != "/test.geo.GeoService/GetCity" {
+		t.Errorf("client_call method_path = %q", got)
+	}
+	if got := calls[0].EventType; got != "client_call.geo" {
+		t.Errorf("client_call event_type = %q, want client_call.geo", got)
+	}
+	if got := returns[0].Fields["grpc_code"]; got != "OK" {
+		t.Errorf("client_return grpc_code = %q, want OK", got)
+	}
+	if got := returns[0].Fields["success"]; got != "true" {
+		t.Errorf("client_return success = %q, want true", got)
+	}
+}
+
+// TestClientGRPC_UnroutedMethodSurfacesStatus checks the failure shape: a
+// gRPC status is an outcome carried on the Response, not a Go error, so a
+// test can assert on it the same way it would on an HTTP status.
+func TestClientGRPC_UnroutedMethodSurfacesStatus(t *testing.T) {
+	pbPath := writeTestDescriptorSet(t)
+	port := freePortForTest(t)
+
+	rt := New(testLogger())
+	src := `
+geo = mock_service("geo",
+    interface("main", "grpc", ` + strconv.Itoa(port) + `),
+    descriptors = "` + pbPath + `",
+    routes = {},
+)
+geo_client = client("geo-client", target = geo.main, descriptors = "` + pbPath + `")
+`
+	if err := rt.LoadString("grpc_client.star", src); err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := rt.startServices(ctx); err != nil {
+		t.Fatalf("startServices: %v", err)
+	}
+	defer rt.stopServices()
+
+	resp := callOp(t, rt, "geo-client", "get_city", map[string]any{"id": int64(1)})
+	if resp.Ok {
+		t.Fatal("expected the unrouted method to fail")
+	}
+	if !strings.Contains(resp.Error, "Unimplemented") {
+		t.Errorf("error = %q, want an Unimplemented status", resp.Error)
+	}
+
+	returns := eventsOfType(rt, "client_return")
+	if len(returns) != 1 {
+		t.Fatalf("got %d client_return events, want 1", len(returns))
+	}
+	if got := returns[0].Fields["grpc_code"]; got != "Unimplemented" {
+		t.Errorf("client_return grpc_code = %q, want Unimplemented", got)
+	}
+	if got := returns[0].Fields["success"]; got != "false" {
+		t.Errorf("client_return success = %q, want false", got)
+	}
+}
+
+// freePortForTest reserves and releases a loopback port so a spec can name
+// it before the service binds.
+func freePortForTest(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
 }

--- a/internal/star/events.go
+++ b/internal/star/events.go
@@ -96,6 +96,14 @@ func (l *EventLog) Emit(typ, service string, fields map[string]string) {
 		if target, ok := fields["target"]; ok {
 			eventType = typ + "." + target
 		}
+	} else if typ == "client_call" || typ == "client_return" || typ == "contract_violation" {
+		// RFC-055 §5.5 — same dotted shape as step events, so a client
+		// call reads as "client_call.courier" in PObserve routing and on
+		// the ShiViz host line, naming both the actor (via the event's
+		// service) and the callee (via the suffix).
+		if target, ok := fields["target"]; ok {
+			eventType = typ + "." + target
+		}
 	}
 
 	ev := Event{

--- a/internal/star/mock_builtins.go
+++ b/internal/star/mock_builtins.go
@@ -232,7 +232,9 @@ func (rt *Runtime) builtinMockService(thread *starlark.Thread, fn *starlark.Buil
 		}
 	}
 
-	rt.registerService(svc)
+	if err := rt.registerService(svc); err != nil {
+		return nil, err
+	}
 	return svc, nil
 }
 

--- a/internal/star/mock_builtins.go
+++ b/internal/star/mock_builtins.go
@@ -136,7 +136,12 @@ func (rt *Runtime) builtinMockService(thread *starlark.Thread, fn *starlark.Buil
 			if err != nil {
 				return nil, fmt.Errorf("mock_service() %q: %w", name, err)
 			}
-			spec, err := protocol.LoadOpenAPI(path)
+			// Resolve relative to the spec's own directory, not the
+			// process CWD — matching load_file(), build=, and client().
+			// Before RFC-055 this used the raw path, so `./api.yaml`
+			// only loaded when faultbox happened to run from the spec's
+			// directory.
+			spec, err := protocol.LoadOpenAPI(rt.resolveSpecPath(path))
 			if err != nil {
 				return nil, fmt.Errorf("mock_service() %q openapi: %w", name, err)
 			}
@@ -209,7 +214,7 @@ func (rt *Runtime) builtinMockService(thread *starlark.Thread, fn *starlark.Buil
 			if err != nil {
 				return nil, fmt.Errorf("mock_service() %q: %w", name, err)
 			}
-			files, err := protocol.LoadDescriptorSet(path)
+			files, err := protocol.LoadDescriptorSet(rt.resolveSpecPath(path))
 			if err != nil {
 				return nil, fmt.Errorf("mock_service() %q descriptors: %w", name, err)
 			}

--- a/internal/star/results.go
+++ b/internal/star/results.go
@@ -575,6 +575,16 @@ func NormalizeTrace(result *SuiteResult) string {
 			case "step_send", "step_recv":
 				target := ev.Fields["target"]
 				line = fmt.Sprintf("%s %s", ev.Type, target)
+			case "client_call", "client_return":
+				// Operation, not path: the path may carry a run-varying
+				// id while the operation name is the stable identity of
+				// what was called (RFC-055).
+				line = fmt.Sprintf("%s %s %s", ev.Type, ev.Fields["target"], ev.Fields["operation"])
+			case "contract_violation":
+				// The detail text quotes schema paths and values that can
+				// vary between runs; the operation that violated is the
+				// determinism-relevant part.
+				line = fmt.Sprintf("contract_violation %s %s", ev.Fields["target"], ev.Fields["operation"])
 			case "unmediated_io":
 				// RFC-040 §8.1 — keep these in the normalized trace so
 				// determinism goldens can differentiate by category. The

--- a/internal/star/runtime.go
+++ b/internal/star/runtime.go
@@ -226,6 +226,11 @@ type Runtime struct {
 	services map[string]*ServiceDef
 	order    []string // dependency order
 
+	// Declared clients (RFC-055) — populated at spec load by client().
+	// Guarded by rt.mu alongside the service registry, since the two share
+	// a name namespace.
+	clients map[string]*ClientVal
+
 	// Running sessions — populated during test execution.
 	sessions map[string]*runningSession
 
@@ -485,6 +490,7 @@ func New(logger *slog.Logger) *Runtime {
 		events:            NewEventLog(),
 		eng:               engine.New(logger),
 		services:          make(map[string]*ServiceDef),
+		clients:           make(map[string]*ClientVal),
 		sessions:          make(map[string]*runningSession),
 		faults:            make(map[string]map[string]*FaultDef),
 		proxyPlaceholders: make(map[string]proxyPlaceholderRef),
@@ -2021,13 +2027,24 @@ func (rt *Runtime) runTestImpl(ctx context.Context, name string) TestResult {
 }
 
 // registerService adds a service to the registry.
-func (rt *Runtime) registerService(svc *ServiceDef) {
+//
+// A name already taken by a client is refused: services and clients are
+// both trace actors keyed by name, so sharing one would fold two
+// participants into a single lane and vector clock (RFC-055 OQ-8). The
+// mirror check lives in client().
+func (rt *Runtime) registerService(svc *ServiceDef) error {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	if c, clash := rt.clients[svc.Name]; clash {
+		return fmt.Errorf("service(%q): a client is already named %q (bound to %s.%s)\n"+
+			"  clients and services share the trace's lane and vector-clock namespace; pick a distinct name",
+			svc.Name, svc.Name, c.Target.Service.Name, c.Target.Interface.Name)
+	}
 	svc.rt = rt
 	rt.services[svc.Name] = svc
 	// Rebuild dependency order.
 	rt.order = rt.dependencyOrder()
+	return nil
 }
 
 // dependencyOrder returns service names in topological order.

--- a/internal/star/types.go
+++ b/internal/star/types.go
@@ -396,6 +396,17 @@ type Response struct {
 	DurationMs int64
 	Ok         bool
 	Error      string
+
+	// RFC-055 client provenance. Empty on responses produced by step
+	// methods; populated when the call came from a client(), so an
+	// assertion can say which caller saw what.
+	Client    string
+	Operation string
+	// ContractOk reports whether the response conformed to the contract.
+	// True when validation is off — "not checked" reads as "no violation
+	// found", which is what an assertion on it should mean.
+	ContractOk    bool
+	ContractError string
 }
 
 var _ starlark.Value = (*Response)(nil)
@@ -431,12 +442,21 @@ func (r *Response) Attr(name string) (starlark.Value, error) {
 		return starlark.String(r.Error), nil
 	case "duration_ms":
 		return starlark.MakeInt64(r.DurationMs), nil
+	case "client":
+		return starlark.String(r.Client), nil
+	case "operation":
+		return starlark.String(r.Operation), nil
+	case "contract_ok":
+		return starlark.Bool(r.ContractOk), nil
+	case "contract_error":
+		return starlark.String(r.ContractError), nil
 	}
 	return nil, starlark.NoSuchAttrError(fmt.Sprintf("response has no .%s attribute", name))
 }
 
 func (r *Response) AttrNames() []string {
-	return []string{"status", "body", "data", "ok", "error", "duration_ms"}
+	return []string{"status", "body", "data", "ok", "error", "duration_ms",
+		"client", "operation", "contract_ok", "contract_error"}
 }
 
 // ---------------------------------------------------------------------------

--- a/poc/client-rfc055/faultbox.star
+++ b/poc/client-rfc055/faultbox.star
@@ -1,0 +1,87 @@
+# RFC-055 — contract-driven clients.
+#
+# The same OpenAPI document drives both ends: mock_service() generates the
+# callee's routes, client() generates the caller's methods. Nothing in this
+# spec spells out a path, an HTTP verb, or a JSON field name — change the
+# contract and both sides follow.
+#
+# Run:
+#   faultbox inspect --clients poc/client-rfc055/faultbox.star   # what can I call?
+#   faultbox test poc/client-rfc055/faultbox.star
+
+CONTRACT = "./orders.openapi.yaml"
+
+# The callee. Routes come from the contract's declared examples; the
+# `/orders/{orderId}` override returns a *degraded* payload — a 200 whose
+# courier_eta is null, which the contract declares non-nullable.
+orders = mock_service("orders",
+    interface("public", "http", 18110),
+    openapi = CONTRACT,
+    examples = "synthesize",
+    overrides = {
+        "GET /orders/{orderId}": json_response(
+            status = 200,
+            body = {"id": 1001, "status": "confirmed", "courier_eta": None},
+        ),
+    },
+)
+
+# Two callers against the same API with different identities. Each gets its
+# own swim lane and its own vector-clock participant, so a trace answers
+# "which client saw the bad response?" rather than showing one anonymous
+# `test` driver.
+mobile = client("mobile-app",
+    target   = orders.public,
+    openapi  = CONTRACT,
+    headers  = {"X-Client": "ios/4.2"},
+    validate = "response",
+)
+
+partner = client("partner-api",
+    target   = orders.public,
+    openapi  = CONTRACT,
+    headers  = {"X-Client": "partner/1.0"},
+    validate = "response",
+)
+
+
+def test_contract_violation_is_visible():
+    """A 200 that violates the published schema is the finding.
+
+    No assertion had to describe the expected shape — `validate="response"`
+    checks the payload against the contract the service publishes, and the
+    violation lands in the trace as its own event.
+    """
+    resp = mobile.get_order(order_id = 1001)
+
+    assert_true(resp.ok, "request should succeed at the transport level")
+    assert_eq(resp.status, 200)
+
+    # The service answered 200 but broke its own contract.
+    assert_true(
+        not resp.contract_ok,
+        "expected a contract violation for the null courier_eta, got: " + resp.contract_error,
+    )
+    assert_true(resp.client == "mobile-app")
+    assert_true(resp.operation == "get_order")
+
+
+def test_both_clients_are_distinct_actors():
+    """Two named callers, two lanes, two sets of anchors."""
+    mobile.get_order(order_id = 1)
+    partner.get_order(order_id = 2)
+
+    mobile_calls = events(where = lambda e: e.type == "client_call" and e.client == "mobile-app")
+    partner_calls = events(where = lambda e: e.type == "client_call" and e.client == "partner-api")
+
+    assert_eq(len(mobile_calls), 1)
+    assert_eq(len(partner_calls), 1)
+
+
+def test_unknown_argument_is_caught():
+    """The contract knows the parameter names, so a typo can't reach the wire."""
+    # `mobile.get_order(order_ids = 1)` would fail at call time with
+    # `unknown argument "order_ids" (did you mean "order_id"?)`.
+    # Exercised in the Go tests; kept here as documentation of the surface.
+    assert_true("get_order" in mobile.operations)
+    assert_true("create_order" in mobile.operations)

--- a/poc/client-rfc055/orders.openapi.yaml
+++ b/poc/client-rfc055/orders.openapi.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: Orders API
+  version: 1.4.0
+paths:
+  /orders:
+    post:
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [item_id, qty]
+              properties:
+                item_id: {type: string}
+                qty: {type: integer}
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, status]
+                properties:
+                  id: {type: integer}
+                  status: {type: string}
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        "200":
+          description: one order
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, status, courier_eta]
+                properties:
+                  id: {type: integer}
+                  status: {type: string}
+                  courier_eta:
+                    type: string
+                    description: ETA from the courier service. Non-nullable — the
+                      degraded path that returns null here is the bug this spec catches.


### PR DESCRIPTION
Implements [RFC-055](https://github.com/faultbox/Faultbox/issues/149) — `client()`, a topology entity that turns an API contract into a **named caller** bound to a service interface, and makes that caller a first-class actor in the trace.

Closes #149.

## Why

Faultbox already ingests contracts, but only to *serve* them: RFC-021 generates HTTP mock routes from OpenAPI, RFC-023 generates typed gRPC responses from a `FileDescriptorSet`. Both are callee-side. On the caller side every request is hand-assembled:

```python
resp = courier.main.call(method = "/courier.v1.CourierService/GetOrder", body = '{"order_id": 42}')
```

Nothing checks the path, the verb, or that the field is `order_id` and not `orderId`. And every driver-initiated call is emitted as `step_send` with `service = "test"`, so a scenario with a mobile client, a partner integration, and an admin tool renders as one undifferentiated lane. You can't ask "did the *partner* client see the error?"

This is the same drift problem RFC-021 identified for mocks, pointed the other way — plus a trace-clarity problem that only shows up once more than one logical caller exists.

## What it looks like

```python
orders  = service("orders", interface("public", "http", 8080), image = "orders:2.1")
courier = service("courier", interface("main", "grpc", 9090, spec = "./courier.pb"), image = "courier:1.4")

mobile   = client("mobile-app",   target = orders.public, openapi = "./orders.yaml", validate = "response")
gcourier = client("gRPC-Courier", target = courier.main)   # contract from interface(spec=)

def test_order_flow():
    o = mobile.create_order(body = {"item_id": "sku-1", "qty": 2})
    with fault(courier.main, grpc_faults.unavailable()):
        r = gcourier.get_order(order_id = o.data["id"])
        assert_true(not r.ok)
```

## Three things beyond autogeneration

**Clients are their own trace actors.** Events carry `service = <client name>` — what the event log keys lanes and vector clocks on — so N logical callers show up as N participants. The `test → client` clock merge on the way out is load-bearing: without it the client's lane reads as an independent process spontaneously emitting requests.

**Contract conformance becomes assertable.** `validate="response"` checks each response against the schema declared for its status code. It deliberately does *not* raise — a contract violation under fault is usually the finding, not a harness error. An undeclared status counts as a violation, which is how the undocumented degraded path surfaces. From the poc run in this PR:

```
#3   mobile-app   client_call.orders         → mobile-app.get_order GET /orders/1001
#5   mobile-app   client_return.orders       ← mobile-app.get_order 200 (0ms)
#6   mobile-app   contract_violation.orders  Error at "/courier_eta": Value is not nullable
```

No assertion described the expected shape. `validate="response"` caught it against the contract the service publishes.

**`interface(spec=)` is finally read.** The kwarg has been parsed and stored since early versions with nothing consuming it. A client that declares no contract inherits it, choosing the loader by extension.

## Shape of the change

| Phase | What |
|---|---|
| 1 | `internal/protocol/`: `client_contract.go` (OperationTable, snake_case naming, collision detection, "did you mean" resolution), `openapi_client.go` (operation walk, request binding, request/response conformance), `grpc_client.go` (descriptor walk, dynamicpb encode, unary invoke, typed decode) |
| 2 | `internal/star/`: `client.go` (ClientVal, OperationVal, call path, `before=` hook, event emission), `client_builtins.go` (the builtin, contract resolution, name validation) |
| 3 | Downstream consumers that had `step_send`/`step_recv` hard-coded: report keep-set, `app.js` (ten inline checks → `isCallEvent`/`isSendEvent`/`isRecvEvent`), normalized trace, assertion-failure context, dotted `event_type` |
| 4 | `faultbox inspect --clients`, `docs/spec-language.md`, `docs/cli-reference.md`, `poc/client-rfc055/` |

Reuses `kin-openapi` and `google.golang.org/protobuf` — both already required. **No new dependencies.**

## Two fixes this surfaced

- **`mock_service(openapi=)` resolved contract paths against the process CWD**, not the spec directory, so `"./api.yaml"` only loaded when `faultbox` ran from the directory containing the spec. Now spec-relative, matching `load_file()`, `build=`, and `client()`. The poc example is what exposed it.
- **`events()` filtered to four hard-coded types**, so client events were invisible to the builtin users reach for first. Client types are now queryable; `step_send`/`step_recv` deliberately stay out — admitting them would silently change what `events()` returns for existing specs.

## Testing

Full suite green, `go vet` clean. New coverage: contract naming and collisions, parameter partitioning, request binding and its error messages, response conformance, client spec-load validation, event emission and vector-clock merges, and the downstream-consumer migration.

Two tests specifically guard claims that are true *by construction* and would otherwise break silently under refactor: that `clientAddr` redirects to the proxy listener (the entire "faults apply to client calls unchanged" story rests on that one lookup), and that `match.event(...)` selects client events with no new syntax (RFC OQ-3 deferred the `match.call()` sugar on the strength of that property).

Two end-to-end loops drive the real RFC-021/023 mocks from the *same* contract the client was built from.

## Not in this PR

Per the RFC's resolved questions: streaming RPCs (skipped when the table builds, rest of the descriptor set still loads), load generation (RFC-050's `load()` — the identity model is in place for it), request synthesis, contract formats beyond OpenAPI/proto, retry emulation, cookie jars. `before=` is HTTP-only.

## Review follow-ups (addressed in this PR)

Four gaps called out after the first push, all now closed:

- **Tutorial chapter 28** — the RFC's Phase 4 listed one and it hadn't been written. Placed in Part 3 next to the mock chapters it mirrors: ch18/19 generate the dependency you can't run, ch28 generates the caller that drives you.
- **gRPC end-to-end through Starlark** — every prior client test in `internal/star` was HTTP. `client(descriptors=)` → attribute call → client event is now covered, driving the typed mock and typed client from the same descriptor set, plus the failure shape (a gRPC status is an outcome on the `Response`, not a Go error).
- **`fault(<client>)` diagnostics** — returned a bare type mismatch. Now explains why a client has nothing to fault and shows both forms against the target it already knows. Same for `fault_start()`.
- **CHANGELOG correction** — the `events()` entry claimed more than shipped. main's v0.14.1 had already removed the type gate from the `where=` path; what this PR adds is the dict-filter form.

Site docs also wired: README feature bullet + docs table, `docs/index.md`, tutorial README and part index, and a `feature-manifest.md` row (the manifest is authoritative — a feature without a row isn't claimed as supported). Plus a drive-by fix for a broken README link to a tutorial directory that hasn't existed under that name in a while.

## Rebase note

main moved during development (v0.14.0 gVisor and v0.14.1 both shipped). Rebased clean. One conflict worth flagging: **v0.14.1 independently fixed the `events()` gap, and better** — it removed the type gate from the `where=` path entirely, since the lambda *is* the filter and pre-filtering had been silently hiding `proxy`, `unmediated_io`, and `packet` events from predicates that named them. I kept main's fix and narrowed mine to what it still adds: client types in the dict-filter path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
